### PR TITLE
Create readnoise schema.

### DIFF
--- a/romancal/datamodels/schemas/reference_files/readnoise.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/readnoise.schema.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+id: "http://stsci.edu/schemas/roman_datamodel/reference_files/readnoise.schema"
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_gainfact.schema
+- $ref: bunit.schema
+- type: object
+  properties:
+    data:
+      title: Read noise
+      default: 0.0
+      ndim: 2
+      datatype: float32


### PR DESCRIPTION
Create a schema for the readnoise reference file, at romancal/datamodels/schemas/reference_files/readnoise.schema.yaml.
This satisfies RCAL-77 . 