### PR TITLE
add a test for retrieving a spectral file from CRDS

### DIFF
--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -51,3 +51,28 @@ def test_get_reference_file(step_class):
 
     with step.open_model(reference_path) as reference_model:
         assert isinstance(reference_model, FlatRefModel)
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Roman CRDS servers are not currently available outside the internal network"
+)
+@pytest.mark.parametrize("step_class", [RomanPipeline, RomanStep])
+def test_get_reference_file_spectral(step_class):
+    """
+    Test that CRDS is properly integrated.
+    """
+    im = mk_level2_image(arrays=(20, 20))
+    # This will be brittle while we're using the dev server.
+    # If this test starts failing mysteriously, check the
+    # metadata values against the flat rmap.
+    im.meta.instrument.optical_element = "GRISM"
+    im.meta.observation.start_time = Time('2021-01-01T12:00:00')
+    model = ImageModel(im)
+
+    step = step_class()
+    reference_path = step.get_reference_file(model, "flat")
+
+    with step.open_model(reference_path) as reference_model:
+        assert isinstance(reference_model, FlatRefModel)
+        assert reference_model.meta.instrument.optical_element == "GRISM"


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #

Resolves RCAL-167

**Description**

Adds a test for 628.3 - CRDS shall provide calibration reference files to the Exposure Level Processing for Wide Field Spectroscopy Mode (WSM).



- [x ] Milestone

- x[ ] Label(s)
