### PR TITLE
Rcal 187 soc 636.1 crds flat test

### DIFF
--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -70,8 +70,6 @@ def test_flatfield_step_interface(instrument, exptype):
 def test_crds_temporal_match(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
 
-    shape = (20, 20)
-
     wfi_image = testutil.mk_level2_image(arrays=True)
     wfi_image.meta.instrument.name = instrument
     wfi_image.meta.instrument.detector = 'WFI01'
@@ -85,9 +83,9 @@ def test_crds_temporal_match(instrument, exptype):
 
     step = FlatFieldStep()
     reffile = step.get_reference_file(wfi_image_model, "flat")
-    assert ("/".join(reffile.rsplit("/", 3)[1:])  == "roman/wfi/roman_wfi_flat_0002.asdf")
+    assert ("/".join(reffile.rsplit("/", 3)[1:]) == "roman/wfi/roman_wfi_flat_0057.asdf")
 
-    wfi_image_model.meta.observation.start_time = Time('2021-01-01T11:11:11.110')
-    wfi_image_model.meta.observation.end_time = Time('2021-01-01T11:33:11.110')
-    assert ("/".join(reffile.rsplit("/", 3)[1:]) == "roman/wfi/roman_wfi_flat_0002.asdf")
-    assert 1==0
+    wfi_image_model.meta.observation.start_time = Time('2021-08-11T11:11:11.110')
+    wfi_image_model.meta.observation.end_time = Time('2021-08-11T11:33:11.110')
+    reffile = step.get_reference_file(wfi_image_model, "flat")
+    assert ("/".join(reffile.rsplit("/", 3)[1:]) == "roman/wfi/roman_wfi_flat_0039.asdf")

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -10,8 +10,8 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_flat_field_image_step(rtdata, ignore_asdf_paths):
 
-    rtdata.get_data("WFI/image/l2_0001_rate.asdf")
-    rtdata.input = "l2_0001_rate.asdf"
+    rtdata.get_data("WFI/image/l2_0004_rate.asdf")
+    rtdata.input = "l2_0004_rate.asdf"
 
     # Test CRDS
     step = FlatFieldStep()
@@ -21,7 +21,7 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_flat" in ref_file_name
 
     # Test FlatFieldStep
-    output = "l2_0001_rate_flatfieldstep.asdf"
+    output = "l2_0004_rate_flatfieldstep.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
@@ -31,8 +31,8 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
 
-    rtdata.get_data("WFI/grism/l2_0001_grism_rate.asdf")
-    rtdata.input = "l2_0001_grism_rate.asdf"
+    rtdata.get_data("WFI/grism/l2_0004_grism_rate.asdf")
+    rtdata.input = "l2_0004_grism_rate.asdf"
 
     # Test CRDS
     step = FlatFieldStep()
@@ -42,7 +42,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_flat" in ref_file_name
 
     # Test FlatFieldStep
-    output = "l2_0001_grism_rate_flatfieldstep.asdf"
+    output = "l2_0004_grism_rate_flatfieldstep.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -48,3 +48,44 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/grism/{output}")
     compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+
+@pytest.mark.bigdata
+def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
+    # Testing that different datetimes pull different
+    # flat files and successfully make level 2 output
+
+    # First file
+    rtdata.get_data("WFI/image/l2_0004_rate.asdf")
+    rtdata.input = "l2_0004_rate.asdf"
+
+    # Test CRDS
+    step = FlatFieldStep()
+    model = rdm.open(rtdata.input)
+    ref_file_path = step.get_reference_file(model, "flat")
+    assert ("/".join(ref_file_path.rsplit("/", 3)[1:]) == "roman/wfi/roman_wfi_flat_0057.asdf")
+
+    # Test FlatFieldStep
+    output = "l2_0004_rate_flatfieldstep.asdf"
+    rtdata.output = output
+    args = ["romancal.step.FlatFieldStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+
+    # Second file
+    rtdata.get_data("WFI/image/l2_0004b_rate.asdf")
+    rtdata.input = "l2_0004b_rate.asdf"
+
+    # Test CRDS
+    step = FlatFieldStep()
+    model = rdm.open(rtdata.input)
+    ref_file_path = step.get_reference_file(model, "flat")
+    assert ("/".join(ref_file_path.rsplit("/", 3)[1:]) == "roman/wfi/roman_wfi_flat_0039.asdf")
+
+    # Test FlatFieldStep
+    output = "l2_0004b_rate_flatfieldstep.asdf"
+    rtdata.output = output
+    args = ["romancal.step.FlatFieldStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #273 

Resolves RCAL-187

**Description**

This PR adds the required flat file CRDS temporal selection test required by SOC-636.1. The added regression test opens a file in artifactory, calls CRDS to select the matching flat file, tests CRDS matched to the correct file (by date), runs the flat step to produce output, and finally tests that final output against a truth file in artifactory. 


Checklist
- [x] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
