### PR TITLE
remove hard-coded config for number of test jobs

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -88,7 +88,7 @@ bc0.build_cmds = [
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
-    "pytest --cov-report=xml --cov=./ -r sxf -n 30 --bigdata --slow \
+    "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     "codecov --token=${codecov_token} -F nightly",


### PR DESCRIPTION
the number of pytest jobs is hard coded at 30; changing it to 'auto' to properly scale with the build server's resources