### PR TITLE
RCAL-308 Update the output of dq_init and ramp_fitting for reference pixel correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ general
 
 - Updated tests to utilize new maker function code. [#395]
 
+- Border reference pixel arrays (and their dq) are copied in ``dq_init``.
+  They are trimmed from the science data (and err/dq) in ``ramp_fit``. [#435]
+
 Documentation
 -------------
 
@@ -41,6 +44,7 @@ jump
 Pipeline
 ________
  - Migrate JWST suffix infrastructure to the Roman Exposure Pipeline [#425]
+
 
 0.5.0 (2021-12-13)
 ==================

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -83,6 +83,21 @@ class DQInitStep(RomanStep):
                 **reference_file_models,
             )
 
+            # copy original border reference file arrays (data and dq)
+            # to their own attributes. they will also remain attached to
+            # the science data until they are trimmed at ramp_fit
+            # these arrays include the overlap regions in the corners
+
+            output_model.border_ref_pix_right = output_model.data[:, :, -4:]
+            output_model.border_ref_pix_left = output_model.data[:, :, :4]
+            output_model.border_ref_pix_top = output_model.data[:, :4, :]
+            output_model.border_ref_pix_bottom = output_model.data[:, -4:, :]
+
+            output_model.dq_border_ref_pix_right = output_model.pixeldq[:, -4:]
+            output_model.dq_border_ref_pix_left = output_model.pixeldq[:, :4]
+            output_model.dq_border_ref_pix_top = output_model.pixeldq[:4, :]
+            output_model.dq_border_ref_pix_bottom = output_model.pixeldq[-4:, :]
+
         else:
             # Skip DQ step if no mask files
             reference_file_models['mask'] = None
@@ -91,6 +106,7 @@ class DQInitStep(RomanStep):
 
             output_model = init_model
             output_model.meta.cal_step.dq_init = 'SKIPPED'
+
 
         # Close the input and reference files
         input_model.close()

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -226,6 +226,10 @@ def test_dqinit_step_interface(instrument, exptype):
         ("WFI", "WFI_IMAGE"),
     ]
 )
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Roman CRDS servers are not currently available outside the internal network"
+)
 def test_dqinit_refpix(instrument, exptype):
     """Test that the basic inferface works for data requiring a DQ reffile"""
 
@@ -241,21 +245,9 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
-    # Create mask model
-    maskref = stnode.MaskRef()
-    meta = {}
-    testutil.add_ref_common(meta)
-    meta['instrument']['optical_element'] = 'F158'
-    meta['instrument']['detector'] = 'WFI01'
-    meta['reftype'] = 'MASK'
-    maskref['meta'] = meta
-    maskref['data'] = np.ones(shape[1:], dtype=np.float32)
-    maskref['dq'] = np.zeros(shape[1:], dtype=np.uint16)
-    maskref['err'] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
-    maskref_model = MaskRefModel(maskref)
 
     # Perform Data Quality application step
-    result = DQInitStep.call(wfi_sci_raw_model, override_mask=maskref_model)
+    result = DQInitStep.call(wfi_sci_raw_model)
 
     # check if reference pixels are correct
     assert result.data.shape == (2, 20, 20)  # no pixels should be trimmed


### PR DESCRIPTION
The dq_init step copies the original 3D border reference pixels and their dq arrays into individual attributes. The ramp fitting step trims the border pixel arrays from the science data/dq/err arrays. 