### PR TITLE
JP-374: ZEROFRAME processing to STCAL changed function signatures.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ linearity
 
 - Added SOC test for absolute photometric calibration. Tweak logging in photom step. [#479]
 
+saturation
+----------
+
+- Updated the saturation step due to an update in STCCAL. [#500]
 
 0.6.0 (2022-03-02)
 ==================

--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -46,9 +46,11 @@ def flag_saturation(input_model, ref_model):
     sat_dq = ref_model.dq.copy()
 
     # Obtain dq arrays updated for saturation
-    gdq_new, pdq_new = flag_saturated_pixels(data, gdq, pdq, sat_thresh,
-                                             sat_dq, ATOD_LIMIT, dqflags.pixel,
-                                             n_pix_grow_sat=0)
+    # The third variable is the processed ZEROFRAME, which is not
+    # used in romancal, so is always None.
+    gdq_new, pdq_new, _ = flag_saturated_pixels(
+        data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel,
+        n_pix_grow_sat=0)
 
     # Save the flags in the output GROUPDQ array
     output_model.groupdq = gdq_new[0, :]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,8 @@ install_requires =
     pyparsing>=2.4.7
     requests>=2.22
     roman_datamodels>=0.12.2
-    stcal==0.6.4
-    stpipe==0.3.1
+    stcal>=0.7
+    stpipe>=0.3.1
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
…n STCAL.

<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #

Resolves [JP-374](https://jira.stsci.edu/browse/JP-374)

**Description**

The ticket JP-374 got merged into STCAL, but changed a saturation function signature causing failures in romancal.  The function signature in romancal has been updated and the saturation unit tests pass.


Checklist
- [ ] Tests

- [ ] Documentation

- [ ] Change log

- [ ] Milestone

- [ ] Label(s)
