### PR TITLE
Update asdf requirement to >= 2.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf@git+https://github.com/asdf-format/asdf.git
+    asdf>=2.8.0
     astropy>=4.0
     crds>=10.3.11
     gwcs>=0.14.0


### PR DESCRIPTION
**Description**

This PR updates the package's asdf requirement, which no longer needs to specify master now that asdf 2.8.0 is released.


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
