### PR TITLE
Create RomanDataModel and open function

### DIFF
--- a/romancal/datamodels/__init__.py
+++ b/romancal/datamodels/__init__.py
@@ -1,0 +1,5 @@
+from .core import RomanDataModel
+from .open_impl import open
+
+
+__all__ = ["RomanDataModel", "open"]

--- a/romancal/datamodels/core.py
+++ b/romancal/datamodels/core.py
@@ -1,0 +1,9 @@
+from stdatamodels import DataModel
+
+
+class RomanDataModel(DataModel):
+    """
+    Base class for Roman data models.  Also serves as a generic
+    model class for data that does not identify its model type.
+    """
+    schema_url = "http://stsci.edu/schemas/roman_datamodel/core.schema"

--- a/romancal/datamodels/open_impl.py
+++ b/romancal/datamodels/open_impl.py
@@ -1,0 +1,87 @@
+"""
+Implementation of the datamodels.open function.
+"""
+from pathlib import PurePath, Path
+
+import asdf
+
+from .core import RomanDataModel
+
+
+def open(init, memmap=False, **model_kwargs):
+    """
+    Open an ASDF file and wrap it in a data model class.
+
+    Parameters
+    ----------
+    init : str or pathlib.PurePath or asdf.AsdfFile
+        If str or `~pathlib.PurePath`, filesystem path to an ASDF file.
+        If `~asdf.AsdfFile`, an open ASDF file.
+
+    memmap : bool, optional
+        Set to True to enable memory-mapping of arrays.  Ignored if the
+        ``init`` argument is an AsdfFile.
+
+    model_kwargs : dict, optional
+        Additional arguments to pass when initializing the model.
+
+    Returns
+    -------
+    model : RomanDataModel
+        Instance of `RomanDataModel` or subclass.
+    """
+    if isinstance(init, (str, PurePath)):
+        if isinstance(init, str):
+            init = Path(init)
+
+        if not init.is_file():
+            raise FileNotFoundError(f"File at path '{init}' does not exist")
+
+        asdf_kwargs = {
+            # The copy_arrays argument instructs the asdf library to
+            # make in-memory copies of arrays, so we need to send it
+            # the opposite of our memmap value.
+            "copy_arrays": not memmap
+        }
+
+        asdf_file = asdf.open(init, **asdf_kwargs)
+        auto_close_asdf_file = True
+    elif isinstance(init, asdf.AsdfFile):
+        asdf_file = init
+        auto_close_asdf_file = False
+    else:
+        raise TypeError("init must be a path to an ASDF file or an open AsdfFile instance")
+
+    model_class = _select_model_class(asdf_file)
+
+    model = model_class(asdf_file, **model_kwargs)
+
+    if auto_close_asdf_file:
+        # TODO: This needs to have a public interface, maybe just
+        # a boolean flag to the DataModel initializer.
+        model._files_to_close.append(asdf_file)
+
+    return model
+
+
+def _select_model_class(asdf_file):
+    """
+    Select a model class based on ASDF file metadata.
+
+    Parameters
+    ----------
+    asdf_file : asdf.AsdfFile
+
+    Returns
+    -------
+    type
+        `RomanDataModel` or subclass.
+    """
+    # TODO: Still need to decide how this is going to work.
+    # Options include:
+    # - Choose according to model_type metadata field (similar to jwst)
+    # - Infer from other relevant metadata (reference file type, exposure type, etc)
+    # - Use ASDF tags to automatically instantiate the correct model
+    # - Use RomanDataModel for all data but select the schema according to one of the above
+    # - ???
+    return RomanDataModel

--- a/romancal/datamodels/tests/test_extension.py
+++ b/romancal/datamodels/tests/test_extension.py
@@ -1,7 +1,7 @@
 import yaml
 import asdf
 
-from ..extension import SCHEMAS_ROOT
+from romancal.datamodels.extension import SCHEMAS_ROOT
 
 
 def test_schema_uri_mapping():

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -1,0 +1,15 @@
+import asdf
+
+from romancal import datamodels
+
+
+def test_model_schemas():
+    model_classes = [
+        m for m in datamodels.__dict__.values()
+        if isinstance(m, type) and issubclass(m, datamodels.RomanDataModel)
+    ]
+    for model_class in model_classes:
+        try:
+            asdf.schema.load_schema(model_class.schema_url)
+        except Exception:
+            assert False, f"Unable to load schema URI '{model_class.schema_url}' for model class {model_class.__name__}"

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -1,14 +1,15 @@
 import asdf
 
-from romancal import datamodels
+from romancal.datamodels import RomanDataModel
 
 
 def test_model_schemas():
-    model_classes = [
-        m for m in datamodels.__dict__.values()
-        if isinstance(m, type) and issubclass(m, datamodels.RomanDataModel)
-    ]
-    for model_class in model_classes:
+    def iter_subclasses(model_class):
+        yield model_class
+        for sub_class in model_class.__subclasses__():
+            yield from iter_subclasses(sub_class)
+
+    for model_class in iter_subclasses(RomanDataModel):
         try:
             asdf.schema.load_schema(model_class.schema_url)
         except Exception:

--- a/romancal/datamodels/tests/test_open.py
+++ b/romancal/datamodels/tests/test_open.py
@@ -1,0 +1,72 @@
+import pytest
+
+from astropy.io import fits
+import asdf
+import numpy as np
+
+from romancal import datamodels
+from romancal.datamodels import RomanDataModel
+
+
+def test_asdf_file_input():
+    with asdf.AsdfFile() as af:
+        af["meta"] = {"telescope": "binoculars"}
+
+        model = datamodels.open(af)
+        assert model.meta.telescope == "binoculars"
+
+        # When an already open file is passed in, the model
+        # is not responsible for closing it.
+        model.close()
+        assert not af._closed
+
+
+def test_path_input(tmp_path):
+    file_path = tmp_path/"test.asdf"
+    with asdf.AsdfFile() as af:
+        af["meta"] = {"telescope": "magnifying glass"}
+        af.write_to(file_path)
+
+    # Test with PurePath input:
+    with datamodels.open(file_path) as model:
+        assert model.meta.telescope == "magnifying glass"
+        af = model._asdf
+
+    # When open creates the file pointer, it should be
+    # closed when the model is closed:
+    assert af._closed
+
+    # Test with string input:
+    with datamodels.open(str(file_path)) as model:
+        assert model.meta.telescope == "magnifying glass"
+        af = model._asdf
+
+    assert af._closed
+
+    # Appropriate error when file is missing:
+    with pytest.raises(FileNotFoundError):
+        with datamodels.open(tmp_path/"missing.asdf"):
+            pass
+
+
+def test_invalid_input():
+    with pytest.raises(TypeError):
+        datamodels.open(fits.HDUList())
+
+
+def test_memmap(tmp_path):
+    file_path = tmp_path/"test.asdf"
+    with asdf.AsdfFile() as af:
+        af["data"] = np.zeros((1024,))
+
+        af.write_to(file_path)
+
+    with datamodels.open(file_path, memmap=True) as model:
+        assert isinstance(model.data.base, np.memmap)
+
+    with datamodels.open(file_path, memmap=False) as model:
+        assert not isinstance(model.data.base, np.memmap)
+
+    # Default should be false:
+    with datamodels.open(file_path) as model:
+        assert not isinstance(model.data.base, np.memmap)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     numpy>=1.17
     pyparsing>=2.2
     requests>=2.22
+    stdatamodels @ git+https://github.com/spacetelescope/stdatamodels
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
This PR adds the `RomanDataModel` base class and `romancal.datamodels.open`.  The logic in `open` that selects the model class is just stubbed out for now, since we haven't settled on how that's going to work (and anyway, we haven't implemented any real models yet).