### PR TITLE
Initial Reference File Testing

### DIFF
--- a/romancal/datamodels/__init__.py
+++ b/romancal/datamodels/__init__.py
@@ -1,5 +1,7 @@
 from .core import RomanDataModel
+from .referencefile import ReferenceFileModel
+from .flat import FlatModel
 from .open_impl import open
 
 
-__all__ = ["RomanDataModel", "open"]
+__all__ = ["RomanDataModel", "ReferenceModel", "FlatModel", "open"]

--- a/romancal/datamodels/__init__.py
+++ b/romancal/datamodels/__init__.py
@@ -4,4 +4,4 @@ from .flat import FlatModel
 from .open_impl import open
 
 
-__all__ = ["RomanDataModel", "ReferenceModel", "FlatModel", "open"]
+__all__ = ["RomanDataModel", "ReferenceFileModel", "FlatModel", "open"]

--- a/romancal/datamodels/core.py
+++ b/romancal/datamodels/core.py
@@ -7,3 +7,4 @@ class RomanDataModel(DataModel):
     model class for data that does not identify its model type.
     """
     schema_url = "http://stsci.edu/schemas/roman_datamodel/core.schema"
+

--- a/romancal/datamodels/open_impl.py
+++ b/romancal/datamodels/open_impl.py
@@ -6,6 +6,7 @@ from pathlib import PurePath, Path
 import asdf
 
 from .core import RomanDataModel
+from .referencefile import ReferenceFileModel
 from .flat import FlatModel
 
 
@@ -86,8 +87,14 @@ def _select_model_class(asdf_file):
     # - Use RomanDataModel for all data but select the schema according to one of the above
     # - ???
 
-    # If we keep it this route, need to check for the existence of reftype first
-    if asdf_file["meta"].get("reftype") == "FLAT":
-        return FlatModel
+    # Check for the existence of reftype to indicate a reference file model
+    if asdf_file["meta"].get("reftype", None):
+        # Check if flat file model
+        if asdf_file["meta"].get("reftype", None) == "FLAT":
+            return FlatModel
+        # Return base reference file model
+        else:
+            return ReferenceFileModel
+    # Not a reference file model
     else:
         return RomanDataModel

--- a/romancal/datamodels/open_impl.py
+++ b/romancal/datamodels/open_impl.py
@@ -88,13 +88,15 @@ def _select_model_class(asdf_file):
     # - ???
 
     # Check for the existence of reftype to indicate a reference file model
-    if asdf_file["meta"].get("reftype", None):
+    reftype = asdf_file["meta"].get("reftype")
+    if reftype is not None:
         # Check if flat file model
-        if asdf_file["meta"].get("reftype", None) == "FLAT":
+        if reftype == "FLAT":
             return FlatModel
         # Return base reference file model
         else:
             return ReferenceFileModel
+
     # Not a reference file model
     else:
         return RomanDataModel

--- a/romancal/datamodels/referencefile.py
+++ b/romancal/datamodels/referencefile.py
@@ -8,3 +8,4 @@ class ReferenceFileModel(RomanDataModel):
 
     def __init__(self, init=None, **kwargs):
         super().__init__(init=init, **kwargs)
+

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -16,7 +16,7 @@ properties:
       telescope:
         title: Telescope used to acquire the data
         type: string
-        enum: ["ROMAN"]
+        enum: [ROMAN]
       exposure:
         title: Exposure parameters
         type: object
@@ -84,6 +84,5 @@ properties:
             type: string
             enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, CLEAR,
                    N/A, ANY, UNKNOWN]
-        required: [detector,optical_element,name]
-    required: [instrument,telescope]
-additionalProperties: true
+        required: [detector, optical_element, name]
+    required: [instrument, telescope]

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -79,10 +79,11 @@ properties:
             enum: [WFI01, WFI02, WFI03, WFI04, WFI05, WFI06, WFI07, WFI08, WFI09,
                    WFI10, WFI11, WFI12, WFI13, WFI14, WFI15, WFI16, WFI17, WFI18,
                    ANY, N/A]
-          filter:
+          optical_element:
             title: Name of the filter element used
             type: string
             enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, CLEAR,
                    N/A, ANY, UNKNOWN]
-
-
+        required: [detector,optical_element,name]
+    required: [instrument,telescope]
+additionalProperties: true

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -16,7 +16,7 @@ properties:
       telescope:
         title: Telescope used to acquire the data
         type: string
-        enum: [Roman]
+        enum: ["ROMAN"]
       exposure:
         title: Exposure parameters
         type: object

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -10,8 +10,16 @@ properties:
       filename:
         title: Name of the file
         type: string
+# NOTE: Commented out due to conflict with meta.date defined in stdatamodels
+# Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
+#        date:
+#          title: Date this file was created (UTC)
+#          tag: tag:stsci.edu:asdf/time/time-1.1.0
       model_type:
         title: Type of data model
+        type: string
+      origin:
+        title: Organization responsible for creating file
         type: string
       telescope:
         title: Telescope used to acquire the data
@@ -26,27 +34,13 @@ properties:
             type: string
             enum:
               # Wide Field Imager
-             [WFI_CORON, WFI_DARK, WFI_FLAT, WFI_FOCUS,  WFI_IMAGE, WFI_WFSS,
-              WFI_LED, WFI_WFSC, WFI_TACONFIRM, WFI_TACQ, WFI_TSGRISM, WFI_TSIMAGE,
-              # WFI Spectrograph
-              WFI_PRISM, WFI_GRISM,
-              # Coronagraph
-              CGI_IMAGE,
-              # Misc
-              N/A, ANY]
+             [WFI_IMAGE, WFI_GRISM, WFI_PRISM, WFI_DARK, WFI_FLAT, WFI_TACQ, WFI_WFSC, WFI_GW]
           start_time:
             title: UTC exposure start time
             type: number
           end_time:
             title: UTC exposure end time
             type: number
-          readpatt:
-            title: Readout pattern
-            type: string
-            enum: [RAPID, ANY, N/A]
-          nints:
-            title: Number of integrations in exposure
-            type: integer
           ngroups:
             title: Number of groups in integration
             type: integer
@@ -58,9 +52,6 @@ properties:
             type: integer
           frame_time:
             title: "[s] Time between frames"
-            type: number
-          group_time:
-            title: "[s] Time between groups"
             type: number
           exposure_time:
             title: "[s] Effective exposure time"
@@ -77,12 +68,10 @@ properties:
             title: Name of detector used to acquire the data
             type: string
             enum: [WFI01, WFI02, WFI03, WFI04, WFI05, WFI06, WFI07, WFI08, WFI09,
-                   WFI10, WFI11, WFI12, WFI13, WFI14, WFI15, WFI16, WFI17, WFI18,
-                   ANY, N/A]
+                   WFI10, WFI11, WFI12, WFI13, WFI14, WFI15, WFI16, WFI17, WFI18]
           optical_element:
             title: Name of the filter element used
             type: string
-            enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, CLEAR,
-                   N/A, ANY, UNKNOWN]
+            enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, DARK, ENGINEERING]
         required: [detector, optical_element, name]
-    required: [instrument, telescope, model_type]
+    required: [date, instrument, telescope]

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -85,4 +85,4 @@ properties:
             enum: [F062, F087, F106, F129, W146, F158, F184, GRISM, PRISM, CLEAR,
                    N/A, ANY, UNKNOWN]
         required: [detector, optical_element, name]
-    required: [instrument, telescope]
+    required: [instrument, telescope, model_type]

--- a/romancal/datamodels/schemas/reference_files/flat.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/flat.schema.yaml
@@ -19,4 +19,4 @@ allOf:
       title: Error array
       default: 0.0
       datatype: float32
-
+additionalProperties: true

--- a/romancal/datamodels/schemas/reference_files/flat.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/flat.schema.yaml
@@ -19,4 +19,3 @@ allOf:
       title: Error array
       default: 0.0
       datatype: float32
-additionalProperties: true

--- a/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
@@ -9,9 +9,11 @@ allOf:
     meta:
       type: object
       properties:
-        date:
-          title: Date this file was created (UTC)
-          type: string
+# NOTE: Commented out due to conflict with meta.date defined in stdatamodels
+# Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
+#        date:
+#          title: Date this file was created (UTC)
+#          tag: "tag:stsci.edu:asdf/time/time-1.1.0"
         origin:
           title: Organization responsible for creating file
           type: string
@@ -29,4 +31,6 @@ allOf:
           type: string
         useafter:
           title: Use after date of the reference file
-          type: string
+          tag: "tag:stsci.edu:asdf/time/time-1.1.0"
+      required: [date,author,description,pedigree,useafter,reftype]
+additionalProperties: true

--- a/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
@@ -13,13 +13,14 @@ allOf:
 # Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
 #        date:
 #          title: Date this file was created (UTC)
-#          tag: "tag:stsci.edu:asdf/time/time-1.1.0"
+#          tag: tag:stsci.edu:asdf/time/time-1.1.0
         origin:
           title: Organization responsible for creating file
           type: string
         reftype:
           title: Reference file type
           type: string
+          enum: [FLAT, BASE]
         pedigree:
           title: The pedigree of the reference file
           type: string
@@ -31,6 +32,5 @@ allOf:
           type: string
         useafter:
           title: Use after date of the reference file
-          tag: "tag:stsci.edu:asdf/time/time-1.1.0"
-      required: [date,author,description,pedigree,useafter,reftype]
-additionalProperties: true
+          tag: tag:stsci.edu:asdf/time/time-1.1.0
+      required: [date, author, description, pedigree, useafter, reftype]

--- a/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/referencefile.schema.yaml
@@ -9,14 +9,6 @@ allOf:
     meta:
       type: object
       properties:
-# NOTE: Commented out due to conflict with meta.date defined in stdatamodels
-# Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
-#        date:
-#          title: Date this file was created (UTC)
-#          tag: tag:stsci.edu:asdf/time/time-1.1.0
-        origin:
-          title: Organization responsible for creating file
-          type: string
         reftype:
           title: Reference file type
           type: string
@@ -33,4 +25,4 @@ allOf:
         useafter:
           title: Use after date of the reference file
           tag: tag:stsci.edu:asdf/time/time-1.1.0
-      required: [date, author, description, pedigree, useafter, reftype]
+      required: [author, description, pedigree, useafter, reftype]

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -2,18 +2,20 @@ import pytest
 
 import asdf
 import numpy as np
+from astropy.time import Time
+from copy import deepcopy
 
 from romancal.datamodels import RomanDataModel
 import romancal.datamodels as DataModels
 from stdatamodels.validate import ValidationWarning
 
+# Helper class to iterate over model subclasses
+def iter_subclasses(model_class):
+    yield model_class
+    for sub_class in model_class.__subclasses__():
+        yield from iter_subclasses(sub_class)
 
 def test_model_schemas(tmp_path):
-    def iter_subclasses(model_class):
-        yield model_class
-        for sub_class in model_class.__subclasses__():
-            yield from iter_subclasses(sub_class)
-
     for model_class in iter_subclasses(RomanDataModel):
         try:
             asdf.schema.load_schema(model_class.schema_url)
@@ -21,71 +23,164 @@ def test_model_schemas(tmp_path):
             assert False, f"Unable to load schema URI '{model_class.schema_url}' for model " \
                           f"class {model_class.__name__}"
 
-def test_referencefile_model_schemas(tmp_path):
-    print("XXX test_referencefile_model_schemas")
-    print("XXX tmp_path = " + str(tmp_path))
 
-    def iter_subclasses(model_class):
-        yield model_class
-        for sub_class in model_class.__subclasses__():
-            yield from iter_subclasses(sub_class)
 
+# Helper function to test required keywords
+# meta = dictionary of required key/value pairs to ensure each are required
+def confirm_required_keywords(tmp_path, meta):
     file_path = tmp_path / "test.asdf"
 
-    for model_class in iter_subclasses(DataModels.referencefile.ReferenceFileModel):
-        print("XXX model_class = "+str(model_class))
-        with asdf.AsdfFile() as af:
-            af["meta"] = {"author":"Space Telescope Science Institute",
-                          "date": "Today",
-                          "description":"Test file",
-                          "instrument":{
-                              "detector":"WFI01",
-                              "filter":"F158",
-                              "name":"WFI"
-                          },
-                          "pedigree":"Test",
-                          "reftype":"REFERENCEFILE",
-                          "telescope":"ROMAN",
-                          "useafter":"Today"
-            }
+    # Returns the "paths" for all the keys in a dictionary (e.g. keys within keys.)
+    # This return is in the form of a list of lists, allowing the paths to be combined in whatever
+    # fashion is appropriate
+    def getkeypaths(meta_dict, path=None):
+        if path is None:
+            path = []
+        for keyname, value in meta_dict.items():
+            newpath = path + [keyname]
+            if isinstance(value, dict):
+                for subkeyname in getkeypaths(value, newpath):
+                    yield subkeyname
+            else:
+                yield newpath
 
+    # Deletes the key/value pair for a "pathed key" (e.g. a key within keys.)
+    # Returns the dictionary minus that key/value pair.
+    def delkeypath(meta_dict, keypath):
+        keylist = keypath.split('.')
+        sub_dict = meta_dict
+        for subkey in keylist[:-1]:
+            sub_dict = sub_dict[subkey]
+        del sub_dict[keylist[-1]]
+        return sub_dict
 
-        # Test referencefile model
-        if (model_class == DataModels.referencefile.ReferenceFileModel):
-            print("XXX Referencefile model found")
+    # Cycle through each key/value pair in meta dictionary
+    for keypathlist in getkeypaths(meta):
+        keypathname = '.'.join(keypathlist)
+
+        # Create temporary copy of meta dictionary and remove one key/value pair
+        badmeta = deepcopy(meta)
+        delkeypath(badmeta,keypathname)
+
+        # Save asdf file with badmeta dictionary as metadata tree
+        with asdf.AsdfFile(badmeta) as af:
             af.write_to(file_path)
 
-            assert DataModels.open(file_path)
+        # Test for warning that required keyword is missing
+        with DataModels.open(file_path) as model:
+            with pytest.warns(ValidationWarning) as record:
+                model.validate()
+        assert (len(record) > 0)
 
-            # with DataModels.open(file_path) as model:
-            #     assert isinstance(model, DataModels.referencefile.ReferenceFileModel)
+# Testing core schema
+def test_core_schemas(tmp_path):
+
+    # Define meta dictionary of required key / value pairs
+    meta = {"meta":
+                {"instrument": {
+                     "detector": "WFI01",
+                     "optical_element": "F158",
+                     "name": "WFI"
+                 },
+                 "telescope": "ROMAN"
+                 }
+            }
+
+    # Test schema for required key/value pairs
+    confirm_required_keywords(tmp_path, meta)
+
+# Testing all reference file schemas
+def test_referencefile_model_schemas(tmp_path):
+
+    # Define base meta dictionary of required key / value pairs for reference files
+    # NOTE 1: date is commented out because it is not properly failing its test
+    #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
+    # NOTE 2: core.schema key/value pairs commented out due to not properly failing their tests
+    #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/7
+
+    meta = {"meta":
+                {
+                    "author": "Space Telescope Science Institute",
+                    "description": "Test file",
+                    "pedigree": "Test",
+                    "reftype": "REFERENCEFILE",
+                    "useafter": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
+#                    "date": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
+#                     # Key/value pairs from core.schema
+#                     "instrument": {
+#                         "detector": "WFI01",
+#                         "optical_element": "F158",
+#                         "name": "WFI"
+#                     },
+#                     "telescope": "ROMAN",
+                }
+    }
+
+    # Set temporary asdf file
+    file_path = tmp_path / "test.asdf"
+
+    # Cycle through reference file models to test each
+    for model_class in iter_subclasses(DataModels.referencefile.ReferenceFileModel):
+        # Test base referencefile model
+        if (model_class == DataModels.referencefile.ReferenceFileModel):
+            # Test required key/values pairs in meta dictionary
+            confirm_required_keywords(tmp_path, meta)
+
+            # Testing referencefile asdf file
+            with asdf.AsdfFile(meta) as af:
+                af.write_to(file_path)
+
+                # Load base referencefile schema
+                schema = asdf.schema.load_schema(
+                    "http://stsci.edu/schemas/roman_datamodel/reference_files/referencefile.schema")
+
+                # Ensure that base referencefile schema contains core schema
+                found = False
+                for schemaref in schema.get("allOf", [{}]):
+                    if schemaref.get("$ref","") == "../core.schema":
+                        found = True
+                        break
+                assert found
+
+                # Test that asdf file opens properly
+                assert DataModels.open(file_path)
+
+                # Confirm that asdf file is opened as base referencefile model
+                with DataModels.open(file_path) as model:
+                    assert isinstance(model, DataModels.referencefile.ReferenceFileModel)
 
         # Test Flat file model
         elif (model_class == DataModels.flat.FlatModel):
-            print("XXX Flat model found")
-            af["meta"]["reftype"] = "FLAT"
-            af["data"] = np.zeros((4096, 4096))
-            af["dq"] = np.zeros((4096, 4096))
-            af["derr"] = np.zeros((4096, 4096))
-            af.write_to(file_path)
 
-            with DataModels.open(file_path) as model:
-                with pytest.warns(None):
-                    print("XXX model.validate = "+str(model.validate()))
-                    model.validate()
-                    assert not model.validate()
-                assert isinstance(model, DataModels.flat.FlatModel)
+            # Testing flat file asdf file
+            with asdf.AsdfFile(meta) as af:
+                # Add required flat file elements
+                af["meta"]["reftype"] = "FLAT"
+                af["data"] = np.zeros((4096, 4096))
+                af["dq"] = np.zeros((4096, 4096))
+                af["derr"] = np.zeros((4096, 4096))
+                af.write_to(file_path)
 
-            af["meta"]["telescope"] = "NOTROMAN"
-            af.write_to(file_path)
-            with DataModels.open(file_path) as model:
-                with pytest.warns(ValidationWarning):
-                    print("XXX Bad model.validate = " + str(model.validate()))
-                    print("XXX model['meta']['telescope'] = " + str(model["meta"]["telescope"]))
+                # Test that asdf file opens properly
+                with DataModels.open(file_path) as model:
+                    with pytest.warns(None) as record:
+                        model.validate()
+
+                    # Confirm that asdf file is opened as flat file model
+                    assert isinstance(model, DataModels.flat.FlatModel)
+                assert (len(record) == 0)
+
+                # Test for invalid flat file
+                af["meta"]["telescope"] = "NOTROMAN"
+                af.write_to(file_path)
+
+                with DataModels.open(file_path) as model:
                     model.validate()
+                    with pytest.warns(ValidationWarning) as record:
+                        model.validate()
                     assert model["meta"]["telescope"] == "NOTROMAN"
-                    assert model.validate() != None
+                assert (len(record) > 0)
 
+        # Raise error if unknown reference file encountered
         else:
             raise Exception("XXX Unknown referencefile model found:" + str(model_class))
-

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -5,18 +5,18 @@ import numpy as np
 from astropy.time import Time
 from copy import deepcopy
 
-from romancal.datamodels import RomanDataModel
-import romancal.datamodels as DataModels
+from romancal import datamodels
 from stdatamodels.validate import ValidationWarning
 
 # Helper class to iterate over model subclasses
-def iter_subclasses(model_class):
-    yield model_class
+def iter_subclasses(model_class, include_base_model=True):
+    if include_base_model:
+        yield model_class
     for sub_class in model_class.__subclasses__():
         yield from iter_subclasses(sub_class)
 
 def test_model_schemas(tmp_path):
-    for model_class in iter_subclasses(RomanDataModel):
+    for model_class in iter_subclasses(datamodels.RomanDataModel):
         try:
             asdf.schema.load_schema(model_class.schema_url)
         except Exception:
@@ -27,8 +27,28 @@ def test_model_schemas(tmp_path):
 
 # Helper function to test required keywords
 # meta = dictionary of required key/value pairs to ensure each are required
-def confirm_required_keywords(tmp_path, meta):
+def confirm_required_keywords(tmp_path, meta, model_class):
     file_path = tmp_path / "test.asdf"
+
+    # dm = model_class(meta)
+    # for required_key in dm.keys():
+    #     original_value = dm[required_key]
+    #     dm[required_key] = None
+    #     with pytest.warns(ValidationWarning):
+    #         dm.validate()
+    #     dm[required_key] = original_value
+
+    dm = model_class(meta)
+    for required_key in dm.keys():
+        original_value = dm[required_key]
+        dm[required_key] = None
+        with pytest.warns(ValidationWarning) as record:
+            dm.validate()
+        dm[required_key] = original_value
+        try:
+            print("XXX record[0] = " + str(record[0]))
+        except:
+            pass
 
     # Returns the "paths" for all the keys in a dictionary (e.g. keys within keys.)
     # This return is in the form of a list of lists, allowing the paths to be combined in whatever
@@ -67,13 +87,17 @@ def confirm_required_keywords(tmp_path, meta):
             af.write_to(file_path)
 
         # Test for warning that required keyword is missing
-        with DataModels.open(file_path) as model:
-            with pytest.warns(ValidationWarning) as record:
+        with datamodels.open(file_path) as model:
+            with pytest.warns(ValidationWarning):
                 model.validate()
-        assert (len(record) > 0)
+        #     with pytest.warns(ValidationWarning) as record:
+        #         model.validate()
+        # assert (len(record) > 0)
 
 # Testing core schema
-def test_core_schemas(tmp_path):
+def test_core_schema(tmp_path):
+    # Set temporary asdf file
+    file_path = tmp_path / "test.asdf"
 
     # Define meta dictionary of required key / value pairs
     meta = {"meta":
@@ -87,23 +111,49 @@ def test_core_schemas(tmp_path):
             }
 
     # Test schema for required key/value pairs
-    confirm_required_keywords(tmp_path, meta)
+    confirm_required_keywords(tmp_path, meta, datamodels.core.RomanDataModel)
 
-# Testing all reference file schemas
-def test_referencefile_model_schemas(tmp_path):
+    # Testing bad core asdf file
+    with asdf.AsdfFile(meta) as af:
+        # Test for invalid entry
+        af["meta"]["telescope"] = "NOTROMAN"
+        af.write_to(file_path)
 
-    # Define base meta dictionary of required key / value pairs for reference files
-    # NOTE 1: date is commented out because it is not properly failing its test
-    #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
-    # NOTE 2: core.schema key/value pairs commented out due to not properly failing their tests
-    #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/7
+        with datamodels.open(file_path) as model:
+            model.validate()
+            with pytest.warns(ValidationWarning) as record:
+                model.validate()
+            assert model["meta"]["telescope"] == "NOTROMAN"
+        assert (len(record) > 0)
 
-    meta = {"meta":
-                {
+# Helper function to confirm that a reference exists within a schema
+def assert_referenced_schema(schema_uri, ref_uri):
+    # Hide function from pytest traceback
+    __tracebackhide__ = True
+
+    # Load schema
+    schema = asdf.schema.load_schema(schema_uri)
+
+    # Search for reference in schema
+    for subschema in schema.get("allOf", []):
+        if asdf.generic_io.resolve_uri(schema_uri, subschema.get("$ref")) == ref_uri:
+            # Reference found
+            return
+    # Reference not found
+    assert False, f"Schema '{schema_uri}' does not reference '{ref_uri}' in a top-level allOf combiner"
+
+
+# Define base meta dictionary of required key / value pairs for reference files
+# NOTE 1: date is commented out because it is not properly failing its test
+#         Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
+# NOTE 2: core.schema key/value pairs commented out due to not properly failing their tests
+#         Ticket: https://github.com/spacetelescope/stdatamodels/issues/7
+REFERENCEFILE_SCHEMA_DICT = {
+    "meta": {
                     "author": "Space Telescope Science Institute",
                     "description": "Test file",
                     "pedigree": "Test",
-                    "reftype": "REFERENCEFILE",
+                    "reftype": "BASE",
                     "useafter": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
 #                    "date": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
 #                     # Key/value pairs from core.schema
@@ -113,74 +163,66 @@ def test_referencefile_model_schemas(tmp_path):
 #                         "name": "WFI"
 #                     },
 #                     "telescope": "ROMAN",
-                }
+        }
     }
 
+# Testing all reference file schemas
+def test_reference_file_model_base(tmp_path):
     # Set temporary asdf file
     file_path = tmp_path / "test.asdf"
 
-    # Cycle through reference file models to test each
-    for model_class in iter_subclasses(DataModels.referencefile.ReferenceFileModel):
-        # Test base referencefile model
-        if (model_class == DataModels.referencefile.ReferenceFileModel):
-            # Test required key/values pairs in meta dictionary
-            confirm_required_keywords(tmp_path, meta)
+    # Get reference dictionary base
+    meta = REFERENCEFILE_SCHEMA_DICT
 
-            # Testing referencefile asdf file
-            with asdf.AsdfFile(meta) as af:
-                af.write_to(file_path)
+    # Test required key/values pairs in meta dictionary
+    confirm_required_keywords(tmp_path, meta, datamodels.referencefile.ReferenceFileModel)
 
-                # Load base referencefile schema
-                schema = asdf.schema.load_schema(
-                    "http://stsci.edu/schemas/roman_datamodel/reference_files/referencefile.schema")
+    # Testing referencefile asdf file
+    with asdf.AsdfFile(meta) as af:
+        af.write_to(file_path)
 
-                # Ensure that base referencefile schema contains core schema
-                found = False
-                for schemaref in schema.get("allOf", [{}]):
-                    if schemaref.get("$ref","") == "../core.schema":
-                        found = True
-                        break
-                assert found
+        # Ensure that base referencefile schema contains core schema
+        assert_referenced_schema(datamodels.referencefile.ReferenceFileModel.schema_url,
+                                 datamodels.core.RomanDataModel.schema_url)
 
-                # Test that asdf file opens properly
-                assert DataModels.open(file_path)
+        # Test that asdf file opens properly
+        assert datamodels.open(file_path)
 
-                # Confirm that asdf file is opened as base referencefile model
-                with DataModels.open(file_path) as model:
-                    assert isinstance(model, DataModels.referencefile.ReferenceFileModel)
+        # Confirm that asdf file is opened as base referencefile model
+        with datamodels.open(file_path) as model:
+            assert isinstance(model, datamodels.referencefile.ReferenceFileModel)
 
-        # Test Flat file model
-        elif (model_class == DataModels.flat.FlatModel):
 
-            # Testing flat file asdf file
-            with asdf.AsdfFile(meta) as af:
-                # Add required flat file elements
-                af["meta"]["reftype"] = "FLAT"
-                af["data"] = np.zeros((4096, 4096))
-                af["dq"] = np.zeros((4096, 4096))
-                af["derr"] = np.zeros((4096, 4096))
-                af.write_to(file_path)
+# Common tests for all ReferenceFileModel subclasses
+@pytest.mark.parametrize("model_class", list(iter_subclasses(
+    datamodels.referencefile.ReferenceFileModel, include_base_model=False)))
+def test_reference_file_model(tmp_path, model_class):
+    # Ensure that specific reference file schema contains the base module schema
+    assert_referenced_schema(model_class.schema_url,
+                             datamodels.referencefile.ReferenceFileModel.schema_url)
 
-                # Test that asdf file opens properly
-                with DataModels.open(file_path) as model:
-                    with pytest.warns(None) as record:
-                        model.validate()
+# FlatModel tests
+def test_flat_model(tmp_path):
+    # Set temporary asdf file
+    file_path = tmp_path / "test.asdf"
 
-                    # Confirm that asdf file is opened as flat file model
-                    assert isinstance(model, DataModels.flat.FlatModel)
-                assert (len(record) == 0)
+    # Get reference dictionary base
+    meta = REFERENCEFILE_SCHEMA_DICT
 
-                # Test for invalid flat file
-                af["meta"]["telescope"] = "NOTROMAN"
-                af.write_to(file_path)
+    # Testing flat file asdf file
+    with asdf.AsdfFile(meta) as af:
+        # Add required flat file elements
+        af["meta"]["reftype"] = "FLAT"
+        af["data"] = np.zeros((4096, 4096))
+        af["dq"] = np.zeros((4096, 4096))
+        af["derr"] = np.zeros((4096, 4096))
+        af.write_to(file_path)
 
-                with DataModels.open(file_path) as model:
-                    model.validate()
-                    with pytest.warns(ValidationWarning) as record:
-                        model.validate()
-                    assert model["meta"]["telescope"] == "NOTROMAN"
-                assert (len(record) > 0)
+        # Test that asdf file opens properly
+        with datamodels.open(file_path) as model:
+            with pytest.warns(None) as record:
+                model.validate()
 
-        # Raise error if unknown reference file encountered
-        else:
-            raise Exception("XXX Unknown referencefile model found:" + str(model_class))
+            # Confirm that asdf file is opened as flat file model
+            assert isinstance(model, datamodels.flat.FlatModel)
+        assert (len(record) == 0)

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -27,8 +27,6 @@ def test_model_schemas(tmp_path):
 # meta = dictionary of required key/value pairs to ensure each are required
 # model_class = the class of the model to be tested
 def confirm_required_keywords(tmp_path, meta, model_class):
-    file_path = tmp_path / "test.asdf"
-
     # Create data model
     dm = model_class(meta)
 

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -1,9 +1,14 @@
+import pytest
+
 import asdf
+import numpy as np
 
 from romancal.datamodels import RomanDataModel
+import romancal.datamodels as DataModels
+from stdatamodels.validate import ValidationWarning
 
 
-def test_model_schemas():
+def test_model_schemas(tmp_path):
     def iter_subclasses(model_class):
         yield model_class
         for sub_class in model_class.__subclasses__():
@@ -13,4 +18,74 @@ def test_model_schemas():
         try:
             asdf.schema.load_schema(model_class.schema_url)
         except Exception:
-            assert False, f"Unable to load schema URI '{model_class.schema_url}' for model class {model_class.__name__}"
+            assert False, f"Unable to load schema URI '{model_class.schema_url}' for model " \
+                          f"class {model_class.__name__}"
+
+def test_referencefile_model_schemas(tmp_path):
+    print("XXX test_referencefile_model_schemas")
+    print("XXX tmp_path = " + str(tmp_path))
+
+    def iter_subclasses(model_class):
+        yield model_class
+        for sub_class in model_class.__subclasses__():
+            yield from iter_subclasses(sub_class)
+
+    file_path = tmp_path / "test.asdf"
+
+    for model_class in iter_subclasses(DataModels.referencefile.ReferenceFileModel):
+        print("XXX model_class = "+str(model_class))
+        with asdf.AsdfFile() as af:
+            af["meta"] = {"author":"Space Telescope Science Institute",
+                          "date": "Today",
+                          "description":"Test file",
+                          "instrument":{
+                              "detector":"WFI01",
+                              "filter":"F158",
+                              "name":"WFI"
+                          },
+                          "pedigree":"Test",
+                          "reftype":"REFERENCEFILE",
+                          "telescope":"ROMAN",
+                          "useafter":"Today"
+            }
+
+
+        # Test referencefile model
+        if (model_class == DataModels.referencefile.ReferenceFileModel):
+            print("XXX Referencefile model found")
+            af.write_to(file_path)
+
+            assert DataModels.open(file_path)
+
+            # with DataModels.open(file_path) as model:
+            #     assert isinstance(model, DataModels.referencefile.ReferenceFileModel)
+
+        # Test Flat file model
+        elif (model_class == DataModels.flat.FlatModel):
+            print("XXX Flat model found")
+            af["meta"]["reftype"] = "FLAT"
+            af["data"] = np.zeros((4096, 4096))
+            af["dq"] = np.zeros((4096, 4096))
+            af["derr"] = np.zeros((4096, 4096))
+            af.write_to(file_path)
+
+            with DataModels.open(file_path) as model:
+                with pytest.warns(None):
+                    print("XXX model.validate = "+str(model.validate()))
+                    model.validate()
+                    assert not model.validate()
+                assert isinstance(model, DataModels.flat.FlatModel)
+
+            af["meta"]["telescope"] = "NOTROMAN"
+            af.write_to(file_path)
+            with DataModels.open(file_path) as model:
+                with pytest.warns(ValidationWarning):
+                    print("XXX Bad model.validate = " + str(model.validate()))
+                    print("XXX model['meta']['telescope'] = " + str(model["meta"]["telescope"]))
+                    model.validate()
+                    assert model["meta"]["telescope"] == "NOTROMAN"
+                    assert model.validate() != None
+
+        else:
+            raise Exception("XXX Unknown referencefile model found:" + str(model_class))
+

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -16,42 +16,7 @@ def iter_subclasses(model_class, include_base_model=True):
 
 def test_model_schemas(tmp_path):
     for model_class in iter_subclasses(datamodels.RomanDataModel):
-        try:
-            asdf.schema.load_schema(model_class.schema_url)
-        except Exception:
-            assert False, f"Unable to load schema URI '{model_class.schema_url}' for model " \
-                          f"class {model_class.__name__}"
-
-
-# Helper function to test required keywords
-# meta = dictionary of required key/value pairs to ensure each are required
-# model_class = the class of the model to be tested
-def confirm_required_keywords(tmp_path, meta, model_class):
-    # Create data model
-    dm = model_class(meta)
-
-    # Cycle through provided required keys, testing a model missing each one in isolation
-    for required_key in dm.keys():
-        # The following is required due to the following bugs:
-        # NOTE 1: meta.date requires skipping because it is not properly failing its test
-        #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
-        # NOTE 2: meta.model_type requires skipping due to not properly failing their tests
-        #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/7
-        if required_key in ["meta.date", "meta.model_type"]:
-            continue
-
-        # Store key value
-        original_value = dm[required_key]
-        # Setting key value to "None" effectively removes it from the model
-        dm[required_key] = None
-
-        # Test for warning that required keyword is missing
-        with pytest.warns(ValidationWarning):
-            dm.validate()
-
-        # Return key and value
-        dm[required_key] = original_value
-
+        asdf.schema.load_schema(model_class.schema_url)
 
 # Testing core schema
 def test_core_schema(tmp_path):
@@ -69,9 +34,6 @@ def test_core_schema(tmp_path):
                  "model_type": "RomanDataModel"
                  }
             }
-
-    # Test schema for required key/value pairs
-    confirm_required_keywords(tmp_path, meta, datamodels.core.RomanDataModel)
 
     # Testing bad core asdf file
     with asdf.AsdfFile(meta) as af:
@@ -135,9 +97,6 @@ def test_reference_file_model_base(tmp_path):
 
     # Get reference dictionary base
     meta = REFERENCEFILE_SCHEMA_DICT
-
-    # Test required key/values pairs in meta dictionary
-    confirm_required_keywords(tmp_path, meta, datamodels.referencefile.ReferenceFileModel)
 
     # Testing referencefile asdf file
     with asdf.AsdfFile(meta) as af:

--- a/romancal/datamodels/tests/test_open.py
+++ b/romancal/datamodels/tests/test_open.py
@@ -5,7 +5,6 @@ import asdf
 import numpy as np
 
 from romancal import datamodels
-from romancal.datamodels import RomanDataModel
 
 
 def test_asdf_file_input():

--- a/romancal/datamodels/tests/test_open.py
+++ b/romancal/datamodels/tests/test_open.py
@@ -58,7 +58,7 @@ def test_memmap(tmp_path):
     file_path = tmp_path/"test.asdf"
     with asdf.AsdfFile() as af:
         af["data"] = np.zeros((1024,))
-
+        af["meta"] = {}
         af.write_to(file_path)
 
     with datamodels.open(file_path, memmap=True) as model:


### PR DESCRIPTION
Added tests for core, referencefile, and flat schemas. Updated the schemas for required keywords and modified time types. Some tests are commented out due to known asdf errors. (RCAL-25, RCAL-26, RCAL-50, RCAL-52)