### PR TITLE
RCAL-136 Jenkins Build31 Hot Fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.3.1 (2021-03-18)
+==================
+
+datamodels
+----------
+
+- Added sorting to test parameters to preserve order for tests done by paralel pytest workers. [#136]
+
+
 0.3.0 (2021-03-14)
 ==================
 

--- a/romancal/datamodels/tests/test_models.py
+++ b/romancal/datamodels/tests/test_models.py
@@ -114,8 +114,9 @@ def test_reference_file_model_base(tmp_path):
 
 
 # Common tests for all ReferenceFileModel subclasses
-@pytest.mark.parametrize("model_class", get_subclasses(
-    datamodels.reference_files.referencefile.ReferenceFileModel, include_base_model=False))
+@pytest.mark.parametrize("model_class", sorted(get_subclasses(
+    datamodels.reference_files.referencefile.ReferenceFileModel, include_base_model=False),
+    key=lambda x: x.__name__))
 def test_reference_file_model(tmp_path, model_class):
     # Ensure that specific reference file schema contains the base module schema
     assert_referenced_schema(model_class.schema_url,
@@ -125,7 +126,7 @@ def test_reference_file_model(tmp_path, model_class):
 NON_REFERENCE_MODELS = get_subclasses(datamodels.RomanDataModel, include_base_model=False) - \
                        get_subclasses(datamodels.reference_files.referencefile.ReferenceFileModel,
                                       include_base_model=True)
-@pytest.mark.parametrize("model_class", NON_REFERENCE_MODELS)
+@pytest.mark.parametrize("model_class", sorted(NON_REFERENCE_MODELS, key=lambda x: x.__name__))
 def test_non_reference_file_model(tmp_path, model_class):
     # Ensure that nonReference files contain core schema
     assert_referenced_schema(model_class.schema_url,


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Resolves RCAL-136: Investigate Jenkins failure

**Description**

This PR addresses ...
- Added sorting to test parameters to preserve order for tests done by parallel pytest workers.

Checklist
- [x] Tests

- [unneeded] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
