### PR TITLE
Photom schema file (RCAL-109)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ datamodels
 
 - Added check for core metadata inclusion in non-reference files. [#169]
 
+- Add Photom Schema [#200]
 
 0.2.0 (2021-02-26)
 ==================

--- a/romancal/datamodels/schemas/reference_files/wfi_img_photom.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/wfi_img_photom.schema.yaml
@@ -13,6 +13,8 @@ allOf:
       - name: optical_element
         datatype: [ascii, 12]
       - name: photmjsr
+        title: surface brightness, in MJy/steradian 
         datatype: float32
       - name: uncertainty
+        title: uncertainty of surface brightness, in MJy/steradian 
         datatype: float32

--- a/romancal/datamodels/schemas/reference_files/wfi_img_photom.schema.yaml
+++ b/romancal/datamodels/schemas/reference_files/wfi_img_photom.schema.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+id: "http://stsci.edu/schemas/roman_datamodel/reference_files/wfi_img_photom.schema"
+title: WFI imaging photometric flux conversion data model
+allOf:
+- $ref: referencefile.schema
+- type: object
+  properties:
+    phot_table:
+      title: Photometric flux conversion factors table
+      datatype:
+      - name: optical_element
+        datatype: [ascii, 12]
+      - name: photmjsr
+        datatype: float32
+      - name: uncertainty
+        datatype: float32


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #

Resolves RCAL-109

**Description**

This PR addresses RCAL-109. wfi_img_photom.schema.yaml is the WFI image Roman analog of the JWST file nrcimg_photom.schema.yaml.  As I understand , there is no wfss mode for Roman, so there is no equivalent of the JWST file nrcwfss_photom.schema.yaml.

Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [x] Milestone

- [x] Label(s)
