### PR TITLE
RCAL-129: Document photom & area reference files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Documentation
 
  - Initial romancal documentation for using datamodels. [#391]
 
+ - Added documentation for PHOTOM and Area reference files, which required placeholder documentation for the photom step. In addition, I fixed an improper object in dark documentation. [#452]
+
 dark
 ----
 

--- a/docs/roman/package_index.rst
+++ b/docs/roman/package_index.rst
@@ -12,6 +12,7 @@ Package Index
    jump/index.rst
    linearity/index.rst
    pipeline/index.rst
+   photom/index.rst
    ramp_fitting/index.rst
    references_general/index.rst
    saturation/index.rst

--- a/docs/roman/photom/index.rst
+++ b/docs/roman/photom/index.rst
@@ -1,0 +1,11 @@
+.. _photom_step:
+
+=======================
+Photometric Calibration
+=======================
+
+.. toctree::
+   :maxdepth: 2
+
+   reference_files.rst
+

--- a/docs/roman/photom/reference_files.rst
+++ b/docs/roman/photom/reference_files.rst
@@ -1,0 +1,8 @@
+Reference Files
+===============
+The ``photom`` step uses :ref:`PHOTOM <photom_reffile>`
+and pixel :ref:`AREA <area_reffile>` reference files.
+
+.. include:: ../references_general/photom_reffile.inc
+
+.. include:: ../references_general/area_reffile.inc

--- a/docs/roman/references_general/area_reffile.inc
+++ b/docs/roman/references_general/area_reffile.inc
@@ -1,0 +1,43 @@
+.. _area_reffile:
+
+AREA Reference File
+-------------------
+
+:REFTYPE: AREA
+:Data models: `~roman_datamodels.datamodels.PixelareaRefModel`
+
+The AREA reference file contains pixel area information for a given
+detector.
+
+.. include:: ../references_general/area_selection.inc
+
+.. include:: ../includes/standard_keywords.inc
+
+Type Specific Keywords for AREA
++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in AREA reference files,
+because they are used as CRDS selectors
+(see :ref:`area_selectors`):
+
+===============   ======================================  ==============
+Attribute           Fully qualified path                   Instruments
+===============   ======================================  ==============
+detector           model.meta.instrument.detector          WFI
+===============   ======================================  ==============
+
+
+Reference File Format
++++++++++++++++++++++
+AREA reference files are ASDF format, with 2D data arrays.
+The format and content of the file is as follows
+(see `~roman_datamodels.datamodels.PixelareaRefModel`):
+
+=======  ============ ==========================  =============
+Data      Array Type   Dimensions                  Data type
+=======  ============ ==========================  =============
+area      NDArray      4096 x 4096                 float32
+=======  ============ ==========================  =============
+
+The area data array contains a 2-D pixel-by-pixel map of relative
+pixel areas, normalized to a value of 1.0. 

--- a/docs/roman/references_general/area_reffile.inc
+++ b/docs/roman/references_general/area_reffile.inc
@@ -36,7 +36,7 @@ The format and content of the file is as follows
 =======  ============ ==========================  =============
 Data      Array Type   Dimensions                  Data type
 =======  ============ ==========================  =============
-area      NDArray      4096 x 4096                 float32
+area      NDArray      4088 x 4088                 float32
 =======  ============ ==========================  =============
 
 The area data array contains a 2-D pixel-by-pixel map of relative

--- a/docs/roman/references_general/area_selection.inc
+++ b/docs/roman/references_general/area_selection.inc
@@ -1,0 +1,14 @@
+.. _area_selectors:
+
+Reference Selection Keywords for AREA
++++++++++++++++++++++++++++++++++++++
+CRDS selects appropriate AREA references based on the following keywords.
+AREA is not applicable for instruments not in the table.
+All keywords used for file selection are *required*.
+
+========== =================================================================
+Instrument Keywords                                                          
+========== =================================================================
+WFI        instrument, detector, date, time            
+========== =================================================================
+

--- a/docs/roman/references_general/dark_reffile.inc
+++ b/docs/roman/references_general/dark_reffile.inc
@@ -19,7 +19,7 @@ Reference File Format
 +++++++++++++++++++++
 DARK reference files are ASDF format, with 3 data arrays.
 The format and content of the file is as follows
-(see `~romancal.datamodels.DarkModel`):
+(see `~roman_datamodels.datamodels.DarkRefModel`):
 
 =======  ============ ==========================  =============
 Data      Array Type   Dimensions                  Data type

--- a/docs/roman/references_general/photom_reffile.inc
+++ b/docs/roman/references_general/photom_reffile.inc
@@ -1,0 +1,56 @@
+.. _photom_reffile:
+
+PHOTOM Reference File
+---------------------
+
+:REFTYPE: PHOTOM
+:Data models: `~roman_datamodels.datamodels.WfiImgPhotomRefModel`
+
+The PHOTOM reference file contains conversion factors for putting
+pixel values into physical units.
+
+.. include:: ../references_general/photom_selection.inc
+
+.. include:: ../includes/standard_keywords.inc
+
+Type Specific Keywords for PHOTOM
++++++++++++++++++++++++++++++++++
+In addition to the standard reference file keywords listed above,
+the following keywords are *required* in PHOTOM reference files,
+because they are used as CRDS selectors
+(see :ref:`photom_selectors`):
+
+===============   ======================================  ==============
+Attribute          Fully qualified path                    Instruments
+===============   ======================================  ==============
+detector           model.meta.instrument.detector          WFI
+===============   ======================================  ==============
+
+
+Tabular PHOTOM Reference File Format
+++++++++++++++++++++++++++++++++++++
+PHOTOM reference files are ASDF format, with data in the phot_table attribute.
+The format and content of the file is as follows
+(see `~romancal.datamodels.WfiImgPhotomRefModel`):
+
+Data is stored in a 2D table, with optical elements for the row names:
++------------+-------------+-------------------------------------------------------+
+| Instrument | Row names                                                           |                                                       
++============+=============+=======================================================+
+| WFI        | F062, F087, F106, F129, W146, F158, F184, F213, GRISM, PRISM, DARK  | 
++------------+-------------+-------------------------------------------------------+
+
+
+And the variable attributes for the columns (with data type):
++------------+----------------+-----------+------------+------------------------+
+| Instrument | Column name    | Data type | Dimensions | Units                  |
++============+=======+================+===========+============+================+
+| WFI        | photmjsr       | float     | scalar     | MJy/steradian          |
++            +----------------+-----------+------------+------------------------+
+|            | uncertainty    | float     | scalar     | MJy/steradian          |
++            +----------------+-----------+------------+------------------------+
+|            | pixelareasr    | float     | scalar     | MJy/steradian          |
++------------+-------+----------------+-----------+------------+----------------+
+
+The pixelareasr variable attribute gives the average pixel area in units of steradians.
+

--- a/docs/roman/references_general/photom_reffile.inc
+++ b/docs/roman/references_general/photom_reffile.inc
@@ -49,7 +49,7 @@ And the variable attributes for the columns (with data type):
 +            +----------------+-----------+------------+------------------------+
 |            | uncertainty    | float     | scalar     | MJy/steradian          |
 +            +----------------+-----------+------------+------------------------+
-|            | pixelareasr    | float     | scalar     | MJy/steradian          |
+|            | pixelareasr    | float     | scalar     | steradian              |
 +------------+-------+----------------+-----------+------------+----------------+
 
 The pixelareasr variable attribute gives the average pixel area in units of steradians.

--- a/docs/roman/references_general/photom_selection.inc
+++ b/docs/roman/references_general/photom_selection.inc
@@ -1,0 +1,13 @@
+.. _photom_selectors:
+
+Reference Selection Keywords for PHOTOM
++++++++++++++++++++++++++++++++++++++++
+CRDS selects appropriate PHOTOM references based on the following keywords.
+PHOTOM is not applicable for instruments not in the table.
+All keywords used for file selection are *required*.
+
+===============   ======================================  ==============
+Attribute           Fully qualified path                   Instruments
+===============   ======================================  ==============
+detector           model.meta.instrument.detector          WFI
+===============   ======================================  ==============

--- a/docs/roman/references_general/references_general.rst
+++ b/docs/roman/references_general/references_general.rst
@@ -56,6 +56,10 @@ documentation on each reference file.
 +---------------------------------------------+--------------------------------------------------+
 | :ref:`linearity <linearity_step>`           | :ref:`LINEARITY <linearity_reffile>`             |
 +---------------------------------------------+--------------------------------------------------+
+| :ref:`photom <photom_step>`                 | :ref:`PHOTOM <photom_reffile>`                   |
++                                             +--------------------------------------------------+
+|                                             | :ref:`AREA <area_reffile>`                       |
++---------------------------------------------+--------------------------------------------------+
 | :ref:`ramp_fitting <ramp_fitting_step>`     | :ref:`GAIN <gain_reffile>`                       |
 +                                             +--------------------------------------------------+
 |                                             | :ref:`READNOISE <readnoise_reffile>`             |
@@ -67,6 +71,8 @@ documentation on each reference file.
 +--------------------------------------------------+---------------------------------------------+
 | Reference File Type (reftype)                    | Pipeline Step                               |
 +==================================================+=============================================+
+| :ref:`AREA <area_reffile>`                       | :ref:`photom <photom_step>`                 |
++--------------------------------------------------+---------------------------------------------+
 | :ref:`DARK <dark_reffile>`                       | :ref:`dark_current <dark_current_step>`     |
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`FLAT <flat_reffile>`                       | :ref:`flatfield <flatfield_step>`           |
@@ -78,6 +84,8 @@ documentation on each reference file.
 | :ref:`LINEARITY <linearity_reffile>`             | :ref:`linearity <linearity_step>`           |
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`MASK <mask_reffile>`                       | :ref:`dq_init <dq_init_step>`               |
++--------------------------------------------------+---------------------------------------------+
+| :ref:`PHOTOM <photom_reffile>`                   | :ref:`photom <photom_step>`                 |
 +--------------------------------------------------+---------------------------------------------+
 | :ref:`READNOISE <readnoise_reffile>`             | :ref:`jump_detection <jump_step>`           |
 +                                                  +---------------------------------------------+


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #173 

Resolves [RCAL-129](https://jira.stsci.edu/browse/RCAL-129)

**Description**

This PR addresses adding documentation for PHOTOM and Area reference files, which required placeholder documentation for the photom step. In addition, I fixed an improper object in dark documentation.


Checklist
- [ ] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
