### PR TITLE
new param for saturation, continute to not flag adjacent pixels for now

### DIFF
--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -47,7 +47,7 @@ def flag_saturation(input_model, ref_model):
 
     # Obtain dq arrays updated for saturation
     gdq_new, pdq_new = flag_saturated_pixels(data, gdq, pdq, sat_thresh,
-                                             sat_dq, ATOD_LIMIT, dqflags.pixel)
+                                             sat_dq, ATOD_LIMIT, dqflags.pixel, n_pix_grow_sat=0)
 
     # Save the flags in the output GROUPDQ array
     output_model.groupdq = gdq_new[0, :]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,12 +30,7 @@ install_requires =
     pyparsing>=2.2
     requests>=2.22
     roman_datamodels>=0.11.0
-<<<<<<< HEAD
     stcal>=0.2.5
-=======
-    romanad==0.10.0
-    stcal @  git+https://github.com/cshanahan1/stcal.git@charge_spill_sat_fix
->>>>>>> 8d0c71f... new param for saturation, continute to not flag adjacent pixels for now
     stpipe>=0.3.1
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,12 @@ install_requires =
     pyparsing>=2.2
     requests>=2.22
     roman_datamodels>=0.11.0
+<<<<<<< HEAD
     stcal>=0.2.5
+=======
+    romanad==0.10.0
+    stcal @  git+https://github.com/cshanahan1/stcal.git@charge_spill_sat_fix
+>>>>>>> 8d0c71f... new param for saturation, continute to not flag adjacent pixels for now
     stpipe>=0.3.1
 
 [options.extras_require]


### PR DESCRIPTION
A new parameter to control the flagging of pixels adjacent to saturated pixels was added to stcal [#83]. This PR just maintains NOT flagging adjacent pixels - the tests need to be modified for this and it's needed for JWST, so it can be added later.