### PR TITLE
Fixed 2 index rst files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,36 @@
-.. _data-models:
+.. romancal documentation master file
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+:ref:`genindex`  |  :ref:`modindex`
 
 ===========
-Data Models
+User Manual
 ===========
 
 .. toctree::
    :maxdepth: 2
 
-   models.rst
-   attributes.rst
-   metadata.rst
-   new_model.rst
-   structure.rst
+   roman/introduction.rst
 
-.. automodapi:: romancal.datamodels
+
+===============================
+Error Propagation Documentation
+===============================
+
+.. toctree::
+   :maxdepth: 1
+
+   roman/error_propagation/index.rst
+
+
+=====================
+Package Documentation
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   roman/package_index.rst
+
+

--- a/docs/roman/package_index.rst
+++ b/docs/roman/package_index.rst
@@ -5,4 +5,4 @@ Package Index
    :maxdepth: 2
 
    datamodels/index.rst
-   stpipe/index.rst
+   flatfield/index.rst


### PR DESCRIPTION
Two of the index rst files in the romancal readthedocs needed updating. As more calibration steps are added, the corresponding rst files will be added.  The current roman/introduction.rst is a straight copy of the JWST version, so needs to be 'romanticized'.