### PR TITLE
RCAL-95: set default output_ext to .asdf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,21 @@ stpipe
 ------
 
 - Create stpipe module which provides Roman-specific Step and Pipeline
-  subclasses. [#103].
+  subclasses. [#103, #128]
+
+flatfield
+---------
+
+- Clean up and improve flatfield step. [#122]
+
+datamodels
+----------
+
+- Added ``RampModel``, ``GLS_RampFitModel``, ``RampFitOutputModel`` and
+  schemas. [#110]
+
+- Added ``DQModel`` and schemas. [#81]
+
 
 0.1.0 (2020-12-11)
 ==================

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -8,7 +8,7 @@ class RomanStep(Step):
     Base class for Roman calibration pipeline steps.
     """
     spec = """
-    output_ext =  string(default='.asdf')
+    output_ext =  string(default='.asdf')    # Default type of output
     """
 
     @classmethod

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -7,6 +7,9 @@ class RomanStep(Step):
     """
     Base class for Roman calibration pipeline steps.
     """
+    spec = """
+    output_ext =  string(default='.asdf')
+    """
 
     @classmethod
     def _datamodels_open(cls, init, **kwargs):
@@ -70,7 +73,7 @@ class RomanStep(Step):
         # JWST maintains a list of relevant suffixes that is monitored
         # by tests to be up-to-date.  Roman will likely need to do
         # something similar.
-        return name, " "
+        return name, "_"
 
 
 # RomanPipeline needs to inherit from Pipeline, but also


### PR DESCRIPTION
This PR sets the default extension for Roman products to `.asdf`. 
~It depends on spacetelescope/stpipe#17~