### PR TITLE
Adding dummy README file to placate readthedocs build.

### DIFF
--- a/romancal/flatfield/README.md
+++ b/romancal/flatfield/README.md
@@ -1,0 +1,1 @@
+This file exists only so that the directory that it is in is not empty, and will be removed once flatfield python files have been added to this directory. The readthedocs build requires this directory to exist.


### PR DESCRIPTION
Building documentation for romancal using readthedocs requires the existence of the directory romancal/flatfield, which will eventually contain code for the flatfield step.  Github only understands files, not directories (empty or not), so I've added this dummy file to the flatfield directory; this file will be removed once python files have been added to the directory.