### PR TITLE
RCAL-38: Regression tests infrastructure

### DIFF
--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -1,0 +1,114 @@
+"""Project default for pytest"""
+import os
+import tempfile
+import pytest
+import inspect
+
+from stdatamodels import s3_utils
+
+#from jwst.associations import (AssociationRegistry, AssociationPool)
+#from jwst.associations.tests.helpers import t_path
+from romancal.lib.tests import helpers as lib_helpers
+
+
+# @pytest.fixture(scope='session')
+# def full_pool_rules(request):
+#     """Setup to use the full example pool and registry"""
+#     pool_fname = t_path('data/mega_pool.csv')
+#     pool = AssociationPool.read(pool_fname)
+#     rules = AssociationRegistry()
+#
+#     return (pool, rules, pool_fname)
+
+
+@pytest.fixture
+def mk_tmp_dirs():
+    """Create a set of temporary directorys and change to one of them."""
+    tmp_current_path = tempfile.mkdtemp()
+    tmp_data_path = tempfile.mkdtemp()
+    tmp_config_path = tempfile.mkdtemp()
+
+    old_path = os.getcwd()
+    try:
+        os.chdir(tmp_current_path)
+        yield (tmp_current_path, tmp_data_path, tmp_config_path)
+    finally:
+        os.chdir(old_path)
+
+
+@pytest.fixture(autouse=True)
+def monkey_patch_s3_client(monkeypatch, request):
+    # If tmpdir is used in the test, then it is providing the file.  Map to it.
+    if "s3_root_dir" in request.fixturenames:
+        path = request.getfixturevalue("s3_root_dir")
+    else:
+        path = None
+    monkeypatch.setattr(s3_utils, "_CLIENT", lib_helpers.MockS3Client(path))
+
+
+@pytest.fixture
+def s3_root_dir(tmpdir):
+    return tmpdir
+
+
+@pytest.fixture
+def slow(request):
+    """Setup slow fixture for tests to identify if --slow
+    has been specified
+    """
+    return request.config.getoption('--slow')
+
+
+@pytest.fixture(scope="module")
+def jail(request, tmpdir_factory):
+    """Run test in a pristine temporary working directory, scoped to module.
+
+    This fixture is the same as _jail in ci_watson, but scoped to module
+    instead of function.  This allows a fixture using it to produce files in a
+    temporary directory, and then have the tests access them.
+    """
+    old_dir = os.getcwd()
+    path = request.module.__name__.split('.')[-1]
+    if request._parent_request.fixturename is not None:
+        path = path + "_" + request._parent_request.fixturename
+    newpath = tmpdir_factory.mktemp(path)
+    os.chdir(str(newpath))
+    yield newpath
+    os.chdir(old_dir)
+
+
+@pytest.mark.trylast
+def pytest_configure(config):
+    terminal_reporter = config.pluginmanager.getplugin('terminalreporter')
+    config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), 'testdescription')
+
+
+class TestDescriptionPlugin:
+    """Pytest plugin to print the test docstring when `pytest -vv` is used.
+
+    This plug-in was added to support JWST instrument team testing and
+    reporting for the JWST calibration pipeline.
+    """
+
+    def __init__(self, terminal_reporter):
+        self.terminal_reporter = terminal_reporter
+        self.desc = None
+
+    def pytest_runtest_protocol(self, item):
+        try:
+            # Get the docstring for the test
+            self.desc = inspect.getdoc(item.obj)
+        except AttributeError:
+            self.desc = None
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_runtest_logstart(self, nodeid, location):
+        # When run as `pytest` or `pytest -v`, no change in behavior
+        if self.terminal_reporter.verbosity <= 1:
+            yield
+        # When run as `pytest -vv`, `pytest -vvv`, etc, print the test docstring
+        else:
+            self.terminal_reporter.write('\n')
+            yield
+            if self.desc:
+                self.terminal_reporter.write(f'\n{self.desc} ')

--- a/romancal/lib/tests/helpers.py
+++ b/romancal/lib/tests/helpers.py
@@ -1,0 +1,42 @@
+import os
+import glob
+import io
+
+
+S3_BUCKET_NAME = "test-s3-data"
+
+
+class MockS3Client:
+    def __init__(self, s3_test_data_path):
+        self.s3_test_data_path = s3_test_data_path
+
+    def get_object(self, bucket_name, key):
+        assert self.object_exists(bucket_name, key)
+
+        with open(self._get_path(key), "rb") as f:
+            return io.BytesIO(f.read())
+
+    def object_exists(self, bucket_name, key):
+        if bucket_name != S3_BUCKET_NAME:
+            return False
+
+        return os.path.isfile(self._get_path(key))
+
+    def prefix_exists(self, bucket_name, key_prefix):
+        return any(self.iterate_keys(bucket_name, key_prefix))
+
+    def iterate_keys(self, bucket_name, key_prefix):
+        if bucket_name != S3_BUCKET_NAME:
+            return
+
+        for k in self._list_keys():
+            if k.startswith(key_prefix):
+                yield k
+
+    def _get_path(self, key):
+        return os.path.join(self.s3_test_data_path, key)
+
+    def _list_keys(self):
+        paths = glob.glob(self.s3_test_data_path + "/**", recursive=True)
+        paths = [p for p in paths if os.path.isfile(p)]
+        return [p.replace(self.s3_test_data_path, "") for p in paths]

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -198,6 +198,14 @@ def rtdata_module(artifactory_repos, envopt, request, jail):
     yield from _rtdata_fixture_implementation(artifactory_repos, envopt, request)
 
 
+@pytest.fixture
+def ignore_asdf_paths():
+    ignore_attr = ["meta.[date, filename]",
+                   "asdf_library",
+                   "history"]
+
+    return {'ignore': ignore_attr}
+
 
 @pytest.fixture
 def diff_astropy_tables():

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -28,10 +28,10 @@ class RegtestData:
     """Defines data paths on Artifactory and data retrieval methods"""
 
     def __init__(self, env="dev", inputs_root="roman-pipeline",
-        results_root="roman-pipeline-results", docopy=True,
-        input=None, input_remote=None, output=None, truth=None,
-        truth_remote=None, remote_results_path=None, test_name=None,
-        traceback=None, **kwargs):
+                 results_root="roman-pipeline-results", docopy=True,
+                 input=None, input_remote=None, output=None, truth=None,
+                 truth_remote=None, remote_results_path=None, test_name=None,
+                 traceback=None, **kwargs):
         self._env = env
         self._inputs_root = inputs_root
         self._results_root = results_root

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -1,27 +1,32 @@
 import os
 import pytest
-#from asdf.commands import diff
+from asdf.commands import diff as asdf_diff
 
-from romancal.step import FlatFieldStep
+from romancal.stpipe import RomanStep
 from romancal import datamodels
 
 
-# @pytest.fixture(scope='module')
-# def run_flat_field(rtdata_module):
-#     """ Run flat field on Level 2 imaging data."""
-#
-#     rtdata = rtdata_module
-#     rtdata.get_data("WFI/image/level2.asdf")
-#     step = FlatFieldStep()
-#     step.run(rtdata.input)
+@pytest.fixture(scope='module')
+def run_flat_field(rtdata_module):
+    """ Run flat field on Level 2 imaging data."""
+
+    rtdata = rtdata_module
+    rtdata.get_data("WFI/image/l2_0001_rate.asdf")
+    args = ["romancal.step.FlatFieldStep", rtdata.input]
+    RomanStep.from_cmdline(args)
 
 
-# def test_flat_field_step(run_flat_field, rtdata_module):
-#     rtdata = rtdata_module
-#     rtdata.input = "level2.asdf"
-#     rtdata.output = "level2flatfield.asdf"
-#     report = diff([rtdata.output, rtdata.truth], False)
-#     assert report is not None, report
+@pytest.mark.bigdata
+def test_flat_field_step(run_flat_field, rtdata_module):
+    rtdata = rtdata_module
+    rtdata.input = "l2_0001_rate.asdf"
+    output = "l2_0001_rate_flatfieldstep.asdf"
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+
+    report = asdf_diff([rtdata.output, rtdata.truth], False)
+    assert report is not None, report
 
 
 @pytest.fixture(scope='module')

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import os
 import pytest
 from asdf.commands import diff as asdf_diff

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -1,15 +1,14 @@
-from io import StringIO
 import os
 import pytest
-from asdf.commands import diff as asdf_diff
 
 from romancal.stpipe import RomanStep
 from romancal.step import FlatFieldStep
 from romancal import datamodels
+from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_flat_field_step(rtdata):
+def test_flat_field_step(rtdata, ignore_asdf_paths):
 
     rtdata.get_data("WFI/image/l2_0001_rate.asdf")
     rtdata.input = "l2_0001_rate.asdf"
@@ -27,12 +26,4 @@ def test_flat_field_step(rtdata):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    compare(rtdata.output, rtdata.truth, **kwargs)
-
-
-def compare(result, truth, **kwargs):
-    f = StringIO()
-    asdf_diff([rtdata.output, rtdata.truth], minimal=False,
-               iostream=StringIO(), **wkargs)
-    if f.getavlue():
-        f.get_value()
+    compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -3,6 +3,7 @@ import pytest
 from asdf.commands import diff as asdf_diff
 
 from romancal.stpipe import RomanStep
+from romancal.step import FlatFieldStep
 from romancal import datamodels
 
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -7,37 +7,31 @@ from romancal.step import FlatFieldStep
 from romancal import datamodels
 
 
-@pytest.fixture(scope='module')
-def run_flat_field(rtdata_module):
-    """ Run flat field on Level 2 imaging data."""
-
-    rtdata = rtdata_module
-    rtdata.get_data("WFI/image/l2_0001_rate.asdf")
-    args = ["romancal.step.FlatFieldStep", rtdata.input]
-    RomanStep.from_cmdline(args)
-
-
 @pytest.mark.bigdata
-def test_flat_field_step(run_flat_field, rtdata_module):
-    rtdata = rtdata_module
+def test_flat_field_step(rtdata):
+
+    rtdata.get_data("WFI/image/l2_0001_rate.asdf")
     rtdata.input = "l2_0001_rate.asdf"
-    output = "l2_0001_rate_flatfieldstep.asdf"
-    rtdata.output = output
 
-    rtdata.get_truth(f"truth/WFI/image/{output}")
-
-    report = asdf_diff([rtdata.output, rtdata.truth], False)
-    assert report is not None, report
-
-
-@pytest.fixture(scope='module')
-def test_crds_retrieval(_jail, rtdata_module):
-    """ Test retrieving a flat file from CRDS."""
-
-    rtdata = rtdata_module
-    rtdata.get_data("WFI/image/level2.asdf")
+    # Test CRDS
     step = FlatFieldStep()
     model = datamodels.ImageModel(rtdata.input)
     ref_file_path = step.get_reference_file(model, "flat")
     ref_file_name = os.path.split(ref_file_path)[-1]
-    assert ref_file_name == "roman_wfi_flat_0003.asdf"
+    assert "roman_wfi_flat" in ref_file_name
+
+    # Test FlatFieldStep
+    output = "l2_0001_rate_flatfieldstep.asdf"
+    rtdata.output = output
+    args = ["romancal.step.FlatFieldStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    compare(rtdata.output, rtdata.truth, **kwargs)
+
+
+def compare(result, truth, **kwargs):
+    f = StringIO()
+    asdf_diff([rtdata.output, rtdata.truth], minimal=False,
+               iostream=StringIO(), **wkargs)
+    if f.getavlue():
+        f.get_value()

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.7.3
+    asdf@git+https://github.com/asdf-format/asdf.git
     astropy>=4.0
     crds>=10.3.11
     gwcs>=0.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,14 +94,14 @@ addopts = --show-capture=no --open-files --doctest-ignore-import-errors
 
 [coverage:run]
 omit =
-    romancal/conftest.py
+    romancal/regtest/conftest.py
     romancal/setup.py
     romancal/tests/test*
     romancal/regtest/test*
     romancal/*/tests/*
     docs/*
     # And list these again for running against installed version
-    */romancal/conftest.py
+    */romancal/regtest/conftest.py
     */romancal/setup.py
     */romancal/tests/test*
     */romancal/regtest/test*


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #18

Resolves RCAL-38

**Description**

This PR ports the jwst RT infrastructure to romancal and adds one regression test.
The test will fail because the dates in the truth file and the output are different.
An option will be added to asdf diff to allow exclusion of a list of attributes.

In the future much of this infrastructure should be moved to a common place, most likely ci_watson.


Checklist
- [x] Tests

- [ ] Documentation (working on it

- [ ] Change log

- [x] Milestone

- [x] Label(s)
