### PR TITLE
RCAL-327 Allow Nan's in linearity ref file remove romanad from setup.

### DIFF
--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -40,7 +40,9 @@ class LinearityStep(RomanStep):
                 return result
 
             lin_model = rdd.LinearityRefModel(self.lin_name)
-            lin_coeffs = lin_model.coeffs  # poly coeffs from linearity model
+
+            # copy poly coeffs from linearity model so Nan's can be updated
+            lin_coeffs = lin_model.coeffs.copy()
             lin_dq = lin_model.dq  # 2D pixeldq from linearity model
 
             gdq = input_model.groupdq   # groupdq array of input model
@@ -52,10 +54,11 @@ class LinearityStep(RomanStep):
             output_model.data = output_model.data[np.newaxis, :]
 
             # Call linearity correction function in stcal
-            new_data, new_pdq = linearity_correction(output_model.data, gdq, pdq,
-                                             lin_coeffs, lin_dq, dqflags.pixel)
+            new_data, new_pdq = linearity_correction(output_model.data,
+                                                     gdq, pdq, lin_coeffs,
+                                                     lin_dq, dqflags.pixel)
 
-            output_model.data = new_data[0,:,:,:]
+            output_model.data = new_data[0, :, :, :]
             output_model.pixeldq = new_pdq
 
             # Close the reference file and update the step status

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     pyparsing>=2.2
     requests>=2.22
     roman_datamodels>=0.11.0
-    romanad==0.10.0
     stcal>=0.2.5
     stpipe>=0.3.1
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #472 

Resolves [RCAL-327](https://jira.stsci.edu/browse/RCAL-327)

**Description**

This PR addresses allows NaN's in the linearity reference file to be updated for processing. 
I also took the opportunity to remove romanad from the setup.cfg file. 


Checklist
- [x] Tests

- [N/A] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)

Tests with INS's input files:
>strun romancal.step.LinearityStep test_in_Apr29.asdf --override_linearity='roman_linearity_WFI01.asdf'
2022-04-29 09:54:05,345 - CRDS - ERROR -  Error determining best reference for 'pars-linearitystep'  =   Unknown reference type 'pars-linearitystep'
2022-04-29 09:54:05,346 - stpipe.LinearityStep - INFO - LinearityStep instance created.
2022-04-29 09:54:05,384 - stpipe.LinearityStep - INFO - Step LinearityStep running with args ('test_in_Apr29.asdf',).
2022-04-29 09:54:05,386 - stpipe.LinearityStep - INFO - Step LinearityStep parameters are: {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': True, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': ''}
2022-04-29 09:54:05,483 - stpipe.LinearityStep - INFO - Using Linearity reference file /Users/ddavis/src/Roman/develop/linearity/Apr08_2022/roman_linearity_WFI01.asdf
2022-04-29 09:54:11,432 - stpipe.LinearityStep - INFO - Saved model in test_in_Apr29_linearitystep.asdf
2022-04-29 09:54:11,432 - stpipe.LinearityStep - INFO - Step LinearityStep done
>

The regression tests will fail until CRDS is updated with updated reference files. 