### PR TITLE
fix string interpolation in Jenkins file

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -91,7 +91,7 @@ bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
-    "codecov --token=${codecov_token} -F nightly",
+    'codecov --token=${codecov_token} -F nightly',
 ]
 bc0.test_configs = [data_config]
 bc0.failedFailureThresh = 0


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

**Description**

This PR addresses a potential security issue in the Jenkins file with
groovy string interpolation of variables. Groovy treats "double quoted"
strings in a slightly different way from "single quoted" strings.
A warning was raised in the Jenkins run of the regression tests.

