### PR TITLE
RCAL-186 Add regression tests for Dark Current Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.6.0 (unreleased)
 ==================
 
+general
+-------
+
+- Added regression tests for dark_current subtraction. [#392]
+
 0.5.0 (2021-12-13)
 ==================
 

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -1,0 +1,83 @@
+"""Regression test for the Dark current subtraction step."""
+import pytest
+
+from romancal.stpipe import RomanStep
+from .regtestdata import compare_asdf
+
+
+@pytest.mark.bigdata
+def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
+    """ Function to run and compare Dark Current subtraction files. Note: This
+        should include tests for overrides etc. """
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearity.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+
+    args = ["romancal.step.DarkCurrentStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    output =\
+        "r0000101001001001001_01101_0001_WFI01_linearity_darkcurrentstep.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)
+
+
+@pytest.mark.bigdata
+def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
+    """ Function to run and compare Dark Current subtraction files. Here the
+        test is for renaming the output file. """
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearity.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+
+    args = ["romancal.step.DarkCurrentStep", rtdata.input,
+            '--output_file=Test_dark']
+    RomanStep.from_cmdline(args)
+    output = "Test_dark_darkcurrentstep.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)
+
+
+@pytest.mark.bigdata
+def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
+    """ Function to run and compare Dark Current subtraction files. Here the
+        test is for renaming the output file. """
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearity.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+
+    args = ["romancal.step.DarkCurrentStep", rtdata.input,
+            '--output_file=Test_dark', '--suffix="suffix_test"']
+    RomanStep.from_cmdline(args)
+    output = "Test_dark_suffix_test.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)
+
+
+@pytest.mark.xfail(reason='RCAL-285 should address this failure')
+@pytest.mark.bigdata
+def test_dark_current_output(rtdata, ignore_asdf_paths):
+    """ Function to run and compare Dark Current subtraction files. Here the
+        test for overriding the CRDS dark reference file. """
+
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearity.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    dark_output_name = \
+        "r0000101001001001001_01101_0001_WFI01_linearity_darkcurrentstep.asdf"
+
+    args = ["romancal.step.DarkCurrentStep",
+            rtdata.input,
+            f"--dark_output={dark_output_name}"]
+    RomanStep.from_cmdline(args)
+    output =\
+        "r0000101001001001001_01101_0001_WFI01_linearity_darkcurrentstep.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-186 Regression tests for Dark Current Step
**
-->

Closes #392

Resolves RCAL-186

**Description**

This PR adds an initial set of dark current regression tests. The test for the option --dark_output is currently xfailed and the ticket RCAL-285 is filed to address that failure. Once this is fixed the test should be reinstated. 


Checklist
- [x] Tests

- [ ] Documentation - N/A

- [x] Change log

- [x] Milestone

- [x] Label(s)
