### PR TITLE
RCAL-243 Added spectroscopic pipeline test for SOC-622.

### DIFF
--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -40,52 +40,52 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     model = rdm.open(rtdata.output)
     pipeline = ExposurePipeline()
 
-    # DMS86 instrument artifact correction tests
+    # DMS90 instrument artifact correction tests
     pipeline.log.info('Status of the step:             assign_wcs    ' +
                   str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS86 MSG: Testing completion of wcs assignment in'
+    pipeline.log.info('DMS90 MSG: Testing completion of wcs assignment in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
     assert model.meta.cal_step.assign_wcs == 'COMPLETE'
     pipeline.log.info('Status of the step:             flat_field    ' +
                   str(model.meta.cal_step.flat_field))
-    pipeline.log.info('DMS86 MSG: Testing completion of flat fielding in'
+    pipeline.log.info('DMS90 MSG: Testing completion of flat fielding in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.flat_field == 'COMPLETE'))
     assert model.meta.cal_step.flat_field == 'COMPLETE'
     pipeline.log.info('Status of the step:             dark          ' +
                   str(model.meta.cal_step.dark))
-    pipeline.log.info('DMS86 MSG: Testing completion of dark correction in'
+    pipeline.log.info('DMS90 MSG: Testing completion of dark correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.dark == 'COMPLETE'))
     assert model.meta.cal_step.dark == 'COMPLETE'
     pipeline.log.info('Status of the step:             dq_init       ' +
                   str(model.meta.cal_step.dq_init))
-    pipeline.log.info('DMS86 MSG: Testing completion of data quality correction in'
+    pipeline.log.info('DMS90 MSG: Testing completion of data quality correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.dq_init == 'COMPLETE'))
     assert model.meta.cal_step.dq_init == 'COMPLETE'
     pipeline.log.info('Status of the step:             jump          ' +
                   str(model.meta.cal_step.jump))
-    pipeline.log.info('DMS86 MSG: Testing completion of jump detection in'
+    pipeline.log.info('DMS90 MSG: Testing completion of jump detection in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.jump == 'COMPLETE'))
     assert model.meta.cal_step.jump == 'COMPLETE'
     pipeline.log.info('Status of the step:             linearity     ' +
                   str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS86 MSG: Testing completion of linearity correction in'
+    pipeline.log.info('DMS90 MSG: Testing completion of linearity correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.linearity == 'COMPLETE'))
     assert model.meta.cal_step.linearity == 'COMPLETE'
     pipeline.log.info('Status of the step:             ramp_fit      ' +
                   str(model.meta.cal_step.ramp_fit))
-    pipeline.log.info('DMS86 MSG: Testing completion of ramp fitting in'
+    pipeline.log.info('DMS90 MSG: Testing completion of ramp fitting in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.ramp_fit == 'COMPLETE'))
     assert model.meta.cal_step.ramp_fit == 'COMPLETE'
     pipeline.log.info('Status of the step:             saturation    ' +
                   str(model.meta.cal_step.saturation))
-    pipeline.log.info('DMS86 MSG: Testing completion of saturation detection in'
+    pipeline.log.info('DMS90 MSG: Testing completion of saturation detection in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.saturation == 'COMPLETE'))
     assert model.meta.cal_step.saturation == 'COMPLETE'
@@ -131,15 +131,15 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     # Create new pointing for the model
     # RA & Dec are each shifted + 10 degrees, unless they are near the upper limit,
     # in which case they are shifted -10 degrees.
-    if model.meta.wcsinfo.ra_ref < 350.0:
-        model.meta.wcsinfo.ra_ref += 10.0
-    else:
-        model.meta.wcsinfo.ra_ref -= 10.0
+    delta = [10.0, 10.0]
+    if model.meta.wcsinfo.ra_ref >= 350.0:
+        delta[0] *= -1.0
 
-    if model.meta.wcsinfo.dec_ref < 80.0:
-        model.meta.wcsinfo.dec_ref += 10.0
-    else:
-        model.meta.wcsinfo.dec_ref -= 10.0
+    if model.meta.wcsinfo.dec_ref >= 80.0:
+        delta[1] *= -1.0
+
+    model.meta.wcsinfo.ra_ref += delta[0]
+    model.meta.wcsinfo.dec_ref += delta[1]
 
     # Create new wcs object for the new pointing
     model = AssignWcsStep.call(model)
@@ -154,5 +154,144 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     pipeline.log.info('DMS89 MSG: Testing that the different pointings create differing wcs.......'
                       + passfail(((np.abs(orig_wcs(2048,2048)[0] -
                                           model.meta.wcs(2048,2048)[0])) - 10.0) < 1.0))
-    assert_allclose([angle + 10.0 for angle in orig_wcs(2048,2048)], model.meta.wcs(2048,2048),
+    assert_allclose([orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]], model.meta.wcs(2048, 2048),
+                    atol=1.0)
+
+@pytest.mark.bigdata
+@pytest.mark.soctests
+def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
+    rtdata.get_data("WFI/grism/r0000201001001001002_01101_0001_WFI04_uncal.asdf")
+    rtdata.input = "r0000201001001001002_01101_0001_WFI04_uncal.asdf"
+
+    # Test Pipeline
+    output = "r0000201001001001002_01101_0001_WFI04_cal.asdf"
+    rtdata.output = output
+    args = ["--disable-crds-steppars",
+            "--steps.jump.rejection_threshold=180.0",
+            "--steps.jump.three_group_rejection_threshold=185.0",
+            "--steps.jump.four_group_rejection_threshold=190",
+            "roman_elp", rtdata.input,
+            ]
+    ExposurePipeline.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/grism/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)
+
+
+    # Perform DMS tests
+    # Initial prep
+    model = rdm.open(rtdata.output)
+    pipeline = ExposurePipeline()
+
+    # DMS90 instrument artifact correction tests
+    pipeline.log.info('Status of the step:             assign_wcs    ' +
+                  str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info('DMS90 MSG: Testing completion of wcs assignment in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
+    assert model.meta.cal_step.assign_wcs == 'COMPLETE'
+    pipeline.log.info('Status of the step:             flat_field    ' +
+                  str(model.meta.cal_step.flat_field))
+    pipeline.log.info('DMS90 MSG: Testing expected skip of flat fielding in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.flat_field == 'SKIPPED'))
+    assert model.meta.cal_step.flat_field == 'SKIPPED'
+    pipeline.log.info('Status of the step:             dark          ' +
+                  str(model.meta.cal_step.dark))
+    pipeline.log.info('DMS90 MSG: Testing completion of dark correction in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.dark == 'COMPLETE'))
+    assert model.meta.cal_step.dark == 'COMPLETE'
+    pipeline.log.info('Status of the step:             dq_init       ' +
+                  str(model.meta.cal_step.dq_init))
+    pipeline.log.info('DMS90 MSG: Testing completion of data quality correction in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.dq_init == 'COMPLETE'))
+    assert model.meta.cal_step.dq_init == 'COMPLETE'
+    pipeline.log.info('Status of the step:             jump          ' +
+                  str(model.meta.cal_step.jump))
+    pipeline.log.info('DMS90 MSG: Testing completion of jump detection in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.jump == 'COMPLETE'))
+    assert model.meta.cal_step.jump == 'COMPLETE'
+    pipeline.log.info('Status of the step:             linearity     ' +
+                  str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info('DMS90 MSG: Testing completion of linearity correction in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.linearity == 'COMPLETE'))
+    assert model.meta.cal_step.linearity == 'COMPLETE'
+    pipeline.log.info('Status of the step:             ramp_fit      ' +
+                  str(model.meta.cal_step.ramp_fit))
+    pipeline.log.info('DMS90 MSG: Testing completion of ramp fitting in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.ramp_fit == 'COMPLETE'))
+    assert model.meta.cal_step.ramp_fit == 'COMPLETE'
+    pipeline.log.info('Status of the step:             saturation    ' +
+                  str(model.meta.cal_step.saturation))
+    pipeline.log.info('DMS90 MSG: Testing completion of saturation detection in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail(model.meta.cal_step.saturation == 'COMPLETE'))
+    assert model.meta.cal_step.saturation == 'COMPLETE'
+
+    # DMS91 data quality tests
+    pipeline.log.info('DMS91 MSG: Testing existence of data quality array (dq) in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail("dq" in model.keys()))
+    assert "dq" in model.keys()
+    pipeline.log.info('DMS91 MSG: Testing existence of general error array (err) in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail("err" in model.keys()))
+    assert "err" in model.keys()
+    pipeline.log.info('DMS91 MSG: Testing existence of Poisson noise variance array (var_poisson)'
+                  'in Level 2 spectroscopic output.......' +
+                  passfail("var_poisson" in model.keys()))
+    assert "var_poisson" in model.keys()
+    pipeline.log.info('DMS91 MSG: Testing existence of read noise variance array (var_rnoise) in'
+                  'Level 2 spectroscopic output.......' +
+                  passfail("var_rnoise" in model.keys()))
+    assert "var_rnoise" in model.keys()
+
+    # DMS88 total exposure time test
+    pipeline.log.info('DMS88 MSG: Testing existence of total exposure time (exposure_time)'
+                  'in Level 2 spectroscopic output.......' +
+                  passfail("exposure_time" in model.meta.exposure))
+    assert "exposure_time" in model.meta.exposure
+
+    # DMS93 WCS tests
+    pipeline.log.info('DMS93 MSG: Testing that the wcs bounding'
+                  'box was generated.......' +
+                  passfail((len(model.meta.wcs.bounding_box) == 2)))
+    assert (len(model.meta.wcs.bounding_box) == 2)
+
+    # Save original wcs information
+    orig_wcs = copy.deepcopy(model.meta.wcs)
+    del model.meta['wcs']
+
+    # Create new pointing for the model
+    # RA & Dec are each shifted + 10 degrees, unless they are near the upper limit,
+    # in which case they are shifted -10 degrees.
+    delta = [10.0, 10.0]
+    if model.meta.wcsinfo.ra_ref >= 350.0:
+        delta[0] *= -1.0
+
+    if model.meta.wcsinfo.dec_ref >= 80.0:
+        delta[1] *= -1.0
+
+    model.meta.wcsinfo.ra_ref += delta[0]
+    model.meta.wcsinfo.dec_ref += delta[1]
+
+    # Create new wcs object for the new pointing
+    model = AssignWcsStep.call(model)
+
+    rtdata.output = output.rsplit(".",1)[0] + "_repoint.asdf"
+    model.to_asdf(rtdata.output)
+
+    # Test that repointed file matches truth
+    rtdata.get_truth("truth/WFI/grism/" + output.rsplit(".",1)[0] + "_repoint.asdf")
+    assert (compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)
+
+    pipeline.log.info('DMS93 MSG: Testing that the different pointings create differing wcs.......'
+                      + passfail(((np.abs(orig_wcs(2048,2048)[0] -
+                                          model.meta.wcs(2048,2048)[0])) - 10.0) < 1.0))
+    assert_allclose([orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]],
+                    model.meta.wcs(2048, 2048),
                     atol=1.0)

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -40,52 +40,52 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     model = rdm.open(rtdata.output)
     pipeline = ExposurePipeline()
 
-    # DMS90 instrument artifact correction tests
+    # DMS86 instrument artifact correction tests
     pipeline.log.info('Status of the step:             assign_wcs    ' +
                   str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS90 MSG: Testing completion of wcs assignment in'
+    pipeline.log.info('DMS86 MSG: Testing completion of wcs assignment in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
     assert model.meta.cal_step.assign_wcs == 'COMPLETE'
     pipeline.log.info('Status of the step:             flat_field    ' +
                   str(model.meta.cal_step.flat_field))
-    pipeline.log.info('DMS90 MSG: Testing completion of flat fielding in'
+    pipeline.log.info('DMS86 MSG: Testing completion of flat fielding in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.flat_field == 'COMPLETE'))
     assert model.meta.cal_step.flat_field == 'COMPLETE'
     pipeline.log.info('Status of the step:             dark          ' +
                   str(model.meta.cal_step.dark))
-    pipeline.log.info('DMS90 MSG: Testing completion of dark correction in'
+    pipeline.log.info('DMS86 MSG: Testing completion of dark correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.dark == 'COMPLETE'))
     assert model.meta.cal_step.dark == 'COMPLETE'
     pipeline.log.info('Status of the step:             dq_init       ' +
                   str(model.meta.cal_step.dq_init))
-    pipeline.log.info('DMS90 MSG: Testing completion of data quality correction in'
+    pipeline.log.info('DMS86 MSG: Testing completion of data quality correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.dq_init == 'COMPLETE'))
     assert model.meta.cal_step.dq_init == 'COMPLETE'
     pipeline.log.info('Status of the step:             jump          ' +
                   str(model.meta.cal_step.jump))
-    pipeline.log.info('DMS90 MSG: Testing completion of jump detection in'
+    pipeline.log.info('DMS86 MSG: Testing completion of jump detection in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.jump == 'COMPLETE'))
     assert model.meta.cal_step.jump == 'COMPLETE'
     pipeline.log.info('Status of the step:             linearity     ' +
                   str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS90 MSG: Testing completion of linearity correction in'
+    pipeline.log.info('DMS86 MSG: Testing completion of linearity correction in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.linearity == 'COMPLETE'))
     assert model.meta.cal_step.linearity == 'COMPLETE'
     pipeline.log.info('Status of the step:             ramp_fit      ' +
                   str(model.meta.cal_step.ramp_fit))
-    pipeline.log.info('DMS90 MSG: Testing completion of ramp fitting in'
+    pipeline.log.info('DMS86 MSG: Testing completion of ramp fitting in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.ramp_fit == 'COMPLETE'))
     assert model.meta.cal_step.ramp_fit == 'COMPLETE'
     pipeline.log.info('Status of the step:             saturation    ' +
                   str(model.meta.cal_step.saturation))
-    pipeline.log.info('DMS90 MSG: Testing completion of saturation detection in'
+    pipeline.log.info('DMS86 MSG: Testing completion of saturation detection in'
                   'Level 2 image output.......' +
                   passfail(model.meta.cal_step.saturation == 'COMPLETE'))
     assert model.meta.cal_step.saturation == 'COMPLETE'


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #

Resolves RCAL-243

**Description**

This PR addresses tests to cover SOC-622. The tests cover:
In Wide Field Spectroscoping (Grism) mode, the DMS shall generate Level 2 science data products consisting of exposures corrected for instrument artifacts, including the following information for each calibrated exposure:

(a) Effective depth for each pixel
(b) Effective exposure time for each pixel
(c) World Coordinate System information.


Checklist
- [x ] Tests

- [ ] Documentation

- [x ] Change log

- [ ] Milestone

- [ ] Label(s)
