### PR TITLE
RCAL-254 Update ramp fit regression tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ jump
 ramp_fitting
 ------------
 
+- Update ramp_fitting regression test output file names [#369]
+
 - Implemented ramp_fitting using stcal. [#276]
 
 saturation

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -10,7 +10,7 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
 
     args = ["romancal.step.RampFitStep", rtdata.input, '--save_opt=True', '--opt_name=rampfit_opt.asdf']
     RomanStep.from_cmdline(args)
-    output = "ramp_0_rampfitstep.asdf"
+    output = "ramp_rampfitstep.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #369

Resolves RCAL-254

**Description**

This PR addresses fixes the naming for the output files for the regression testing. 


Checklist
- [x ] Tests

- [x ] Documentation

- [x ] Change log

- [ x] Milestone

- [x ] Label(s)
