### PR TITLE
RCAL-268 Regression tests for Linearity correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 general
 -------
 
+- Added regression tests for linearity correction. [#3xx]
+
+
 - Added regression tests for dark_current subtraction. [#392]
 
 0.5.0 (2021-12-13)

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -1,0 +1,40 @@
+"""Regression test for the linearity correction step."""
+import pytest
+
+from romancal.stpipe import RomanStep
+from .regtestdata import compare_asdf
+
+
+@pytest.mark.bigdata
+def test_linearity_step(rtdata, ignore_asdf_paths):
+    """ Function to run and compare linearity correction files."""
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_saturation.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
+
+    args = ["romancal.step.LinearityStep", rtdata.input]
+    RomanStep.from_cmdline(args)
+    output =\
+        "r0000101001001001001_01101_0001_WFI01_saturation_linearitystep.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)
+
+
+@pytest.mark.bigdata
+def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
+    """ Function to run and linearity correction files. Here the
+        test is for renaming the output file. """
+    rtdata.get_data(
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_saturation.asdf")
+    rtdata.input = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
+
+    args = ["romancal.step.LinearityStep", rtdata.input,
+            '--output_file=Test_linearity']
+    RomanStep.from_cmdline(args)
+    output = "Test_linearity_linearitystep.asdf"
+    rtdata.output = output
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

Closes #394

Resolves RCAL-268

**Description**

This PR adds regression tests for Linearity correction

results from local pytest,
...
-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========== 2 passed, 15 deselected, 2 warnings in 743.94s (0:12:23) ===========

Checklist
- [x] Tests

- [ ] Documentation - N/A

- [x] Change log

- [x] Milestone

- [x] Label(s)
