### PR TITLE
Record step/pipeline logs in ImageModel.cal_logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ saturation
 
 - Updated RTD to include saturation reference files. [#350]
 
+stpipe
+------
+
+ - Record step/pipeline logs in ImageModel.cal_logs array. [#352]
 
 0.4.2 (2021-09-13)
 ==================

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -202,7 +202,9 @@ def rtdata_module(artifactory_repos, envopt, request, jail):
 def ignore_asdf_paths():
     ignore_attr = ["meta.[date, filename]",
                    "asdf_library",
-                   "history"]
+                   "history",
+                   "cal_logs",
+                   ]
 
     return {'ignore': ignore_attr}
 

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -4,6 +4,8 @@ Roman Calibration Pipeline base class
 from stpipe import Step, Pipeline
 
 import roman_datamodels as rdm
+from roman_datamodels.datamodels import ImageModel
+from roman_datamodels.stnode import LogMessage
 
 
 class RomanStep(Step):
@@ -37,8 +39,9 @@ class RomanStep(Step):
             List of reference files used.  The first element of each tuple
             is the reftype code, the second element is the filename.
         """
-        #  JWST uses this to add the cal code and CRDS software versions.
-        pass
+        if isinstance(model, ImageModel):
+            for log_record in self.log_records:
+                model.cal_logs.append(LogMessage.from_log_record(log_record))
 
     def record_step_status(self, model, step_name, success=True):
         """

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -1,11 +1,20 @@
 """
 Roman Calibration Pipeline base class
 """
+import logging
+import time
+
 from stpipe import Step, Pipeline
 
 import roman_datamodels as rdm
 from roman_datamodels.datamodels import ImageModel
-from roman_datamodels.stnode import LogMessage
+
+
+_LOG_FORMATTER = logging.Formatter(
+    "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S"
+)
+_LOG_FORMATTER.converter = time.gmtime
 
 
 class RomanStep(Step):
@@ -41,7 +50,7 @@ class RomanStep(Step):
         """
         if isinstance(model, ImageModel):
             for log_record in self.log_records:
-                model.cal_logs.append(LogMessage.from_log_record(log_record))
+                model.cal_logs.append(_LOG_FORMATTER.format(log_record))
 
     def record_step_status(self, model, step_name, success=True):
         """

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -77,3 +77,13 @@ def test_get_reference_file_spectral(step_class):
     with step.open_model(reference_path) as reference_model:
         assert isinstance(reference_model, FlatRefModel)
         assert reference_model.meta.instrument.optical_element == "GRISM"
+
+
+def test_log_messages(tmp_path):
+    class LoggingStep(RomanStep):
+        def process(self):
+            self.log.warning("Splines failed to reticulate")
+            return ImageModel(mk_level2_image(arrays=(20,20)))
+
+    result = LoggingStep().run()
+    assert any(l.message == "Splines failed to reticulate" for l in result.cal_logs)

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -86,4 +86,4 @@ def test_log_messages(tmp_path):
             return ImageModel(mk_level2_image(arrays=(20,20)))
 
     result = LoggingStep().run()
-    assert any(l.message == "Splines failed to reticulate" for l in result.cal_logs)
+    assert any("Splines failed to reticulate" in l for l in result.cal_logs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,13 +29,7 @@ install_requires =
     numpy>=1.19
     pyparsing>=2.2
     requests>=2.22
-    # force a temporary install of rad from github
-    romanad
-    # fix rad version until CRDS is updated
-    #romanad==0.6.1
-    #Fix roman_datamodels during updates
-    roman_datamodels @ git+https://github.com/eslavich/roman_datamodels.git@RCAL-244-save-output-logs
-    #roman_datamodels==0.5.2
+    roman_datamodels>=0.8.0
     stcal>=0.2.5
     stpipe>=0.3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,10 +34,10 @@ install_requires =
     # fix rad version until CRDS is updated
     #romanad==0.6.1
     #Fix roman_datamodels during updates
-    roman_datamodels
+    roman_datamodels @ git+https://github.com/eslavich/roman_datamodels.git@RCAL-244-save-output-logs
     #roman_datamodels==0.5.2
     stcal>=0.2.5
-    stpipe>=0.2.1
+    stpipe @ git+https://github.com/eslavich/stpipe.git@RCAL-244-save-output-logs
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     roman_datamodels @ git+https://github.com/eslavich/roman_datamodels.git@RCAL-244-save-output-logs
     #roman_datamodels==0.5.2
     stcal>=0.2.5
-    stpipe @ git+https://github.com/eslavich/stpipe.git@RCAL-244-save-output-logs
+    stpipe>=0.3.1
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Resolves RCAL-244

**Description**

This PR uses a new feature in stpipe to access log messages from the step/pipeline and record them in ImageModel.cal_logs.  Depends on the following dependency PRs:

https://github.com/spacetelescope/stpipe/pull/35
https://github.com/spacetelescope/rad/pull/96
https://github.com/spacetelescope/roman_datamodels/pull/53

Here's an example cal_logs array:

```yaml
cal_logs: !<asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0>
  - '2021-11-17T19:45:16.299Z :: stpipe.LoggingStep :: INFO :: Step LoggingStep running
    with args ().'
  - '2021-11-17T19:45:16.300Z :: stpipe.LoggingStep :: INFO :: Step LoggingStep parameters
    are: {''pre_hooks'': [], ''post_hooks'': [], ''output_file'': None, ''output_dir'':
    None, ''output_ext'': ''.asdf'', ''output_use_model'': False, ''output_use_index'':
    True, ''save_results'': False, ''skip'': False, ''suffix'': None, ''search_output_file'':
    True, ''input_dir'': ''''}'
  - '2021-11-17T19:45:16.300Z :: stpipe.LoggingStep :: WARNING :: Splines failed to
    reticulate'
```

Checklist
- [x] Tests

- [ ] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
