### PR TITLE
RCAL-339 Update photom step to skip spectroscopic data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ linearity
   photom
 ------
 
-- Photom updated to skip updating photometric converstions for spectral data [#]
+- Photom updated to skip updating photometric converstions for spectral data [#498]
 
 - Added photom correction step and unit tests. [#469]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,11 @@ linearity
   photom
 ------
 
- - Added photom correction step and unit tests. [#469]
+- Photom updated to skip updating photometric converstions for spectral data [#]
 
- - Added SOC test for absolute photometric calibration. Tweak logging in photom step. [#479]
+- Added photom correction step and unit tests. [#469]
+
+- Added SOC test for absolute photometric calibration. Tweak logging in photom step. [#479]
 
 
 0.6.0 (2022-03-02)

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -42,8 +42,20 @@ class PhotomStep(RomanStep):
                 self.log.debug(f'Using PHOTOM ref file: {reffile}')
 
                 # Do the correction
-                output_model = photom.apply_photom(input_model, photom_model)
-                output_model.meta.cal_step.photom = 'COMPLETE'
+                if input_model.meta.exposure.type == "WFI_IMAGE":
+                    output_model = photom.apply_photom(input_model,
+                                                       photom_model)
+                    output_model.meta.cal_step.photom = 'COMPLETE'
+                else:
+                    self.log.warning('No photometric corrections for '
+                                     'spectral data')
+                    self.log.warning('Photom step will be skipped')
+                    input_model.meta.cal_step.photom = 'SKIPPED'
+                    try:
+                        photom_model.close()
+                    except AttributeError:
+                        pass
+                    return input_model
 
             else:
                 # Skip Photom step if no photom file

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -208,4 +208,7 @@ def test_photom_step_interface(instrument, exptype):
 
     assert (result.data == wfi_image.data).all()
     assert result.data.shape == shape
-    assert result.meta.cal_step.photom == 'COMPLETE'
+    if exptype == "WFI_IMAGE":
+        assert result.meta.cal_step.photom == 'COMPLETE'
+    else:
+        assert result.meta.cal_step.photom == 'SKIPPED'


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #497 

Resolves [RCAL-339](https://jira.stsci.edu/browse/RCAL-339)

**Description**

This PR allows the photometric constants for spectroscopic data to remain as None as 
we agreed to with INS. 


Checklist
- [x] Tests

- [N/A] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
