### PR TITLE
RCAL-224 Update pixel and group dq arrays in results from Jump Detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 jump
 ----
 
+ - Fix to jump_step to save the update pixel and group dq arrays [#319
+
  - Updated code for ``jump`` step using ``stcal``. [#309]
 
  - Added simple regression test. [#315]

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -115,6 +115,10 @@ class JumpStep(RomanStep):
                                     flag_4_neighbors,
                                     dqflags_d)
 
+            gdq = gdq[0, :, :, :]
+            pdq = pdq[0, :, :]
+            result.groupdq = gdq.copy()
+            result.pixeldq = pdq.copy()
             gain_model.close()
             readnoise_model.close()
             tstop = time.time()


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #319

Resolves RCAL-224

**Description**

This PR updates pixel and dq arrays with the results from Jump detection. 
Note: the solution uses a copy to avoid a known error in the python 3.9 memory management. 
The error is 
UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown

Once this is fixed 
            pdq = pdq[0, :, :]
            result.pixeldq = pdq.copy()
should become
             result.pixeldq = pdq[0, :, :]



Checklist
- [ x] Tests

- [x ] Documentation

- [ x] Change log

- [ x] Milestone

- [x ] Label(s)


pytest --debug --bigdata ~/src/Roman/romancal/romancal/regtest/ --basetemp=/Users/ddavis/src/Roman/develop/test/tmp_t/ -k test_jump_det
writing pytestdebug information to /Users/ddavis/src/Roman/develop/Jump/pytestdebug.log
....
romancal/regtest/test_jump_det.py::test_jump_detection_step
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.9/site-packages/stcal/jump/twopoint_difference.py:142: RuntimeWarning: invalid value encountered in sqrt
    sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================= 1 passed, 6 deselected, 1 warning in 431.54s (0:07:11) ===
