### PR TITLE
Additional files required by readthedocs

### DIFF
--- a/docs/roman/includes/standard_keywords.inc
+++ b/docs/roman/includes/standard_keywords.inc
@@ -1,0 +1,27 @@
+
+Standard Keywords
++++++++++++++++++
+The following table lists the keywords that are *required* to be present in all
+reference files.  The first column gives the keyword name.  The second column 
+gives the roman data model name for each keyword, which is useful when using
+data models in creating and populating a new reference file.  The third column
+gives the equivalent meta tag in ASDF reference file headers, which is the same
+as the name within the data model meta tree (second column).
+
+==========  ==========================  ========================
+Keyword     Data Model Name             ASDF meta tag
+==========  ==========================  ========================
+AUTHOR      model.meta.author           author
+DATAMODL    model.meta.model_type       model_type
+DATE        model.meta.date             date
+DESCRIP     model.meta.description      description
+FILENAME    model.meta.filename         N/A     
+INSTRUME    model.meta.instrument.name  instrument: {name}
+PEDIGREE    model.meta.pedigree         pedigree
+REFTYPE     model.meta.reftype          reftype
+TELESCOP    model.meta.telescope        telescope
+USEAFTER    model.meta.useafter         useafter
+==========  ==========================  ========================
+
+**NOTE:** More information on standard required keywords can be found here:
+:ref:`Standard Required Keywords`

--- a/docs/roman/references_general/flat_selection.inc
+++ b/docs/roman/references_general/flat_selection.inc
@@ -1,0 +1,15 @@
+.. _flat_selectors:
+
+Reference Selection Keywords for FLAT
++++++++++++++++++++++++++++++++++++++
+CRDS selects appropriate FLAT references based on the following keywords.
+FLAT is not applicable for instruments not in the table.
+Non-standard keywords used for file selection are *required*.
+
+========== ========================================================================
+Instrument Keywords                                                                 
+========== ========================================================================
+WFI        INSTRUME, DETECTOR, EXP_TYPE, FILTER, BAND, READPATT, GRATING
+CGI        INSTRUME, DETECTOR, EXP_TYPE, FILTER, BAND, READPATT, GRATING
+========== ========================================================================
+


### PR DESCRIPTION
Adding more files required for the readthedocs build, as shown from the build log. There is 1 more error (which I am still investigating) from that log, regarding a missing class in the datamodels module.