### PR TITLE
Rcal-340 Updates to flat field code to handle no flat for grism data & remove skip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
-0.8.0 (Unreleased)
+0.7.1 (Unreleased)
 ==================
 
 general
 -------
 
-- Update regression tests with new data, remove skips for flat fielding tests, and code cleanup [#]
+- Update regression tests with new data, remove skips for flat fielding tests, and code cleanup [#504]
 
 
 0.7.0 (2022-05-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.8.0 (Unreleased)
 ==================
 
+general
+-------
+
+- Update regression tests with new data, remove skips for flat fielding tests, and code cleanup [#]
 
 
 0.7.0 (2022-05-13)

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -48,7 +48,8 @@ def do_flat_field(output_model, flat_model):
     flat_model : Roman data model
         data model containing flat-field
     """
-    if output_model.data.shape != flat_model.data.shape:
+    if flat_model is not None and \
+            output_model.data.shape != flat_model.data.shape:
         # Check to see if flat data array is smaller than science data
         log.warning('Flat data array is not the same '
                     'shape as the science data')

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -2,10 +2,10 @@
 Flat-field a science image
 """
 
+from crds.core.exceptions import CrdsLookupError
 from ..stpipe import RomanStep
 from . import flat_field
 import roman_datamodels as rdm
-from crds.core.exceptions import CrdsLookupError
 
 __all__ = ["FlatFieldStep"]
 

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -5,6 +5,7 @@ Flat-field a science image
 from ..stpipe import RomanStep
 from . import flat_field
 import roman_datamodels as rdm
+from crds.core.exceptions import CrdsLookupError
 
 __all__ = ["FlatFieldStep"]
 
@@ -20,7 +21,10 @@ class FlatFieldStep(RomanStep):
         input_model = rdm.open(step_input)
         # Get reference file paths
         reference_file_names = {}
-        reffile = self.get_reference_file(input_model, "flat")
+        try:
+            reffile = self.get_reference_file(input_model, "flat")
+        except CrdsLookupError:
+            reffile = None
         reference_file_names['flat'] = reffile if reffile != 'N/A' else None
 
         # Open the relevant reference files as datamodels

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -10,9 +10,9 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
     """ Function to run and compare Jump Detection files. Note: This should
         include tests for overrides etc. """
 
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
-    rtdata.get_data(f"WFI/image/{input_datafile}")
-    rtdata.input = input_datafile
+    input_file = "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
+    rtdata.get_data(f"WFI/image/{input_file}")
+    rtdata.input = input_file
 
     # Note: the thresholds should be reset to the defaults once we have better
     # input data

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -18,9 +18,11 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     output = "r0000101001001001001_01101_0001_WFI01_rampfitstep.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None
 
     output = "rampfit_opt_fitopt.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -10,8 +10,8 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_dq_init_image_step(rtdata, ignore_asdf_paths):
-    # DMS25 Test: Testing retrieval of best ref file for image data,
-    # and creation of a ramp file with CRDS selected mask file applied.
+    """DMS25 Test: Testing retrieval of best ref file for image data,
+       and creation of a ramp file with CRDS selected mask file applied."""
 
     input_file = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
@@ -62,7 +62,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
      and creation of a ramp file with CRDS selected mask file applied."""
 
     input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
-    rtdata.get_data(f"WFI/grism/[input_file]")
+    rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
     # Test CRDS

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -1,3 +1,4 @@
+"""Tests for the DQ Init module and DMS 25 and DMS 26 requirements"""
 import os
 import pytest
 
@@ -12,19 +13,23 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     # DMS25 Test: Testing retrieval of best ref file for image data,
     # and creation of a ramp file with CRDS selected mask file applied.
 
-    rtdata.get_data("WFI/image/r0000101001001001001_01101_0001_WFI01_uncal.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    rtdata.get_data(f"WFI/image/{input_file}")
+    rtdata.input = input_file
 
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info('DMS25 MSG: Testing retrieval of best ref file for image data, '
+    step.log.info('DMS25 MSG: Testing retrieval of best '
+                  'ref file for image data, '
                   'Success is creation of a ramp file with CRDS selected '
                   'mask file applied.')
 
-    step.log.info(f'DMS25 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info('DMS25 MSG: First data file: '
+                  f'{rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(f'DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info('DMS25 MSG: CRDS matched mask file: '
+                  f'{ref_file_path.rsplit("/", 1)[1]}')
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -38,15 +43,17 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
                   ' not having been implemented yet.')
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(f'DMS25 MSG: Does ramp data contain pixeldq from mask file? : '
+    step.log.info(f'DMS25 MSG: Does ramp data contain '
+                  'pixeldq from mask file? : '
                   f'{("roman.pixeldq" in ramp_out.to_flat_dict())}')
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    step.log.info(f'DMS25 MSG: Was the proper data quality array initialized'
+    step.log.info('DMS25 MSG: Was the proper data quality array initialized'
                   ' for the ramp data produced? : '
                   f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
@@ -54,18 +61,23 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     """DMS26 Test: Testing retrieval of best ref file for grism data,
      and creation of a ramp file with CRDS selected mask file applied."""
 
-    rtdata.get_data("WFI/grism/r0000101001001001001_01102_0001_WFI01_uncal.asdf")
-    rtdata.input = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
+    input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
+    rtdata.get_data(f"WFI/grism/[input_file]")
+    rtdata.input = input_file
 
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info('DMS26 MSG: Testing retrieval of best ref file for grism data, '
-                  'Success is creation of a ramp file with CRDS selected mask file applied.')
+    step.log.info('DMS26 MSG: Testing retrieval of best '
+                  'ref file for grism data, '
+                  'Success is creation of a ramp file with CRDS selected '
+                  'mask file applied.')
 
-    step.log.info(f'DMS26 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS26 MSG: First data file: '
+                  f'{rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(f'DMS26 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS26 MSG: CRDS matched mask file: '
+                  f'{ref_file_path.rsplit("/", 1)[1]}')
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -79,11 +91,14 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
                   'not having been implemented yet.')
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(f'DMS26 MSG: Does ramp data contain pixeldq from mask file? : '
+    step.log.info('DMS26 MSG: Does ramp data contain pixeldq '
+                  'from mask file? : '
                   f'{("roman.pixeldq" in ramp_out.to_flat_dict())}')
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    step.log.info(f'DMS26 MSG: Was proper data quality initialized ramp data produced? : '
+    step.log.info('DMS26 MSG: Was proper data quality initialized '
+                  'ramp data produced? : '
                   f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 import roman_datamodels as rdm
+from crds.core.exceptions import CrdsLookupError
 from romancal.stpipe import RomanStep
 from romancal.step import FlatFieldStep
 from .regtestdata import compare_asdf
@@ -33,7 +34,9 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
-    """Test for the flat field step using grism data."""
+    """Test for the flat field step using grism data. The reference file for
+       the grism and prism data should be None, only testing the grism
+       case here."""
 
     input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
@@ -42,9 +45,12 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     # Test CRDS
     step = FlatFieldStep()
     model = rdm.open(rtdata.input)
-    ref_file_path = step.get_reference_file(model, "flat")
-    ref_file_name = os.path.split(ref_file_path)[-1]
-    assert "roman_wfi_flat" in ref_file_name
+    try:
+        ref_file_path = step.get_reference_file(model, "flat")
+        ref_file_name = os.path.split(ref_file_path)[-1]
+    except CrdsLookupError:
+        ref_file_name = None
+    assert ref_file_name is None
 
     # Test FlatFieldStep
     output = "r0000201001001001002_01101_0001_WFI01_flat.asdf"

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -38,7 +38,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
        the grism and prism data should be None, only testing the grism
        case here."""
 
-    input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -31,13 +31,13 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
                         **ignore_asdf_paths) is None
 
 
-@pytest.mark.skip(reason="There are no grism flats.")
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using grism data."""
 
-    rtdata.get_data("WFI/grism/l2_0005_grism_rate.asdf")
-    rtdata.input = "l2_0005_grism_rate.asdf"
+    input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
+    rtdata.get_data(f"WFI/grism/{input_file}")
+    rtdata.input = input_file
 
     # Test CRDS
     step = FlatFieldStep()
@@ -47,7 +47,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_flat" in ref_file_name
 
     # Test FlatFieldStep
-    output = "l2_0005_grism_rate_flat.asdf"
+    output = "r0000201001001001002_01101_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -9,6 +9,7 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_flat_field_image_step(rtdata, ignore_asdf_paths):
+    """Test for the flat field step using imaging data."""
 
     input_data = "r0000101001001001001_01101_0001_WFI01_rampfitstep.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
@@ -26,12 +27,14 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None
 
 
 @pytest.mark.skip(reason="There are no grism flats.")
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
+    """Test for the flat field step using grism data."""
 
     rtdata.get_data("WFI/grism/l2_0005_grism_rate.asdf")
     rtdata.input = "l2_0005_grism_rate.asdf"
@@ -49,14 +52,15 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+                         **ignore_asdf_paths) is None)
 
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
-    # DMS79 Test: Testing that different datetimes pull different
-    # flat files and successfully make level 2 output
+    """DMS79 Test: Testing that different datetimes pull different
+       flat files and successfully make level 2 output"""
 
     # First file
     input_l2_file = "r0000101001001001001_01101_0001_WFI01_assign_wcs.asdf"
@@ -92,9 +96,11 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
 
-    step.log.info(f'DMS79 MSG: Was proper flat fielded Level 2 data produced? : '
+    step.log.info('DMS79 MSG: Was proper flat fielded '
+                  'Level 2 data produced? : '
                   f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None
 
     # This test requires a second file, in order to meet the DMS79 requirement.
     # The test will show that two files with different observation dates match
@@ -131,13 +137,16 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
                   'implemented yet.')
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    step.log.info(f'DMS79 MSG: Was proper flat fielded Level 2 data produced? : '
+    step.log.info('DMS79 MSG: Was proper flat fielded '
+                  'Level 2 data produced? : '
                   f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None
 
     # Test differing flat matches
-    step.log.info(f'DMS79 MSG REQUIRED TEST: Are the two data files matched to different '
-                  f'flat files? : '
-                  f'{("/".join(ref_file_path.rsplit("/", 3)[1:])) != ("/".join(ref_file_path_b.rsplit("/", 3)[1:]))}')
+    step.log.info('DMS79 MSG REQUIRED TEST: Are the two data files '
+                  'matched to different flat files? : '
+                  f'{("/".join(ref_file_path.rsplit("/", 3)[1:]))} != '
+                  f'{("/".join(ref_file_path_b.rsplit("/", 3)[1:]))}')
     assert ("/".join(ref_file_path.rsplit("/", 1)[1:])) != \
            ("/".join(ref_file_path_b.rsplit("/", 1)[1:]))

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -1,33 +1,39 @@
+"""Regression tests for the photom step of the Roman pipeline"""
+import math
 import pytest
 
 import roman_datamodels as rdm
+from astropy import units as u
 from romancal.stpipe import RomanStep
 from romancal.step import PhotomStep
 from .regtestdata import compare_asdf
-from astropy import units as u
-import math
 
 
 @pytest.mark.bigdata
 def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
-    # DMS140 Test: Testing application of photometric correction using CRDS selected photom file.
+    """DMS140 Test: Testing application of photometric correction using
+       CRDS selected photom file."""
 
-    rtdata.get_data("WFI/image/r0000201001001001001_01101_0001_WFI01_cal.asdf")
-    rtdata.input = "r0000201001001001001_01101_0001_WFI01_cal.asdf"
+    input_data = "r0000201001001001001_01101_0001_WFI01_cal.asdf"
+    rtdata.get_data(f"WFI/image/{input_data}")
+    rtdata.input = input_data
 
     # Define step (for running and log access)
     step = PhotomStep()
 
-    #  In Wide Field Imaging mode, the DMS shall generate Level 2 science data products with
-    #  absolute photometry calibrated in the WFI filter used for the exposure.
-    step.log.info('DMS140 MSG: Testing absolute photometric calibrated image data. '
-                  'Success is creation of a Level 2 image file with CRDS selected '
-                  'photom file applied.')
+    #  In Wide Field Imaging mode, the DMS shall generate Level 2 science
+    # data products with absolute photometry calibrated in the WFI filter
+    # used for the exposure.
+    step.log.info('DMS140 MSG: Testing absolute photometric '
+                  'calibrated image data. '
+                  'Success is creation of a Level 2 image file with '
+                  'CRDS selected photom file applied.')
 
-    step.log.info(f'DMS140 MSG: Image data file: {rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info('DMS140 MSG: Image data file: '
+                  f'{rtdata.input.rsplit("/", 1)[1]}')
 
-    # Note: if any of the following tests fail, check for a different photom match from CRDS.
-    # Values come from roman_wfi_photom_0034.asdf
+    # Note: if any of the following tests fail, check for a different
+    # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
 
     # Test PhotomStep
     output = "r0000201001001001001_01101_0001_WFI01_cal_photomstep.asdf"
@@ -100,4 +106,5 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     rtdata.get_truth(f"truth/WFI/image/{output}")
     step.log.info(f'DMS140 MSG: Was the proper absolute photometry calibrated image data produced?'
                   f' : {(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -18,7 +18,6 @@ def passfail(bool_expr):
     return "Fail"
 
 
-#@pytest.mark.skip(reason="CRDS flat error.")
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
@@ -169,7 +168,6 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
                     model.meta.wcs(2048, 2048), atol=1.0)
 
 
-#@pytest.mark.skip(reason="CRDS flat error.")
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -1,19 +1,21 @@
+""" Tests for the saturation step"""
 import os
 import pytest
 
+import roman_datamodels as rdm
 from romancal.stpipe import RomanStep
 from romancal.step import SaturationStep
-import roman_datamodels as rdm
 from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
 def test_saturation_image_step(rtdata, ignore_asdf_paths):
-    # Testing retrieval of best ref file for image data,
-    # and creation of a ramp file with CRDS selected saturation file applied.
+    """ Testing retrieval of best ref file for image data,
+    and creation of a ramp file with CRDS selected saturation file applied. """
 
-    rtdata.get_data("WFI/image/r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf"
+    input_file = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    rtdata.get_data(r"WFI/image/{input_file}")
+    rtdata.input = input_file
 
     # Test CRDS
     step = SaturationStep()
@@ -32,19 +34,21 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
 
     ramp_out = rdm.open(rtdata.output)
-    assert ("roman.pixeldq" in ramp_out.to_flat_dict())
+    assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)
+    assert (compare_asdf(rtdata.output, rtdata.truth,
+            **ignore_asdf_paths) is None)
 
 
 @pytest.mark.bigdata
 def test_saturation_grism_step(rtdata, ignore_asdf_paths):
-    # Testing retrieval of best ref file for grism data,
-    # and creation of a ramp file with CRDS selected saturation file applied.
+    """ Testing retrieval of best ref file for grism data,
+     and creation of a ramp file with CRDS selected saturation file applied."""
 
-    rtdata.get_data("WFI/grism/r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf")
-    rtdata.input = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    input_file = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    rtdata.get_data(f"WFI/grism/{input_file}")
+    rtdata.input = input_file
 
     # Test CRDS
     step = SaturationStep()
@@ -66,4 +70,5 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth,
+                        **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -14,7 +14,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     and creation of a ramp file with CRDS selected saturation file applied. """
 
     input_file = "r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf"
-    rtdata.get_data(r"WFI/image/{input_file}")
+    rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
     # Test CRDS

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -13,7 +13,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     """ Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected saturation file applied. """
 
-    input_file = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    input_file = "r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf"
     rtdata.get_data(r"WFI/image/{input_file}")
     rtdata.input = input_file
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #502 

Resolves [RCAL-340](https://jira.stsci.edu/browse/RCAL-340)

**Description**

This PR updates to flat field code to handle the case of grism observations with no flat field reference files and removes the skip so that DMS-86, 87, 90, & 91 are covered. 
The results of the regression tests can be found at
https://plwishmaster.stsci.edu:8081/me/my-views/view/all/job/RT/job/Roman-Developers-Pull-Requests/12/

Checklist
- [x] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
