### PR TITLE
Rcal 46 Initial documentation for error propagation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ general
 Documentation
 -------------
 
- - Add documentation for DNS build 0.5, e.g. reference array trimming [#457]
+- Add documentation for error propagation in ramp fitting and flat field [#]
+
+- Add documentation for DNS build 0.5, e.g. reference array trimming [#457]
 
 
 0.6.0 (2022-03-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ general
 Documentation
 -------------
 
-- Add documentation for error propagation in ramp fitting and flat field [#]
+- Add documentation for error propagation in ramp fitting and flat field [#476]
 
 - Add documentation for DNS build 0.5, e.g. reference array trimming [#457]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,3 +22,4 @@ Package Documentation
    :maxdepth: 1
 
    roman/package_index.rst
+   roman/error_propagation/index.rst

--- a/docs/roman/error_propagation/index.rst
+++ b/docs/roman/error_propagation/index.rst
@@ -1,0 +1,10 @@
+.. _error_propagation:
+
+=================
+Error Propagation
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   main.rst

--- a/docs/roman/error_propagation/main.rst
+++ b/docs/roman/error_propagation/main.rst
@@ -1,26 +1,30 @@
-in the pipeline. Anytime a step
-creates or updates variances, the total error (ERR) array values are always recomputed
-as the square root of the quadratic sum of all variances available at the time.
-Note that the ERR array values are always expressed as standard deviation
-(i.e. square root of the variance).
+Description
+-----------
+Steps in the various pipeline modules calculate variances due to different sources of
+noise or modify variances that were computed by previous steps.
+For some cases these arrays are being propagated to subsequent steps in the pipeline.
+Anytime a step creates or updates variances, the total error (ERR) array values
+are recomputed as the square root of the quadratic sum of all variances available
+to the step.
+Note that the ERR array values are always expressed as a standard deviation
+(the square root of the variance).
 
 The table below is a summary of which steps create or update variance and error arrays,
 as well as which steps make use of these data. Details of how each step computes or
 uses these data are given in the subsequent sections below.
 
-================= ===== ======================= ====================================== =========
-Step              Stage Creates arrays          Updates arrays                         Step uses
-================= ===== ======================= ====================================== =========
-ramp_fitting      ELPP  VAR_POISSON, VAR_RNOISE ERR                                    None
-flat_field        ELPP  VAR_FLAT                ERR, VAR_POISSON, VAR_RNOISE           None
-photom            ELPP  None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
-================= ===== ======================= ====================================== =========
+================= ===== ======================= ============================ =========
+Step              Stage Creates arrays          Updates arrays               Step uses
+================= ===== ======================= ============================ =========
+ramp_fitting      ELPP  VAR_POISSON, VAR_RNOISE ERR                          None
+flat_field        ELPP  VAR_FLAT                ERR, VAR_POISSON, VAR_RNOISE None
+================= ===== ======================= ============================ =========
 
 ELPP Processing
 ---------------
 ELPP processing pipelines perform detector-level corrections and ramp fitting for
 individual exposures, for nearly all imaging and spectroscopic modes. Details
-of the pipelines can be found at :ref:
+of the pipelines can be found at :ref:`roman_elp <exposure_pipeline>`.
 
 The ELPP pipeline steps that alter the ERR, VAR_POISSON, or VAR_RNOISE arrays
 the science countrate data are discussed below.
@@ -44,11 +48,3 @@ reference file ERR array.
 The science data ERR array is then updated to be the square root of the quadratic sum of
 the three variance arrays.
 For more details see :ref:`flat_field <flatfield_step>`.
-
-photom
-++++++
-The calibration information for the ``photom`` step includes a scalar flux conversion
-constant. Currently the scalar conversion factor or any 2-D
-response values are not applied to the science data, ERR arrays,
-or the variance (VAR_POISSON, VAR_RNOISE, and VAR_FLAT) arrays.
-For details of the photom correction, see :ref:`photom <photom_step>`.

--- a/docs/roman/error_propagation/main.rst
+++ b/docs/roman/error_propagation/main.rst
@@ -1,0 +1,54 @@
+in the pipeline. Anytime a step
+creates or updates variances, the total error (ERR) array values are always recomputed
+as the square root of the quadratic sum of all variances available at the time.
+Note that the ERR array values are always expressed as standard deviation
+(i.e. square root of the variance).
+
+The table below is a summary of which steps create or update variance and error arrays,
+as well as which steps make use of these data. Details of how each step computes or
+uses these data are given in the subsequent sections below.
+
+================= ===== ======================= ====================================== =========
+Step              Stage Creates arrays          Updates arrays                         Step uses
+================= ===== ======================= ====================================== =========
+ramp_fitting      ELPP  VAR_POISSON, VAR_RNOISE ERR                                    None
+flat_field        ELPP  VAR_FLAT                ERR, VAR_POISSON, VAR_RNOISE           None
+photom            ELPP  None                    ERR, VAR_POISSON, VAR_RNOISE, VAR_FLAT None
+================= ===== ======================= ====================================== =========
+
+ELPP Processing
+---------------
+ELPP processing pipelines perform detector-level corrections and ramp fitting for
+individual exposures, for nearly all imaging and spectroscopic modes. Details
+of the pipelines can be found at :ref:
+
+The ELPP pipeline steps that alter the ERR, VAR_POISSON, or VAR_RNOISE arrays
+the science countrate data are discussed below.
+Any step not listed here does not alter or use the variance or error arrays
+in any way and simply propagates the information to the next step.
+
+ramp_fitting
+++++++++++++
+This step calculates and populates the VAR_POISSON and VAR_RNOISE arrays to pass to the
+next step or saved in the optional output 'rate' files. The ERR array is updated as the square root of the
+quadratic sum of the variances. VAR_POISSON and VAR_RNOISE represent the uncertainty in the
+computed slopes (per pixel) due to Poisson and read noise, respectively.
+The details of the calculations can be found at :ref:`ramp_fitting <ramp_fitting_step>`.
+
+flat_field
+++++++++++
+The SCI array of the exposure being processed is divided by the flat-field reference
+image, and the VAR_POISSON and VAR_RNOISE arrays are divided by the square of the flat.
+A VAR_FLAT array is created, computed from the science data and the flat-field
+reference file ERR array.
+The science data ERR array is then updated to be the square root of the quadratic sum of
+the three variance arrays.
+For more details see :ref:`flat_field <flatfield_step>`.
+
+photom
+++++++
+The calibration information for the ``photom`` step includes a scalar flux conversion
+constant. Currently the scalar conversion factor or any 2-D
+response values are not applied to the science data, ERR arrays,
+or the variance (VAR_POISSON, VAR_RNOISE, and VAR_FLAT) arrays.
+For details of the photom correction, see :ref:`photom <photom_step>`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
-    asdf>=2.10.0
-    astropy>=5.0
+    git+https://github.com/asdf-format/asdf
+    astropy>=5.04
     crds>=11.9.0
     gwcs>=0.17.0
     jsonschema>=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.10.0
-    astropy>=5.04
+    astropy>=5.0
     crds>=11.9.0
     gwcs>=0.17.0
     jsonschema>=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.10.0
-    astropy>=5.0
+    astropy>=5.04
     crds>=11.9.0
     gwcs>=0.17.0
     jsonschema>=3.0.2
@@ -30,6 +30,7 @@ install_requires =
     pyparsing>=2.2
     requests>=2.22
     roman_datamodels>=0.11.0
+    romanad==0.10.0
     stcal>=0.2.5
     stpipe>=0.3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     asdf>=2.11.0
-    astropy>=5.04
+    astropy>=5.0.4
     crds>=11.9.0
     gwcs>=0.17.0
     jsonschema>=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
-    git+https://github.com/asdf-format/asdf
+    asdf>=2.11.0
     astropy>=5.04
     crds>=11.9.0
     gwcs>=0.17.0


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #20 

Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-46)

**Description**

This PR addresses adds documentation for the error propagation in the ELPP pipeline. 
Currently we have definitions for the errors in ramp fitting and the flat field steps. The
code changes were in other issues. 
Also bump astropy >=5.0.4


Checklist
- [ ] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
