### PR TITLE
RCAL-285 dark current subtraction output file fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ dark
 
  - Updated dark current step to use stcal. Created tests for the updated step. [#420]
 
+ - Fixed dark subtraction output crash. [#423]
+
 
 jump
 ----

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -67,6 +67,11 @@ class DarkCurrentStep(RomanStep):
                 save_dark_data_as_dark_model(dark_data, dark_model)
             dark_model.close()
 
+            # Reshaping data variables back from stcal
+            input_model.data = input_model.data[0]
+            input_model.groupdq = input_model.groupdq[0]
+            input_model.err = input_model.err[0]
+
             # Convert data to RampModel
             out_ramp = dark_output_data_as_ramp_model(out_data, input_model)
 

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -59,7 +59,6 @@ def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
             **ignore_asdf_paths) is None)
 
 
-@pytest.mark.xfail(reason='RCAL-285 should address this failure')
 @pytest.mark.bigdata
 def test_dark_current_output(rtdata, ignore_asdf_paths):
     """ Function to run and compare Dark Current subtraction files. Here the


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #406 

Resolves [RCAL-285](https://jira.stsci.edu/browse/RCAL-285)

**Description**

This PR fixes dark_current subtraction step with the optional --dark_output.


Checklist
- [x] Tests

- [ ] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
