### PR TITLE
Replaced JWST references with Roman

### DIFF
--- a/docs/roman/datamodels/models.rst
+++ b/docs/roman/datamodels/models.rst
@@ -5,8 +5,8 @@ About models
 
 The purpose of the data model is to abstract away the peculiarities of
 the underlying file format.  The same data model may be used for data
-created from scratch in memory, or loaded from ASDF files or
-some future file format.
+created from scratch in memory, or loaded from ASDF files or some future file 
+format.
 
 
 Hierarchy of models
@@ -39,7 +39,7 @@ To create a new `ImageModel`, just call its constructor.  To create a
 new model where all of the arrays will have default values, simply
 provide a shape as the first argument::
 
-    from jwst.datamodels import ImageModel
+    from romancal.datamodels import ImageModel
     with ImageModel((1024, 1024)) as im:
         ...
 
@@ -53,7 +53,7 @@ consumed::
   print(im.data)
 
 If you already have data in a numpy array, you can also create a model
-using that array by passing it in as a data metadata argument::
+using that array by passing it in as a data keyword argument::
 
     data = np.empty((50, 50))
     dq = np.empty((50, 50))
@@ -68,7 +68,6 @@ model from a file on disk.  It may be passed any of the following:
 
     - a path to an ASDF file
     - a readable file-like object
-    TBD
 
 The file will be opened, and based on the nature of the data in the
 file, the correct data model class will be returned.  For example, if
@@ -101,13 +100,13 @@ Saving a data model to a file
 
 Simply call the `save` method on the model instance.  The format to
 save into will either be deduced from the filename (if provided) or
-the `format` metadata argument::
+the `format` keyword argument::
 
     im.save("myimage.asdf")
 
 .. note::
 
-   Unlike ``astropy.io.asdf``, `save` always clobbers the output file.
+   This `save` always clobbers the output file.
 
 
 Copying a model
@@ -144,17 +143,22 @@ history::
     entry =  util.create_history_entry("Processed through the frobulator step")
     model.history.append(entry)
 
-These history entries are stored in ``HISTORY`` metadata when saving
-to ASDF format.
-   TBD
+These history entries are stored in ``HISTORY`` keywords when saving
+to ASDF format. As an option, history entries can contain a dictionary
+with a description of the software used. The dictionary must have the
+following keys:
 
-The calling sequence to create  a history entry with the software
+  ``name``: The name of the software
+  ``author``: The author or institution that produced the software
+  ``homepage``: A URI to the homepage of the software
+  ``version``: The version of the software
+
+The calling sequence to create a history entry with the software
 description is::
 
   entry =  util.create_history_entry(description, software=software_dict)
 
-where the second argument is the dictionary with the metadata
-mentioned.
+where the second argument is the dictionary with the keywords mentioned.
 
 Looking at the contents of a model
 ----------------------------------
@@ -185,15 +189,16 @@ The number of displayed rows is controlled by the ``max_row`` argument::
   │ ├─coordinates (dict) ...
   │ └─28 not shown
   ├─var_poisson (ndarray): shape=(2048, 2048), dtype=float32
-  ├─var_rnoise (ndarray): shape=(2048, 2048), dtype=float32
+  └─var_rnoise (ndarray): shape=(2048, 2048), dtype=float32 ...
+
   Some nodes not shown.
 
 
 Searching a model
 -----------------
 
-``model.search()`` can be used to search the ASDF tree by...
-   TBD
+``model.search()`` can be used to search the ASDF tree by ``key`` or
+``value``::
 
   im.search(key='filter')
 
@@ -203,72 +208,3 @@ Searching a model
   │ └─filter (str): F170LP
   └─ref_file (dict)
     └─filteroffset (dict)
-
-
-
-Converting from ``astropy.io.asdf``
-===================================
-
-This section describes how to port code that uses ``astropy.io.asdf``
-to use `romancal.datamodels`.
-
-Opening a file
---------------
-
-Instead of::
-
-    astropy.io.asdf.open("myfile.asdf")
-
-use::
-
-    from romancal.datamodels import ImageModel
-    with ImageModel("myfile.asdf") as model:
-        ...
-
-In place of `ImageModel`, use the type of data one expects to find in
-the file.  For example, if spectrographic data is expected, use
-`SpecModel`.  If it doesn't matter (perhaps the application is only
-sorting ASDF files into categories) use the base class `RomanDataModel`.
-
-An alternative is to use::
-
-    from romancal import datamodels
-    with datamodels.open("myfile.asdf") as model:
-        ...
-
-The `datamodels.open()` method checks if the `DATAMODL` ASDF metadata has
-been set, which records the DataModel that was used to create the file.
-If the metadata is not set, then `datamodels.open()` does its best to
-guess the best DataModel to use.
-
-Accessing data
---------------
-
-Data should be accessed through one of the pre-defined data members on
-the model (`data`, `dq`, `err`).  There is no longer a need to hunt
-through the HDU list to find the data.
-
-Instead of::
-
-    hdulist['SCI'].data
-
-use::
-
-    model.data
-
-Accessing metadata
-------------------
-
-The data model hides direct access to ASDF header metadata.  Instead,
-use the :ref:`metadata` tree.
-
-There is a convenience method, ...
-
-TBD
-
-Extra ASDF metadata
--------------------
-
-When loading arbitrary ASDF files, there may be metadata that are not
-listed in the schema for that data model. 
- TBD

--- a/docs/roman/datamodels/new_model.rst
+++ b/docs/roman/datamodels/new_model.rst
@@ -12,7 +12,7 @@ For further reading and details, see the reference materials in
 
 In this tutorial, we'll go through the process of creating a new type
 of model for a file format used for storing the bad pixel mask for a 
-hypothetical Roman instrument called "WFI".  This file format has a 2D array 
+hypothetical Roman instrument called "MY_WFI".  This file format has a 2D array 
 containing a bit field for each of the pixels, and a table describing what 
 each of the bits in the array means.
 

--- a/docs/roman/datamodels/structure.rst
+++ b/docs/roman/datamodels/structure.rst
@@ -23,7 +23,7 @@ attribute is not defined, which in turn calls _make_default_array if
 the schema says the attribute is an array. All these methods can be
 found in properties.py.
 
-The base class for Datamodels is RomanDataModel,  in model_base.py. It takes
+The base class for Datamodels is RomanDataModel, in model_base.py. It takes
 several arguments, the most important of which is init, which as the
 name suggests, specifies how to initialize the primary data array of
 the model. Init is most usually the name of a file, but can be an
@@ -40,8 +40,11 @@ same name.
 As an alternative to creating a model by initializing an object of the
 specific class, you can call the open function, which is in
 util.py. This function takes the same arguments as the __init_
-method.
-TBD
+method. If it is called with the name of aa ASDF file, it looks in the
+metadata for a keyword named DATAMODL that contains the name of
+the class to use to open the model. If that keyword is not found,
+checks the dimensionality of the image and uses a generic model type
+to open the image.
 
 The base class for Datamodels loads the schema from the a file in the
 schemas subdirectory. If the base class is passed a descriptor of an
@@ -53,16 +56,14 @@ determine the file type. This test is in filetype.py.
 
 To write a model back to a file, call the save method on the file. It
 first calls validate_required to check the schema to see if all the
-required fields are present in the model.
-
-TBD
+required fields are present in the model. (More information needed)
 
 Items within a model are accessed as attribute, that is, with dot
 motation. The code which handles getting and setting attributes is
 found in properties.py. Datamodels distinguishes between items at the
 endpoints of the asdf tree and subtrees within the asdf tree. The
 former are returned as scalars or numpy arrays, depending on whether
-the endpoint represents metadata or data array. Subtrees are
+the endpoint represents a keyword or data array. Subtrees are
 returned as nodes. A node is an object containing the subtree as well
 as the subschema which describes the subtree.  If one tries to get an
 attribute that does not exist in the asdf tree, one of several things

--- a/docs/roman/error_propagation/main.rst
+++ b/docs/roman/error_propagation/main.rst
@@ -3,7 +3,7 @@ Description
 Steps in the various pipeline modules calculate variances due to different sources of
 noise or modify variances that were computed by previous steps.  In some cases the
 variance arrays are only used internally within a given step.  For several steps,
-these arrays must be propagated to subsequent steps in the pipeline. Anytime a step
+these arrays must be propagated to subsequent steps in the pipeline. Any time a step
 creates or updates variances, the total error (ERR) array values are always recomputed
 as the square root of the quadratic sum of all variances available at the time.
 Note that the ERR array values are always expressed as standard deviation
@@ -19,19 +19,14 @@ Step              Stage Creates arrays          Updates arrays                  
 ramp_fitting        1   VAR_POISSON, VAR_RNOISE ERR                                    None
 gain_scale          1   None                    ERR, VAR_POISSON, VAR_RNOISE           None
 flat_field          2   VAR_FLAT                ERR, VAR_POISSON, VAR_RNOISE           None
-fringe              2   None                    ERR                                    None
-barshadow           2   None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
-pathloss            2   None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
 photom              2   None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
-outlier_detection   3   None                    None                                   ERR
-wfs_combine         3   None                    ERR                                    None
 ================= ===== ======================= ====================================== =========
 
 Stage 1 Pipelines 
 -----------------
 Stage 1 pipelines perform detector-level corrections and ramp fitting for
 individual exposures, for nearly all imaging and spectroscopic modes. Details 
-of the pipelines can be found at :ref:`Stage 1 Pipelines <calwebb_detector1>`.
+of the pipelines can be found at :ref:`Stage 1 Pipelines <calroman_detector1>`.
 
 The Stage 1 pipeline steps that alter the ERR, VAR_POISSON, or VAR_RNOISE arrays of
 the science countrate data are discussed below.
@@ -59,8 +54,8 @@ Stage 2 Pipelines
 -----------------
 Stage 2 pipelines perform additional instrument-level and observing-mode corrections and 
 calibrations to produce fully calibrated exposures. There are two main Stage 2 pipelines:
-one for imaging :ref:`calwebb_image2 <calwebb_image2>` and one for 
-spectroscopy :ref:`calwebb_spec2 <calwebb_spec2>`.
+one for imaging :ref:`calroman_image2 <calroman_image2>` and one for 
+spectroscopy :ref:`calroman_spec2 <calroman_spec2>`.
 In these pipelines, the various steps that apply corrections and calibrations
 apply those same corrections/calibrations to all variance arrays and update the total
 ERR array.
@@ -75,29 +70,6 @@ The science data ERR array is then updated to be the square root of the quadrati
 the three variance arrays.
 For more details see :ref:`flat_field <flatfield_step>`.
 
-fringe 
-++++++
-For MIRI MRS (IFU) mode exposures, the SCI and ERR arrays in the science exposure
-are divided by the fringe reference image.  For details of the fringe correction, see 
-:ref:`fringe <fringe_step>`.
-
-barshadow 
-+++++++++
-This step is applied only to NIRSpec MSA data for extended sources. Once the
-2-D correction array for each slit has been computed, it is applied to the
-science (SCI), error (ERR), and variance (VAR_POISSON, VAR_RNOISE, and VAR_FLAT)
-arrays of the slit.  The correction values are divided into the SCI and ERR
-arrays, and the square of the correction values are divided into the variance 
-arrays.   For details of the bar shadow correction, see
-:ref:`barshadow <barshadow_step>`.
-
-pathloss
-++++++++
-The ``pathloss`` step corrects NIRSpec and NIRISS SOSS data for various types of
-light losses. The correction factors are divided into the SCI and ERR arrays of
-the science data, and the square of the correction values are divided into the
-variance arrays. For details of this step, see :ref:`pathloss <pathloss_step>`.
-
 photom
 ++++++ 
 The calibration information for the ``photom`` step includes a scalar flux conversion
@@ -109,27 +81,3 @@ calibration values are multiplied into the science exposure SCI and ERR arrays,
 and the square of the calibration values is multiplied into all variance arrays.
 For details of the photom correction, see :ref:`photom <photom_step>`.
 
-Stage 3 pipelines
------------------
-Stage 3 pipelines perform operations that work with multiple exposures and in
-most cases produce some kind of combined product.  The operations in these
-pipelines that either use or modify variance/error arrays that are propagated 
-through the pipeline are ``outlier_detection`` and ``wfs_combine``.
-
-outlier_detection
-+++++++++++++++++
-The ``outlier_detection`` step is used in all Stage 3 pipelines.  It uses the ERR array to
-make a local noise model, based on the readnoise and calibration errors of earlier 
-steps in the pipeline. This step does not modify the ERR array or any of the VAR
-arrays.
-
-wfs_combine
-+++++++++++
-The ``wfs_combine`` step is only applied in the Stage 3 Wavefront Sensing and Control
-(calwebb_wfs-image3) pipeline for dithered pairs of WFS&C exposures.
-This step can modify variance/error arrays, but only if the optional
-"do_refine" parameter is set to True (the default is False). In this
-case the algorithm to refine image offsets will be used and the ERR array values will be
-altered on output, using a combination of the input image errors.
-See the step documentation at :ref:`wfs_combine <wfs_combine_step>` for
-more details.

--- a/docs/roman/introduction.rst
+++ b/docs/roman/introduction.rst
@@ -252,8 +252,8 @@ For example, to save the result from the dark current step of
     $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --steps.dark_current.output_file='intermediate'
 
-A file, ``intermediate_dark_current.asdf``, will then be created. Note that the
-suffix of the step is always appended to any given name.
+An asdf file named ``intermediate_dark_current.asdf`` will then be created. Note 
+that the suffix of the step is always appended to any given name.
 
 You can also specify a particular file name for saving the end result of
 the entire pipeline using the ``--output_file`` argument also

--- a/docs/roman/introduction.rst
+++ b/docs/roman/introduction.rst
@@ -65,15 +65,14 @@ For example, running the full stage 1 pipeline or an individual step by
 referencing their class names is done as follows:
 ::
 
-  $ strun romancal.pipeline.Detector1Pipeline jw00017001001_01101_00001_nrca1_uncal.asdf
-  $ strun romancal.dq_init.DQInitStep jw00017001001_01101_00001_nrca1_uncal.asdf
+  $ strun romancal.pipeline.Detector1Pipeline roman00017001001_01101_00001_uncal.asdf
+  $ strun romancal.flat_field.FlatFieldStep roman00017001001_01101_00001_uncal.asdf
 
 When a pipeline or step is executed in this manner (i.e. by referencing the
 class name), it will be run using a CRDS-supplied configuration merged with
 default values
 
-If you want to use non-default parameter
-values, you can specify them as
+If you want to use non-default parameter values, you can specify them as
 keyword arguments on the command line or set them in the appropriate
 configuration file.
 
@@ -83,16 +82,14 @@ For example, to override the default selection of a dark current reference
 file from CRDS when running a pipeline:
 ::
 
-    $ strun romancal.pipeline.Detector1Pipeline jw00017001001_01101_00001_nrca1_uncal.asdf
-          --steps.dark_current.override_dark='my_dark.asdf'
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun romancal.pipeline.Detector1Pipeline roman00017001001_01101_00001_uncal.asdf
           --steps.dark_current.override_dark='my_dark.asdf'
 
 You can get a list of all the available arguments for a given pipeline or
 step by using the '-h' (help) argument to strun:
 ::
 
-    $ strun dq_init.cfg -h
+    $ strun flat_field.cfg -h
     $ strun romancal.pipeline.Detector1Pipeline -h
 
 
@@ -102,14 +99,6 @@ Exit Status
 
 - 0: Successful completion of the step/pipeline
 - 1: General error occurred
-- 64: No science data found
-
-The "No science data found" condition is returned by the ``assign_wcs`` step of
-``calwebb_spec2.cfg`` pipeline when, after successfully determining the WCS
-solution for a file, the WCS indicates that no science data will be found. This
-condition most often occurs with NIRSpec's NRS2 detector: There are certain
-optical and MSA configurations in which dispersion will not cross to the NRS2
-detector.
 
 .. _run_from_python:
 
@@ -121,17 +110,17 @@ You can execute a pipeline or a step from within python by using the
 ::
 
  from romancal.pipeline import Detector1Pipeline
- result = Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.asdf')
+ result = Detector1Pipeline.call('roman00017001001_01101_00001_uncal.asdf')
 
- from romancal.linearity import LinearityStep
- result = LinearityStep.call('jw00001001001_01101_00001_mirimage_uncal.asdf')
+ from romancal.gain import GainStep
+ result = GainStep.call('roman00001001001_01101_00001_uncal.asdf')
 
 The easiest way to use optional arguments when calling a pipeline from
 within python is to set those parameters in the pipeline configuration file and
 then supply the file as a keyword argument:
 ::
 
- Detector1Pipeline.call('jw00017001001_01101_00001_nrca1_uncal.asdf', config_file='calwebb_detector1.cfg')
+ Detector1Pipeline.call('roman00017001001_01101_00001_uncal.asdf', config_file='calroman_detector1.cfg')
 
 
 .. _intro_file_conventions:
@@ -148,11 +137,9 @@ There are two general types of input to any step or pipeline: references files
 and data files.  The references files, unless explicitly
 overridden, are provided through CRDS.
 
-Data files are the science input, such as exposure ASDF files and association
-files. All files are assumed to be co-resident in the directory where the primary
-input file is located. This is particularly important for associations: Roman
-associations contain file names only. All files referred to by an association
-are expected to be located in the directory in which the association file is located.
+Data files are the science input, such as exposure ASDF files. All files are 
+assumed to be co-resident in the directory where the primary
+input file is located. 
 
 .. _intro_output_file_discussion:
 
@@ -164,10 +151,9 @@ specified by the :ref:`output_dir <intro_output_directory>` configuration
 parameter.
 
 File names for the outputs from pipelines and steps come from
-three different sources:
+two different sources:
 
 - The name of the input file
-- The product name defined in an association
 - As specified by the :ref:`output_file <intro_output_file>` argument
 
 Regardless of the source, each pipeline/step uses the name as a "base
@@ -182,10 +168,7 @@ will be overwritten.
 Output File and Associations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Stage 2 pipelines can take an individual file or an :ref:`association
-<associations>` as input. Nearly all Stage 3 pipelines require an association as
-input. Normally, the output file is defined in each association's "product name"
-which defines the basename that will be used for output file naming.
+Stage 2 pipelines can take an individual file as input. 
 
 Often, one may reprocess the same set of data multiple times, such as to change
 reference files or parameters in configuration parameters.
@@ -206,10 +189,10 @@ name. If the input file name already has a known suffix, that suffix
 will be replaced. For example:
 ::
 
- $ strun dq_init.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+ $ strun flat_field.cfg roman00017001001_01101_00001_uncal.asdf
 
 produces an output file named
-``jw00017001001_01101_00001_nrca1_dq_init.asdf``.
+``roman00017001001_01101_00001_flat_field.asdf``.
 
 See :ref:`pipeline_step_suffix_definitions` for a list of the more common
 suffixes used.
@@ -225,11 +208,11 @@ Output Directory
 By default, all pipeline and step outputs will drop into the current
 working directory, i.e., the directory in which the process is
 running. To change this, use the ``output_dir`` argument. For example, to
-have all output from ``calwebb_detector1``, including any saved
+have all output from ``calroman_detector1``, including any saved
 intermediate steps, appear in the sub-directory ``calibrated``, use
 ::
 
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --output_dir=calibrated
 
 ``output_dir`` can be specified at the step level, overriding what was
@@ -237,7 +220,7 @@ specified for the pipeline. From the example above, to change the name
 and location of the ``dark_current`` step, use the following
 ::
 
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --output_dir=calibrated
         --steps.dark_current.output_file='dark_sub.asdf'
         --steps.dark_current.output_dir='dark_calibrated'
@@ -262,11 +245,11 @@ individual steps, you have two options:
     This option will save the step results using the name specified.
 
 For example, to save the result from the dark current step of
-``calwebb_detector1`` in a file named based on ``intermediate``, use
+``calroman_detector1`` in a file named based on ``intermediate``, use
 
 ::
 
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --steps.dark_current.output_file='intermediate'
 
 A file, ``intermediate_dark_current.asdf``, will then be created. Note that the
@@ -276,7 +259,7 @@ You can also specify a particular file name for saving the end result of
 the entire pipeline using the ``--output_file`` argument also
 ::
    
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --output_file='stage1_processed'
 
 In this situation, using the default configuration, three files are created:
@@ -293,16 +276,16 @@ For any step that uses a calibration reference file you always have the
 option to override the automatic selection of a reference file from CRDS and
 specify your own file to use. Arguments for this are of the form
 ``--override_<ref_type>``, where ``ref_type`` is the name of the reference file
-type, such as ``mask``, ``dark``, ``gain``, or ``linearity``. When in doubt as to
+type, such as ``mask``, ``dark``, or ``gain``. When in doubt as to
 the correct name, just use the ``-h`` argument to ``strun`` to show you the list
 of available override arguments.
 
-To override the use of the default linearity file selection, for example,
+To override the use of the default flat_field file selection, for example,
 you would use:
 ::
 
-  $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
-          --steps.linearity.override_linearity='my_lin.asdf'
+  $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
+          --steps.flat_field.override_linearity='my_lin.asdf'
 
 Skip
 ----
@@ -311,20 +294,20 @@ Another argument available to all steps in a pipeline is ``skip``.
 If ``skip=True`` is set for any step, that step will be skipped, with the
 output of the previous step being automatically passed directly to the input
 of the step following the one that was skipped. For example, if you want to
-skip the linearity correction step, edit the calwebb_detector1.cfg file to
+skip the flat fielding step, edit the calroman_detector1.cfg file to
 contain:
 ::
 
    [steps]
-      [[linearity]]
+      [[flat_field]]
         skip = True
       ...
 
 Alternatively you can specify the ``skip`` argument on the command line:
 ::
 
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
-        --steps.linearity.skip=True
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
+        --steps.flat_field.skip=True
 
 Logging Configuration
 ---------------------
@@ -350,7 +333,7 @@ pipeline cfg file.
 For example:
 ::
 
-    $ strun calwebb_detector1.cfg jw00017001001_01101_00001_nrca1_uncal.asdf
+    $ strun calroman_detector1.cfg roman00017001001_01101_00001_uncal.asdf
         --logcfg=pipeline-log.cfg
 
 and the file ``pipeline-log.cfg`` contains:
@@ -400,18 +383,18 @@ configuration file add ``--save-parameters <filename.asdf>`` to the command:
 
 $ strun <step.class> <required-input-files> --save-parameters <filename.asdf>
 
-For example, to save the parameters used for a run of the ``calwebb_image2.cfg`` pipeline, use:
+For example, to save the parameters used for a run of the ``calroman_image2.cfg`` pipeline, use:
 ::
 
 $ collect_pipeline_cfgs .
-$ strun calwebb_image2.cfg jw82500001003_02101_00001_NRCALONG_rate.asdf --save-parameters my_image2.asdf
+$ strun calroman_image2.cfg roman82500001003_02101_00001_rate.asdf --save-parameters my_image2.asdf
 
 Once saved, the file can be edited, removing parameters that should be left
 at their default/CRDS values, and setting the remaining parameters to the
 desired values. Once modified, the new configuration file can be used:
 ::
 
-$ strun my_image2.asdf jw82500001003_02101_00001_NRCALONG_rate.asdf
+$ strun my_image2.asdf roman82500001003_02101_00001_rate.asdf
 
 Note that the parameter values will reflect whatever was set on the
 command-line, through a specified local configuration file, and what was
@@ -429,7 +412,7 @@ Guide at :ref:`stpipe-user-steps`.
 Available Pipelines
 ===================
 There are many pre-defined pipeline modules for processing
-data from different instrument observing modes through each of the 3 stages
+data from different instrument observing modes through each of the 2 stages
 of calibration. For all of the details see :ref:`pipelines`.
 
 .. _pipeline_step_suffix_definitions:
@@ -438,7 +421,7 @@ Pipeline/Step Suffix Definitions
 --------------------------------
 
 However the output file name is determined (:ref:`see above
-<intro_output_file_discussion>`), the various stage 1, 2, and 3 pipeline modules
+<intro_output_file_discussion>`), the various stage 1 and 2 pipeline modules
 will use that file name, along with a set of predetermined suffixes, to compose
 output file names. The output file name suffix will always replace any known
 suffix of the input file name. Each pipeline module uses the appropriate suffix
@@ -458,24 +441,7 @@ Optional fitting results from ramp_fit step    fitopt
 Background-subtracted image                    bsub
 Per integration background-subtracted image    bsubints
 Calibrated image                               cal
-Calibrated per integration images              calints
 CR-flagged image                               crf
-CR-flagged per integration images              crfints
-Resampled 2D image                             i2d
-Resampled 2D spectrum                          s2d
-Resampled 3D IFU cube                          s3d
-1D extracted spectrum                          x1d
-1D extracted spectra per integration           x1dints
-1D combined spectrum                           c1d
-Source catalog                                 cat
-Time Series photometric catalog                phot
-Time Series white-light catalog                whtlt
-Coronagraphic PSF image stack                  psfstack
-Coronagraphic PSF-aligned images               psfalign
-Coronagraphic PSF-subtracted images            psfsub
-AMI fringe and closure phases                  ami
-AMI averaged fringe and closure phases         amiavg
-AMI normalized fringe and closure phases       aminorm
 =============================================  ========
 
 


### PR DESCRIPTION
Replaced references to JWST with references to Roman in the readthedocs Roman Cal documentation.  Some areas will need embellishment or clarification as code development progresses. 