### PR TITLE
RCAL-234 Fix Jump Unit Tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ jump
 
  - Added simple regression test. [#315]
 
+ - Updated temp readnoise file in jump tests to include required exposure keywords. [#333]
+
  ramp_fitting
  ------------
 

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -59,6 +59,8 @@ def generate_wfi_reffiles(tmpdir_factory):
     meta['pedigree'] = 'DUMMY'
     meta['description'] = 'DUMMY'
     meta['useafter'] = Time('2022-01-01T11:11:11.111')
+    meta['exposure'] = {}
+    meta['exposure']['type'] = 'WFI_IMAGE'
 
     rn_ref['meta'] = meta
     rn_ref['data'] = np.ones(shape, dtype=np.float32)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #332 

Resolves RCAL-234

**Description**

This PR updates temp readnoise file in jump tests to include required exposure keywords.


Checklist
- [x ] Tests

- [ ] Documentation

- [x ] Change log

- [x ] Milestone

- [x ] Label(s)
