### PR TITLE
Create readnoise schema.

### DIFF
--- a/romancal/datamodels/schemas/reference_files/readnoise.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/readnoise.schema.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+id: "http://stsci.edu/schemas/roman_datamodel/reference_files/readnoise.schema"
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_gainfact.schema
+- type: object
+  properties:
+    data:
+      $ref: ../core/asdf/ndarray-1.0.0
+


### PR DESCRIPTION
Create a schema for the readnoise reference file, at romancal/datamodels/schemas/reference_files/readnoise.schema.yaml.
This satisfies RCAL-77 . This PR addresses reviewer comments from PR#114. 