### PR TITLE
Rcal 346 spec photom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@
 photom
 ------
 
-- Adds explicit test that photometric keywords are preserved for spectroscopic data
-  .
+- Adds explicit test that photometric keywords are preserved for spectroscopic data. [#513]
+  
 
 0.7.1 (2022-05-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.7.2 (unreleased)
 ==================
 
+photom
+------
+
+- Adds explicit test that photometric keywords are preserved for spectroscopic data
+  .
+
 0.7.1 (2022-05-19)
 ==================
 

--- a/romancal/photom/photom.py
+++ b/romancal/photom/photom.py
@@ -22,38 +22,23 @@ def photom_io(input_model, photom_metadata):
     -------
 
     """
+    # Get the scalar conversion factor.
+    conversion = photom_metadata['photmjsr']  # unit is MJy / sr
 
-    # Check for spectroscopic or dark data (which lack conversion
-    # values in the photom reference file)
-    if input_model.meta.instrument.optical_element.upper() in ("PRISM", "GRISM", "DARK"):
-        # Store the conversion factor in the meta data
-        log.info(f'photmjsr value: None')
-        input_model.meta.photometry.conversion_megajanskys = None
-        input_model.meta.photometry.conversion_microjanskys = None
+    # Store the conversion factor in the meta data
+    log.info(f'photmjsr value: {conversion:.6g}')
+    input_model.meta.photometry.conversion_megajanskys = conversion
+    input_model.meta.photometry.conversion_microjanskys = conversion.to(
+        u.microjansky / u.arcsecond ** 2)
 
-        # Store the uncertainty conversion factor in the meta data
-        log.info(f'uncertainty value: None')
-        input_model.meta.photometry.conversion_megajanskys_uncertainty = None
-        input_model.meta.photometry.conversion_microjanskys_uncertainty = None
+    # Get the scalar conversion uncertainty factor
+    uncertainty_conv = photom_metadata['uncertainty']
 
-    else:
-        # Get the scalar conversion factor.
-        conversion = photom_metadata['photmjsr']  # unit is MJy / sr
-
-        # Store the conversion factor in the meta data
-        log.info(f'photmjsr value: {conversion:.6g}')
-        input_model.meta.photometry.conversion_megajanskys = conversion
-        input_model.meta.photometry.conversion_microjanskys = conversion.to(
-            u.microjansky / u.arcsecond ** 2)
-
-        # Get the scalar conversion uncertainty factor
-        uncertainty_conv = photom_metadata['uncertainty']
-
-        # Store the uncertainty conversion factor in the meta data
-        log.info(f'uncertainty value: {uncertainty_conv:.6g}')
-        input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
-        input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(
-            u.microjansky / u.arcsecond ** 2)
+    # Store the uncertainty conversion factor in the meta data
+    log.info(f'uncertainty value: {uncertainty_conv:.6g}')
+    input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
+    input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(
+        u.microjansky / u.arcsecond ** 2)
 
     # Return updated input model
     return input_model

--- a/romancal/photom/photom.py
+++ b/romancal/photom/photom.py
@@ -22,23 +22,38 @@ def photom_io(input_model, photom_metadata):
     -------
 
     """
-    # Get the scalar conversion factor.
-    conversion = photom_metadata['photmjsr']  # unit is MJy / sr
 
-    # Store the conversion factor in the meta data
-    log.info(f'photmjsr value: {conversion:.6g}')
-    input_model.meta.photometry.conversion_megajanskys = conversion
-    input_model.meta.photometry.conversion_microjanskys = conversion.to(
-        u.microjansky / u.arcsecond ** 2)
+    # Check for spectroscopic or dark data (which lack conversion
+    # values in the photom reference file)
+    if input_model.meta.instrument.optical_element.upper() in ("PRISM", "GRISM", "DARK"):
+        # Store the conversion factor in the meta data
+        log.info(f'photmjsr value: None')
+        input_model.meta.photometry.conversion_megajanskys = None
+        input_model.meta.photometry.conversion_microjanskys = None
 
-    # Get the scalar conversion uncertainty factor
-    uncertainty_conv = photom_metadata['uncertainty']
+        # Store the uncertainty conversion factor in the meta data
+        log.info(f'uncertainty value: None')
+        input_model.meta.photometry.conversion_megajanskys_uncertainty = None
+        input_model.meta.photometry.conversion_microjanskys_uncertainty = None
 
-    # Store the uncertainty conversion factor in the meta data
-    log.info(f'uncertainty value: {uncertainty_conv:.6g}')
-    input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
-    input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(
-        u.microjansky / u.arcsecond ** 2)
+    else:
+        # Get the scalar conversion factor.
+        conversion = photom_metadata['photmjsr']  # unit is MJy / sr
+
+        # Store the conversion factor in the meta data
+        log.info(f'photmjsr value: {conversion:.6g}')
+        input_model.meta.photometry.conversion_megajanskys = conversion
+        input_model.meta.photometry.conversion_microjanskys = conversion.to(
+            u.microjansky / u.arcsecond ** 2)
+
+        # Get the scalar conversion uncertainty factor
+        uncertainty_conv = photom_metadata['uncertainty']
+
+        # Store the uncertainty conversion factor in the meta data
+        log.info(f'uncertainty value: {uncertainty_conv:.6g}')
+        input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
+        input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(
+            u.microjansky / u.arcsecond ** 2)
 
     # Return updated input model
     return input_model

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -179,52 +179,6 @@ def test_apply_photom2():
     assert (np.allclose(output_model.data[iy, ix], input_model.data[iy, ix], rtol=1.e-7))
 
 
-def test_apply_photom_spectroscopic():
-    """Test apply_photom properly populates photometric keywords for spectroscopic data"""
-
-    # Create sample WFI Level 2 science datamodel
-    input_model = testutil.mk_level2_image()
-
-    # Create photom reference datamodel
-    photom_model = create_photom_wfi_image(min_r=3.1, delta=0.1)
-
-    # Select optical element
-    input_model.meta.instrument.optical_element = "PRISM"
-
-    print("\n")
-    print("XXX input_model.meta.photometry = "+str(input_model.meta.photometry))
-
-    # Apply photom correction for optical element W146
-    output_model = photom.apply_photom(input_model, photom_model)
-
-    # Select pixel for comparison
-    shape = input_model.data.shape
-    ix = shape[1] // 2
-    iy = shape[0] // 2
-
-    # Test that the data has not changed
-    assert (np.allclose(output_model.data[iy, ix], input_model.data[iy, ix], rtol=1.e-7))
-
-    # Test that keywords are properly populated
-    assert output_model.meta.photometry.conversion_megajanskys is None
-    assert output_model.meta.photometry.conversion_microjanskys is None
-    assert output_model.meta.photometry.conversion_megajanskys_uncertainty is None
-    assert output_model.meta.photometry.conversion_microjanskys_uncertainty is None
-
-    # Set reference pixel areas
-    area_ster = 2.31307642258977E-14 * u.steradian
-    area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
-
-    # Tests for pixel areas
-    assert(np.isclose(output_model.meta.photometry.pixelarea_steradians.value,
-                        area_ster.value, atol=1.e-7))
-    assert output_model.meta.photometry.pixelarea_steradians.unit == area_ster.unit
-    assert(np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value,
-                        area_a2.value, atol=1.e-7))
-    assert output_model.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit
-
-
-
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
@@ -249,8 +203,6 @@ def test_photom_step_interface(instrument, exptype):
     photom = testutil.mk_wfi_img_photom()
     photom_model = WfiImgPhotomRefModel(photom)
 
-    photom_model
-
     # Run photom correction step
     result = PhotomStep.call(wfi_image_model, override_photom=photom_model)
 
@@ -260,3 +212,66 @@ def test_photom_step_interface(instrument, exptype):
         assert result.meta.cal_step.photom == 'COMPLETE'
     else:
         assert result.meta.cal_step.photom == 'SKIPPED'
+
+
+@pytest.mark.parametrize(
+    "instrument, exptype",
+    [
+        ("WFI", "WFI_PRISM"),
+    ]
+)
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Roman CRDS servers are not currently available outside the internal network"
+)
+def test_photom_step_interface_spectroscopic(instrument, exptype):
+    """Test apply_photom properly populates photometric keywords for spectroscopic data"""
+
+    # Create a small area for the file
+    shape = (20, 20)
+
+    # Create input node
+    wfi_image = testutil.mk_level2_image(shape=shape)
+
+    # Select exposure type and optical element
+    wfi_image.meta.exposure.type = "WFI_PRISM"
+    wfi_image.meta.instrument.optical_element = "PRISM"
+
+    # Set photometric values for spectroscopic data
+    wfi_image.meta.photometry.pixelarea_steradians = 2.31307642258977E-14 * u.steradian
+    wfi_image.meta.photometry.pixelarea_arcsecsq = 0.000984102303070964 * u.arcsecond * u.arcsecond
+    wfi_image.meta.photometry.conversion_megajanskys = None
+    wfi_image.meta.photometry.conversion_megajanskys_uncertainty = None
+    wfi_image.meta.photometry.conversion_microjanskys = None
+    wfi_image.meta.photometry.conversion_microjanskys_uncertainty = None
+
+    # Create input model
+    wfi_image_model = ImageModel(wfi_image)
+
+    # Create photom model
+    photom = testutil.mk_wfi_img_photom()
+    photom_model = WfiImgPhotomRefModel(photom)
+
+    # Run photom correction step
+    result = PhotomStep.call(wfi_image_model, override_photom=photom_model)
+
+    # Test that the data has not changed
+    assert (np.allclose(result.data, wfi_image_model.data, rtol=1.e-7))
+
+    # Test that keywords are properly preserved
+    assert result.meta.photometry.conversion_megajanskys is None
+    assert result.meta.photometry.conversion_microjanskys is None
+    assert result.meta.photometry.conversion_megajanskys_uncertainty is None
+    assert result.meta.photometry.conversion_microjanskys_uncertainty is None
+
+    # Set reference pixel areas
+    area_ster = 2.31307642258977E-14 * u.steradian
+    area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
+
+    # Tests for pixel areas
+    assert(np.isclose(result.meta.photometry.pixelarea_steradians.value,
+                        area_ster.value, atol=1.e-7))
+    assert result.meta.photometry.pixelarea_steradians.unit == area_ster.unit
+    assert(np.isclose(result.meta.photometry.pixelarea_arcsecsq.value,
+                        area_a2.value, atol=1.e-7))
+    assert result.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #

Resolves [RCAL-346](https://jira.stsci.edu/browse/RCAL-346)

**Description**

This PR explicitly test that photometric keywords are populated with none for GRISM, PRISM, and DARK.


Checklist
- [x] Tests

- [ ] Documentation

- [x] Change log

- [ ] Milestone

- [x] Label(s)
