### PR TITLE
Update intersphinx documentation URLs for numpy and scipy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,8 +63,8 @@ def check_sphinx_version(expected_version):
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'numpy': ('https://numpy.org/devdocs', None),
+    'scipy': ('http://scipy.github.io/devdocs', None),
     'matplotlib': ('http://matplotlib.org/', None),
     }
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #

Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

**Description**

This PR addresses the location change of the scipy and numpy intersphinx inventory files which was causing documentation build  errors. 


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [x] Milestone

- [x] Label(s)
