### PR TITLE
Rcal 292 Update regression test inputs parameters to reduce runtime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Documentation
 jump
 ----
 
+ - Update Jump regression test parameters to reduce test time [#411]
+
  - Update code to suppress output from the jump step if not requested [#399]
 
 0.5.0 (2021-12-13)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+	soctests: run only the SOC tests in the suite.
+	

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -12,7 +12,12 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
     rtdata.get_data("WFI/image/l1_0007_science_raw_dqinitstep.asdf")
     rtdata.input = "l1_0007_science_raw_dqinitstep.asdf"
 
-    args = ["romancal.step.JumpStep", rtdata.input]
+    # Note: the thresholds should be reset to the defaults once we have better
+    # input data
+    args = ["romancal.step.JumpStep", rtdata.input,
+            '--rejection_threshold=180.',
+            '--three_group_rejection_threshold=185.',
+            '--four_group_rejection_threshold=190.']
     RomanStep.from_cmdline(args)
     output = "l1_0007_science_raw_dqinitstep_jumpstep.asdf"
     rtdata.output = output


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #409

Resolves RCAL-292

**Description**

This PR updates the jump regression test input parameter to reduce the runtime. The parameters are
-steps.jump.rejection_threshold=180. 
--steps.jump.three_group_rejection_threshold=185. 
--steps.jump.four_group_rejection_threshold=190.

Running the local regression tests with the updated parameters, 
pytest --bigdata ~/src/Roman/romancal/romancal/regtest/ --basetemp=/Users/ddavis/src/Roman/develop/test/tmp_tc/ \
-k jump  2>&1 | tee regression_test_Jan21_01.log
============================= test session starts ==============================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal, configfile: pytest.ini
plugins: arraydiff-0.3, asdf-2.8.1, remotedata-0.3.2, ci-watson-0.5, mock-3.6.1, xdist-2.4.0, filter-subpackage-0.1.1, hypothesis-6.26.0, openfiles-0.5.0, forked-1.3.0, doctestplus-0.11.1, astropy-header-0.1.2, cov-3.0.0
collected 17 items / 16 deselected / 1 selected

../../../romancal/romancal/regtest/test_jump_det.py .                    [100%]

================= 1 passed, 16 deselected in 487.06s (0:08:07)

takes 8 min, without 3.7 hours, a reduction of ~28x 


Checklist
- [x] Tests

- [ ] Documentation, N/A

- [x] Change log

- [x] Milestone

- [x] Label(s)
