### PR TITLE
Update readme to advise using roman-crds-test.stsci.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ Note: CRDS_CONTEXT values flagged with an asterisk in the above table are estima
 
 The test suite require access to a CRDS cache, but currently (2021-02-09) the shared /grp/crds
 cache does not include Roman files.  Developers inside the STScI network can sync a cache from
-roman-crds-dev.stsci.edu (if working from home, be sure to connect to the VPN first):
+roman-crds-test.stsci.edu (if working from home, be sure to connect to the VPN first):
 
 ```bash
-$ export CRDS_SERVER_URL=https://roman-crds-dev.stsci.edu
-$ export CRDS_PATH=$HOME/roman-crds-dev-cache
+$ export CRDS_SERVER_URL=https://roman-crds-test.stsci.edu
+$ export CRDS_PATH=$HOME/roman-crds-test-cache
 $ crds sync --contexts roman-edit
 ```
 


### PR DESCRIPTION
Seems like the test server, now that it's available, will be more stable than dev.