### PR TITLE
Rcal-164 Add grism model to flat field regression tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,21 +1,14 @@
-<<<<<<< HEAD
 0.3.0 (unreleased)
 =======
-0.3.1 (2021-03-18)
-==================
 
 datamodels
 ----------
 
 - Added sorting to test parameters to preserve order for tests done by paralel pytest workers. [#136]
 
-
-0.3.0 (2021-03-14)
->>>>>>> Added changelog.
-==================
-
 general
 -------
+- Added grism to the regression tests [# 201]
 
 - Update README and CHANGES.rst [#195]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ datamodels
 
 general
 -------
-- Added grism to the regression tests [# 201]
+- Added grism to the regression tests [# 222]
 
 - Update README and CHANGES.rst [#195]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,17 +1,4 @@
-<<<<<<< HEAD
 0.3.0 (unreleased)
-=======
-0.3.1 (2021-03-18)
-==================
-
-datamodels
-----------
-
-- Added sorting to test parameters to preserve order for tests done by paralel pytest workers. [#136]
-
-
-0.3.0 (2021-03-14)
->>>>>>> Added changelog.
 ==================
 
 general

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,17 @@
+<<<<<<< HEAD
 0.3.0 (unreleased)
+=======
+0.3.1 (2021-03-18)
+==================
+
+datamodels
+----------
+
+- Added sorting to test parameters to preserve order for tests done by paralel pytest workers. [#136]
+
+
+0.3.0 (2021-03-14)
+>>>>>>> Added changelog.
 ==================
 
 general

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -8,7 +8,7 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_flat_field_step(rtdata, ignore_asdf_paths):
+def test_flat_field_image_step(rtdata, ignore_asdf_paths):
 
     rtdata.get_data("WFI/image/l2_0001_rate.asdf")
     rtdata.input = "l2_0001_rate.asdf"
@@ -26,4 +26,25 @@ def test_flat_field_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
+    compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+
+@pytest.mark.bigdata
+def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
+
+    rtdata.get_data("WFI/grism/l2_0001_grism_rate.asdf")
+    rtdata.input = "l2_0001_grism_rate.asdf"
+
+    # Test CRDS
+    step = FlatFieldStep()
+    model = rdm.open(rtdata.input)
+    ref_file_path = step.get_reference_file(model, "flat")
+    ref_file_name = os.path.split(ref_file_path)[-1]
+    assert "roman_wfi_flat" in ref_file_name
+
+    # Test FlatFieldStep
+    output = "l2_0001_grism_rate_flatfieldstep.asdf"
+    rtdata.output = output
+    args = ["romancal.step.FlatFieldStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/grism/{output}")
     compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-164: Add grism model to flat field regression tests
**
-->

Closes #

Resolves RCAL-164

**Description**

This PR adds a grism model to the flat field regression tests.


Checklist
- [x] Tests
pytest --bigdata ~/src/Roman/romancal/romancal/regtest -k test_flat
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/ddavis/src/Roman/romancal, configfile: setup.cfg
plugins: asdf-2.8.0, arraydiff-0.3, remotedata-0.3.2, cov-2.11.1, ci-watson-0.5, xdist-2.2.1, hypothesis-6.3.1, filter-subpackage-0.1.1, openfiles-0.5.0, forked-1.3.0, astropy-header-0.1.2, doctestplus-0.9.0
collected 2 items                                                                                                             

../../../romancal/romancal/regtest/test_wfi_flat_field.py ..                                                            [100%]

====================================================== warnings summary =======================================================
romancal/regtest/test_wfi_flat_field.py::test_flat_field_image_step
romancal/regtest/test_wfi_flat_field.py::test_flat_field_grism_step
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "dtf2d" yielded 1 of "dubious year (Note 6)"
    warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),

romancal/regtest/test_wfi_flat_field.py::test_flat_field_image_step
romancal/regtest/test_wfi_flat_field.py::test_flat_field_grism_step
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
    warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),

romancal/regtest/test_wfi_flat_field.py::test_flat_field_image_step
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/asdf/asdf.py:348: AsdfWarning: File 'file:///Users/ddavis/crds_cach_test/references/roman/wfi/roman_wfi_flat_0002.asdf' was created with extension class 'astropy.io.misc.asdf.extension.AstropyAsdfExtension' (from package astropy==4.2.1), but older package (astropy==4.2) is installed.
    warnings.warn(msg, AsdfWarning)

romancal/regtest/test_wfi_flat_field.py::test_flat_field_grism_step
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/asdf/asdf.py:348: AsdfWarning: File 'file:///Users/ddavis/crds_cach_test/references/roman/wfi/roman_wfi_flat_0005.asdf' was created with extension class 'astropy.io.misc.asdf.extension.AstropyAsdfExtension' (from package astropy==4.2.1), but older package (astropy==4.2) is installed.
    warnings.warn(msg, AsdfWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================== 2 passed, 6 warnings in 423.39s (0:07:03) ==========================================
(rcal_dev) bash>printenv CRDS_SERVER_URL
https://roman-crds-test.stsci.edu/

- [ ] Documentation

- [x] Change log

- [x] Milestone

- [ ] Label(s)
