### PR TITLE
Skip Flatfield For Non-Image Exposure Types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ assign_wcs
 flat
 ----
 
-- Added check for WFI_Image in flat field step (skip if a different exposure type). Added test. [#366]
+- Added check in flat field step to skip spectroscopic observations. Added test. [#366]
 
 jump
 ----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ assign_wcs
 
 - Added ``assign_wcs`` step to romancal. [#361]
 
+flat
+----
+
+- Added check for WFI_Image in flat field step (skip if a different exposure type). Added test. [#366]
+
 jump
 ----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ jump
 
 - Updates for unit tests to use stcal [#322]
 
-- Fix to jump_step to save the update pixel and group dq arrays [#319]
+- Fix to jump_step to save the update pixel and group dq arrays. [#319]
 
 - Updated code for ``jump`` step using ``stcal``. [#309]
 

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -56,8 +56,7 @@ def do_flat_field(output_model, flat_model):
         output_model.meta.cal_step.flat_field = 'SKIPPED'
     elif output_model.meta.exposure.type != "WFI_IMAGE":
         # Check to see if attempt to flatten non-Image data
-        log.warning('Exposure type is '+output_model.meta.exposure.type+', which is not WFI_IMAGE')
-        log.warning('Flat Field Step will be skipped')
+        log.info('Skipping flat field for spectral exposure.')
         output_model.meta.cal_step.flat_field = 'SKIPPED'
     else:
         apply_flat_field(output_model, flat_model)

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -54,6 +54,11 @@ def do_flat_field(output_model, flat_model):
                     'shape as the science data')
         log.warning('Step will be skipped')
         output_model.meta.cal_step.flat_field = 'SKIPPED'
+    elif output_model.meta.exposure.type != "WFI_IMAGE":
+        # Check to see if attempt to flatten non-Image data
+        log.warning('Exposure type is '+output_model.meta.exposure.type+', which is not WFI_IMAGE')
+        log.warning('Flat Field Step will be skipped')
+        output_model.meta.cal_step.flat_field = 'SKIPPED'
     else:
         apply_flat_field(output_model, flat_model)
         output_model.meta.cal_step.flat_field = 'COMPLETE'

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -97,6 +97,10 @@ def test_crds_temporal_match(instrument, exptype):
 @pytest.mark.parametrize(
     "exptype", ["WFI_GRISM", "WFI_PRISM",]
 )
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Roman CRDS servers are not currently available outside the internal network"
+)
 # Test that spectroscopic exposure types will skip flat field step
 def test_spectroscopic_skip(instrument, exptype):
     wfi_image = testutil.mk_level2_image(arrays=True)

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -89,3 +89,26 @@ def test_crds_temporal_match(instrument, exptype):
     ref_file_path_b = step.get_reference_file(wfi_image_model, "flat")
     assert ("/".join(ref_file_path.rsplit("/", 1)[1:])) != \
            ("/".join(ref_file_path_b.rsplit("/", 1)[1:]))
+
+
+@pytest.mark.parametrize(
+    "instrument", ["WFI",]
+)
+@pytest.mark.parametrize(
+    "exptype", ["WFI_GRISM", "WFI_PRISM",]
+)
+# Test that spectroscopic exposure types will skip flat field step
+def test_spectroscopic_skip(instrument, exptype):
+    wfi_image = testutil.mk_level2_image(arrays=True)
+    wfi_image.meta.instrument.name = instrument
+    wfi_image.meta.instrument.detector = 'WFI01'
+    wfi_image.meta.instrument.optical_element = 'F158'
+
+    wfi_image.meta.observation.start_time = Time('2020-01-01T11:11:11.110')
+    wfi_image.meta.observation.end_time = Time('2020-01-01T11:33:11.110')
+
+    wfi_image.meta.exposure.type = exptype
+    wfi_image_model = ImageModel(wfi_image)
+
+    result = FlatFieldStep.call(wfi_image_model)
+    assert result.meta.cal_step.flat_field == 'SKIPPED'


### PR DESCRIPTION


<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-353: <Fix a bug>
**
-->

Closes #363 

Resolves RCAL-253 Add a check for exposure type for the FlatField Step

**Description**

This PR adds a check for WFI_Image in flat field step, and skips the step (with appropriate calstep update) if a different exposure type. Test of this is also added.


Checklist
- [x ] Tests

- [ ] Documentation

- [x ] Change log

- [x ] Milestone

- [ ] Label(s)
