### PR TITLE
Rcal 178 Jump Step for Roman data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.5.0 (unreleased)
 =======
 
+Jump
+----------
+
+ - Updated code for Jump step using stcal [#277]
+
 0.4.2 (2021-09-13)
 
 general

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Jump
 ----------
 
- - Updated code for Jump step using stcal [#277]
+ - Updated code for Jump step using stcal [#309]
 
 0.4.2 (2021-09-13)
 

--- a/romancal/jump/__init__.py
+++ b/romancal/jump/__init__.py
@@ -1,0 +1,3 @@
+from .jump_step import JumpStep
+
+__all__ = ['JumpStep']

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -5,8 +5,9 @@ Detect jumps in a science image
 import roman_datamodels as rdm
 import numpy as np
 import time
+
 from ..stpipe import RomanStep
-from .. roman_datamodels import dqflags
+from .. datamodels import dqflags
 from stcal.jump.jump import detect_jumps
 
 import logging
@@ -38,7 +39,7 @@ class JumpStep(RomanStep):
     def process(self, input):
 
         # Open input as a Roman DataModel (single integration; 3D arrays)
-        with rdm.RampModel(input) as input_model:
+        with rdm.datamodels.RampModel(input) as input_model:
 
             # Extract the needed info from the Roman Data Model
             meta = input_model.meta
@@ -98,8 +99,8 @@ class JumpStep(RomanStep):
             dqflags_d = {
                 "GOOD": dqflags.group["GOOD"],
                 "DO_NOT_USE": dqflags.group["DO_NOT_USE"],
-                "SATURATED":  dqflags.group["SATURATED"],
-                "JUMP_DET":  dqflags.group["JUMP_DET"]
+                "SATURATED": dqflags.group["SATURATED"],
+                "JUMP_DET": dqflags.group["JUMP_DET"]
             }
 
             gdq, pdq = detect_jumps(frames_per_group, data, gdq, pdq, err,

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -52,7 +52,7 @@ class JumpStep(RomanStep):
 
             # Modify the arrays for input into the 'common' jump (4D)
             data = r_data[np.newaxis, :].astype(np.float32)
-            gdq = r_gdq[np.newaxis, :].astype(np.uint9)
+            gdq = r_gdq[np.newaxis, :].astype(np.uint8)
             pdq = r_pdq[np.newaxis, :].astype(np.uint32)
             err = r_err[np.newaxis, :].astype(np.float32)
 

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -47,6 +47,7 @@ class JumpStep(RomanStep):
             r_gdq = input_model.groupdq
             r_pdq = input_model.pixeldq
             r_err = input_model.err
+            result = input_model.copy()
 
             frames_per_group = meta.exposure.nframes
 
@@ -93,15 +94,17 @@ class JumpStep(RomanStep):
             self.log.info('Using READNOISE reference file: %s',
                           readnoise_filename)
             readnoise_model = rdd.ReadnoiseRefModel(readnoise_filename)
-            readnoise_2d = readnoise_model.data
+            readnoise_2d = np.copy(readnoise_model.data)
 
-            # DG 0810/21:  leave for now; make dqflags changes in a later, separate PR
+            # DG 0810/21:  leave for now; make dqflags changes in a later,
+            #              separate PR
             dqflags_d = {}  # Dict of DQ flags
             dqflags_d = {
                 "GOOD": dqflags.group["GOOD"],
                 "DO_NOT_USE": dqflags.group["DO_NOT_USE"],
                 "SATURATED": dqflags.group["SATURATED"],
-                "JUMP_DET": dqflags.group["JUMP_DET"]
+                "JUMP_DET": dqflags.group["JUMP_DET"],
+                "NO_GAIN_VALUE": dqflags.pixel["NO_GAIN_VALUE"]
             }
 
             gdq, pdq = detect_jumps(frames_per_group, data, gdq, pdq, err,

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -52,10 +52,10 @@ class JumpStep(RomanStep):
             frames_per_group = meta.exposure.nframes
 
             # Modify the arrays for input into the 'common' jump (4D)
-            data = r_data[np.newaxis, :].astype(np.float32)
-            gdq = r_gdq[np.newaxis, :].astype(np.uint8)
-            pdq = r_pdq[np.newaxis, :].astype(np.uint32)
-            err = r_err[np.newaxis, :].astype(np.float32)
+            data = np.copy(r_data[np.newaxis, :])
+            gdq = r_gdq[np.newaxis, :]
+            pdq = r_pdq[np.newaxis, :]
+            err = np.copy(r_err[np.newaxis, :])
 
             tstart = time.time()
 

--- a/romancal/step.py
+++ b/romancal/step.py
@@ -5,10 +5,11 @@ made available by this package.
 from .dark_current.dark_current_step import DarkCurrentStep
 from .dq_init.dq_init_step import DQInitStep
 from .flatfield.flat_field_step import FlatFieldStep
-
+from .jump.jump_step import JumpStep
 
 __all__ = [
     "DarkCurrentStep",
     "DQInitStep",
     "FlatFieldStep",
+    "JumpStep",
 ]

--- a/romancal/stpipe/integration.py
+++ b/romancal/stpipe/integration.py
@@ -24,4 +24,5 @@ def get_steps():
         ("romancal.step.DarkCurrentStep", None, False),
         ("romancal.step.DQInitStep", None, False),
         ("romancal.step.FlatFieldStep", None, False),
+        ("romancal.step.JumpStep", None, False),
     ]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #

Resolves RCAL-178

**Description**

This PR adds the jump step for roman data. 


Checklist
- [ x] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone
x
- [ x] Label(s)

strun --debug romancal.step.JumpStep l1_0006_science_raw_dqinitstep.asdf
2021-09-17 13:35:30,208 - CRDS - ERROR -  Error determining best reference for 'pars-jumpstep'  =   Unknown reference type 'pars-jumpstep'
2021-09-17 13:35:30,210 - stpipe.JumpStep - INFO - JumpStep instance created.
2021-09-17 13:35:30,237 - stpipe.JumpStep - INFO - Step JumpStep running with args ('l1_0006_science_raw_dqinitstep.asdf',).
2021-09-17 13:35:30,238 - stpipe.JumpStep - INFO - Step JumpStep parameters are: {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': True, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': '', 'rejection_threshold': 4.0, 'three_group_rejection_threshold': 6.0, 'four_group_rejection_threshold': 5.0, 'maximum_cores': 'none', 'flag_4_neighbors': True, 'max_jump_to_flag_neighbors': 1000.0, 'min_jump_to_flag_neighbors': 10.0}
2021-09-17 13:35:31,761 - stpipe.JumpStep - INFO - CR rejection threshold = 4 sigma
2021-09-17 13:35:32,504 - stpipe.JumpStep - INFO - Using GAIN reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_gain_0015.asdf
2021-09-17 13:35:33,259 - stpipe.JumpStep - INFO - Using READNOISE reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_readnoise_0014.asdf
2021-09-17 13:35:33,598 - stpipe.JumpStep - INFO - Executing two-point difference method
2021-09-17 13:35:34,473 - stpipe.JumpStep - INFO - Working on integration 1:
2021-09-17 13:35:38,212 - stpipe.JumpStep - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/stcal/jump/twopoint_difference.py:142: RuntimeWarning: invalid value encountered in sqrt
  sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)

2021-09-17 13:35:42,063 - stpipe.JumpStep - INFO - From highest outlier Two-point found 775478 pixels                  with at least one CR and at least four groups
2021-09-17 13:35:42,063 - stpipe.JumpStep - INFO - From highest outlier Two-point found 0 pixels                  with at least one CR and three groups
2021-09-17 13:35:42,063 - stpipe.JumpStep - INFO - From highest outlier Two-point found 1 pixels                  with at least one CR and two groups
2021-09-17 13:36:03,998 - stpipe.JumpStep - INFO - Total elapsed time = 30.3997 sec
2021-09-17 13:36:04,009 - stpipe.JumpStep - INFO - The execution time in seconds: 32.247611
2021-09-17 13:36:05,493 - stpipe.JumpStep - INFO - Saved model in l1_0006_science_raw_dqinitstep_jumpstep.asdf
2021-09-17 13:36:05,493 - stpipe.JumpStep - INFO - Step JumpStep done
