### PR TITLE
Add developer CRDS setup instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Note: CRDS_CONTEXT values flagged with an asterisk in the above table are estima
 
 The test suite require access to a CRDS cache, but currently (2021-02-09) the shared /grp/crds
 cache does not include Roman files.  Developers inside the STScI network can sync a cache from
-roman-crds-dev.stsci.edu:
+roman-crds-dev.stsci.edu (if working from home, be sure to connect to the VPN first):
 
 ```bash
 $ export CRDS_SERVER_URL=https://roman-crds-dev.stsci.edu

--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ Note: CRDS_CONTEXT values flagged with an asterisk in the above table are estima
 
 ## Unit Tests
 
+### Setup
+
+The test suite require access to a CRDS cache, but currently (2021-02-09) the shared /grp/crds
+cache does not include Roman files.  Developers inside the STScI network can sync a cache from
+roman-crds-dev.stsci.edu:
+
+```bash
+$ export CRDS_SERVER_URL=https://roman-crds-dev.stsci.edu
+$ export CRDS_PATH=$HOME/roman-crds-dev-cache
+$ crds sync --contexts roman-edit
+```
+
+The CRDS_READONLY_CACHE variable should not be set, since references will need to be downloaded
+to your local cache as they are requested.
+
+### Running tests
+
 Unit tests can be run via `pytest`.  Within the top level of your local `roman` repo checkout:
 
     pip install -e .[test]


### PR DESCRIPTION
One of the tests I added recently requires access to a CRDS cache, but I forgot to add instructions on setting that up.