### PR TITLE
Add automatic meta.date management to RomanDataModel

### DIFF
--- a/romancal/datamodels/core.py
+++ b/romancal/datamodels/core.py
@@ -1,4 +1,5 @@
 from stdatamodels import DataModel
+from astropy.time import Time
 
 
 class RomanDataModel(DataModel):
@@ -24,3 +25,22 @@ class RomanDataModel(DataModel):
             key: val for key, val in self.to_flat_dict(include_arrays=False).items()
             if isinstance(val, (str, int, float, complex, bool))
         }
+
+    def on_init(self, init):
+        """
+        Hook invoked by the base class before returning a newly
+        created model instance.
+        """
+        super().on_init(init)
+
+        if self.meta.date is None:
+            self.meta.date = Time(Time.now(), format="isot")
+
+    def on_save(self, init):
+        """
+        Hook invoked by the base class before writing a model
+        to a file.
+        """
+        super().on_save(init)
+
+        self.meta.date = Time(Time.now(), format="isot")

--- a/romancal/datamodels/open_impl.py
+++ b/romancal/datamodels/open_impl.py
@@ -48,10 +48,8 @@ def open(init, memmap=False, **model_kwargs):
         }
 
         asdf_file = asdf.open(init, **asdf_kwargs)
-        auto_close_asdf_file = True
     elif isinstance(init, asdf.AsdfFile):
         asdf_file = init
-        auto_close_asdf_file = False
     elif isinstance(init, RomanDataModel):
         # Make a copy of the model so that the original instance can
         # be closed without impacting this one.
@@ -62,11 +60,6 @@ def open(init, memmap=False, **model_kwargs):
     model_class = _select_model_class(asdf_file)
 
     model = model_class(asdf_file, **model_kwargs)
-
-    if auto_close_asdf_file:
-        # TODO: This needs to have a public interface, maybe just
-        # a boolean flag to the DataModel initializer.
-        model._files_to_close.append(asdf_file)
 
     return model
 

--- a/romancal/datamodels/schemas/core.schema.yaml
+++ b/romancal/datamodels/schemas/core.schema.yaml
@@ -223,9 +223,9 @@ properties:
       filename:
         title: Name of the file
         type: string
-        date:
-          title: Date this file was created (UTC)
-          tag: tag:stsci.edu:asdf/time/time-1.1.0
+      date:
+        title: Date this file was created (UTC)
+        tag: tag:stsci.edu:asdf/time/time-1.1.0
       guidestar:
         title: Guide star information
         type: object

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -43,7 +43,6 @@ def test_core_schema(tmp_path):
         af.write_to(file_path)
 
         with datamodels.open(file_path) as model:
-            model.validate()
             with pytest.warns(ValidationWarning):
                 model.validate()
             assert model["meta"]["telescope"] == "NOTROMAN"
@@ -68,8 +67,6 @@ def assert_referenced_schema(schema_uri, ref_uri):
 
 # Define base meta dictionary of required key / value pairs for reference files
 #
-# NOTE 1: date is commented out because it is not properly failing its test
-#         Ticket: https://github.com/spacetelescope/stdatamodels/issues/23
 # NOTE 2: core.schema key/value pairs commented out due to not properly failing their tests
 #         Ticket: https://github.com/spacetelescope/stdatamodels/issues/7
 REFERENCEFILE_SCHEMA_DICT = {
@@ -79,7 +76,7 @@ REFERENCEFILE_SCHEMA_DICT = {
                     "pedigree": "Test",
                     "reftype": "BASE",
                     "useafter": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
-#                    "date": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
+                    "date": Time('1999-01-01T00:00:00.123456789',format='isot', scale='utc'),
 #                     # Key/value pairs from core.schema
 #                     "instrument": {
 #                         "detector": "WFI01",
@@ -148,3 +145,13 @@ def test_flat_model(tmp_path):
 
             # Confirm that asdf file is opened as flat file model
             assert isinstance(model, datamodels.reference_files.flat.FlatModel)
+
+
+def test_meta_date_management(tmp_path):
+    model = datamodels.RomanDataModel({"meta": {"date": Time("2000-01-01T00:00:00.000")}})
+    assert model.meta.date == Time("2000-01-01T00:00:00.000")
+    model.save(str(tmp_path/"test.asdf"))
+    assert abs((Time.now() - model.meta.date).value) < 1.0
+
+    model = datamodels.RomanDataModel()
+    assert abs((Time.now() - model.meta.date).value) < 1.0

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -148,7 +148,13 @@ def test_flat_model(tmp_path):
 
 
 def test_meta_date_management(tmp_path):
-    model = datamodels.RomanDataModel({"meta": {"date": Time("2000-01-01T00:00:00.000")}})
+    model = datamodels.RomanDataModel({
+        "meta": {
+            "date": Time("2000-01-01T00:00:00.000"),
+            "instrument": {"name": "WFI", "detector": "WFI01", "optical_element": "F062"},
+            "telescope": "ROMAN",
+        }
+    })
     assert model.meta.date == Time("2000-01-01T00:00:00.000")
     model.save(str(tmp_path/"test.asdf"))
     assert abs((Time.now() - model.meta.date).value) < 1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numpy>=1.19
     pyparsing>=2.2
     requests>=2.22
-    stdatamodels>=0.1.0
+    stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git
     stpipe>=0.1.0
 
 [options.extras_require]


### PR DESCRIPTION
Now that https://github.com/spacetelescope/stdatamodels/pull/44 has been merged, we can support `astropy.time.Time` objects in the meta.date attribute here.