### PR TITLE
RCAL-330: Change Reference Datamodel Storage Type in Steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.7.2 (unreleased)
 ==================
 
+general
+-------
+
+- Simplified reference file name and model storage in dq and flat steps. [#514]
+
 photom
 ------
 

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -63,24 +63,20 @@ class DQInitStep(RomanStep):
         else:
             init_model = input_model
 
-        # Get reference file paths
-        reference_file_names = {}
-        reffile = self.get_reference_file(init_model, "mask")
-        reference_file_names['mask'] = reffile if reffile != 'N/A' else None
+        # Get reference file path
+        reference_file_name = self.get_reference_file(init_model, "mask")
 
-        # Open the relevant reference files as datamodels
-        reference_file_models = {}
-
-        # Test for reference files
-        if reffile is not None:
+        # Test for reference file
+        if reference_file_name is not None:
             # If there are mask files, perform dq step
-            reference_file_models['mask'] = rdm.open(reffile)
-            self.log.debug(f'Using MASK ref file: {reffile}')
+            # Open the relevant reference files as datamodels
+            reference_file_model = rdm.open(reference_file_name)
+            self.log.debug(f'Using MASK ref file: {reference_file_name}')
 
             # Apply the DQ step
             output_model = dq_initialization.do_dqinit(
                 init_model,
-                **reference_file_models,
+                reference_file_model,
             )
 
             # copy original border reference file arrays (data and dq)
@@ -100,7 +96,7 @@ class DQInitStep(RomanStep):
 
         else:
             # Skip DQ step if no mask files
-            reference_file_models['mask'] = None
+            reference_file_model = None
             self.log.warning('No MASK reference file found.')
             self.log.warning('DQ initialization step will be skipped.')
 
@@ -112,8 +108,7 @@ class DQInitStep(RomanStep):
         input_model.close()
         init_model.close()
         try:
-            for model in reference_file_models.values():
-                model.close()
+            reference_file_model.close()
         except AttributeError:
             pass
 

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -19,35 +19,30 @@ class FlatFieldStep(RomanStep):
     def process(self, step_input):
 
         input_model = rdm.open(step_input)
+
         # Get reference file paths
-        reference_file_names = {}
         try:
-            reffile = self.get_reference_file(input_model, "flat")
+            reference_file_name = self.get_reference_file(input_model, "flat")
         except CrdsLookupError:
-            reffile = None
-        reference_file_names['flat'] = reffile if reffile != 'N/A' else None
+            reference_file_name = None
 
-        # Open the relevant reference files as datamodels
-        reference_file_models = {}
-
-        if reffile is not None:
-            reference_file_models['flat'] = rdm.open(reffile)
-            self.log.debug(f'Using FLAT ref file: {reffile}')
+        if reference_file_name is not None:
+            reference_file_model = rdm.open(reference_file_name)
+            self.log.debug(f'Using FLAT ref file: {reference_file_name}')
         else:
-            reference_file_models['flat'] = None
+            reference_file_model = None
             self.log.debug('Using FLAT ref file')
 
         # Do the flat-field correction
         output_model = flat_field.do_correction(
             input_model,
-            **reference_file_models,
+            reference_file_model,
         )
 
         # Close the input and reference files
         input_model.close()
         try:
-            for model in reference_file_models.values():
-                model.close()
+            reference_file_model.close()
         except AttributeError:
             pass
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #478 

Resolves [RCAL-330](https://jira.stsci.edu/browse/RCAL-330)

**Description**

This PR simplified reference file name and model storage in dq and flat steps. (Changing them from lists to single variables and removing the list traversal code.)

Checklist
- [x] Tests

- [ ] Documentation

- [x] Change log

- [ ] Milestone

- [x] Label(s)
