### PR TITLE
rcal-310 Update code to update suffixes, update regtests for the new names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ assign_wcs
 
 - Add distortion transform to assign_wcs step. [#510]
 
+general
+-------
+
+- Update pipeline steps to define the default suffix when saving the step results [#455]
+
 photom
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ photom
 ------
 
 - Adds explicit test that photometric keywords are preserved for spectroscopic data. [#513]
-  
+
 
 0.7.1 (2022-05-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ assign_wcs
 general
 -------
 
-- Update pipeline steps to define the default suffix when saving the step results [#455]
+- Update pipeline steps to define the default suffix when saving the step results [#521]
 
 photom
 ------

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0033.pmap",
+    "CRDS_CONTEXT=roman_0034.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0032.pmap",
+    "CRDS_CONTEXT=roman_0033.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0034.pmap",
+    "CRDS_CONTEXT=roman_0036.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0033.pmap",
+    "CRDS_CONTEXT=roman_0034.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0032.pmap",
+    "CRDS_CONTEXT=roman_0033.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0034.pmap",
+    "CRDS_CONTEXT=roman_0036.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/spacetelescope/romancal
 git+https://github.com/spacetelescope/roman_datamodels
-git+https://github.com/spacetelescope/stpipe
+git+https://github.com/spacetelescope/stpipe@0.3.1
 git+https://github.com/spacetelescope/stcal
 git+https://github.com/spacetelescope/stdatamodels

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -5,5 +5,5 @@
 #
 # Add a CRDS context number for the delivery as a record here
 #
-# CRDS_CONTEXT = roman_0032.pmap
+# CRDS_CONTEXT = roman_0033.pmap
 #

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -37,7 +37,7 @@ class AssignWcsStep(RomanStep):
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
             log.debug(f'reference files used in assign_wcs: {reference_file_names}')
-            result = load_wcs(input_model, reference_file_names)
+            result = load_wcs(input_model.copy(), reference_file_names)
 
         if self.save_results:
             try:

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -37,7 +37,7 @@ class AssignWcsStep(RomanStep):
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
             log.debug(f'reference files used in assign_wcs: {reference_file_names}')
-            result = load_wcs(input_model.copy(), reference_file_names)
+            result = load_wcs(input_model, reference_file_names)
 
         if self.save_results:
             try:
@@ -96,6 +96,7 @@ def load_wcs(input_model, reference_files=None):
     output_model.meta.cal_step['assign_wcs'] = 'COMPLETE'
 
     return output_model
+
 
 def wfi_distortion(model, reference_files):
     """

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -38,6 +38,13 @@ class AssignWcsStep(RomanStep):
                 reference_file_names[reftype] = reffile if reffile else ""
             log.debug(f'reference files used in assign_wcs: {reference_file_names}')
             result = load_wcs(input_model, reference_file_names)
+
+        if self.save_results:
+            try:
+                self.suffix = 'assignwcs'
+            except AttributeError:
+                self['suffix'] = 'assignwcs'
+
         return result
 
 

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -65,6 +65,11 @@ class DarkCurrentStep(RomanStep):
             # Convert data to RampModel
             out_ramp = dark_output_data_as_ramp_model(out_data, input_model)
 
+        if self.save_results:
+            try:
+                self.suffix = 'darkcurrent'
+            except AttributeError:
+                self['suffix'] = 'darkcurrent'
             dark_model.close()
 
         return out_ramp

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -10,6 +10,7 @@ from roman_datamodels.testing import utils as testutil
 
 __all__ = ["DQInitStep"]
 
+
 class DQInitStep(RomanStep):
     """Initialize the Data Quality extension from the
     mask reference file.
@@ -21,7 +22,6 @@ class DQInitStep(RomanStep):
     is bitwise OR'd with the pixeldq (or dq) attribute of the
     input model.
     """
-
 
     reference_file_types = ['mask']
 
@@ -50,9 +50,9 @@ class DQInitStep(RomanStep):
             for key in input_model.keys():
                 # If a dictionary (like meta), overwrite entires (but keep
                 # required dummy entries that may not be in input_model)
-                if isinstance(input_ramp[key],dict):
+                if isinstance(input_ramp[key], dict):
                     input_ramp[key].update(input_model.__getattr__(key))
-                elif isinstance(input_ramp[key],np.ndarray):
+                elif isinstance(input_ramp[key], np.ndarray):
                     # Cast input ndarray as RampModel dtype
                     input_ramp[key] = input_model.__getattr__(key).astype(input_ramp[key].dtype)
                 else:

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -117,4 +117,10 @@ class DQInitStep(RomanStep):
         except AttributeError:
             pass
 
+        if self.save_results:
+            try:
+                self.suffix = 'dq_init'
+            except AttributeError:
+                self['suffix'] = 'dq_init'
+
         return output_model

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -119,8 +119,8 @@ class DQInitStep(RomanStep):
 
         if self.save_results:
             try:
-                self.suffix = 'dq_init'
+                self.suffix = 'dqinit'
             except AttributeError:
-                self['suffix'] = 'dq_init'
+                self['suffix'] = 'dqinit'
 
         return output_model

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -26,16 +26,15 @@ class FlatFieldStep(RomanStep):
         except CrdsLookupError:
             reference_file_name = None
 
-
         # Check for a valid reference file
-        if reffile == 'N/A':
+        if reference_file_name == 'N/A':
             self.log.warning('No Flat reference file found')
             self.log.warning('Flat Field step will be skipped')
-            reffile = None
+            reference_file_name = None
 
-        if reffile is not None:
-            reference_file_models['flat'] = rdm.open(reffile)
-            self.log.debug(f'Using FLAT ref file: {reffile}')
+        if reference_file_name is not None:
+            reference_file_model = rdm.open(reference_file_name)
+            self.log.debug(f'Using FLAT ref file: {reference_file_name}')
         else:
             reference_file_model = None
             self.log.debug('Using FLAT ref file')

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -30,6 +30,12 @@ class FlatFieldStep(RomanStep):
         # Open the relevant reference files as datamodels
         reference_file_models = {}
 
+        # Check for a valid reference file
+        if reffile == 'N/A':
+            self.log.warning('No Flat reference file found')
+            self.log.warning('Flat Field step will be skipped')
+            reffile = None
+
         if reffile is not None:
             reference_file_models['flat'] = rdm.open(reffile)
             self.log.debug(f'Using FLAT ref file: {reffile}')

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -76,8 +76,8 @@ def test_crds_temporal_match(instrument, exptype):
     wfi_image.meta.instrument.detector = 'WFI01'
     wfi_image.meta.instrument.optical_element = 'F158'
 
-    wfi_image.meta.exposure.start_time = Time('2020-01-01T11:11:11.110')
-    wfi_image.meta.exposure.end_time = Time('2020-01-01T11:33:11.110')
+    wfi_image.meta.exposure.start_time = Time('2020-01-02T11:11:11.110')
+    wfi_image.meta.exposure.end_time = Time('2020-01-02T11:33:11.110')
 
     wfi_image.meta.exposure.type = exptype
     wfi_image_model = ImageModel(wfi_image)
@@ -85,8 +85,8 @@ def test_crds_temporal_match(instrument, exptype):
     step = FlatFieldStep()
     ref_file_path = step.get_reference_file(wfi_image_model, "flat")
 
-    wfi_image_model.meta.exposure.start_time = Time('2021-08-11T11:11:11.110')
-    wfi_image_model.meta.exposure.end_time = Time('2021-08-11T11:33:11.110')
+    wfi_image_model.meta.exposure.start_time = Time('2021-09-01T00:11:11.110')
+    wfi_image_model.meta.exposure.end_time = Time('2021-09-01T00:33:11.110')
     ref_file_path_b = step.get_reference_file(wfi_image_model, "flat")
     assert ("/".join(ref_file_path.rsplit("/", 1)[1:])) != \
            ("/".join(ref_file_path_b.rsplit("/", 1)[1:]))
@@ -110,8 +110,8 @@ def test_spectroscopic_skip(instrument, exptype):
     wfi_image.meta.instrument.detector = 'WFI01'
     wfi_image.meta.instrument.optical_element = 'F158'
 
-    wfi_image.meta.exposure.start_time = Time('2020-01-01T11:11:11.110')
-    wfi_image.meta.exposure.end_time = Time('2020-01-01T11:33:11.110')
+    wfi_image.meta.exposure.start_time = Time('2020-02-01T00:00:00.000')
+    wfi_image.meta.exposure.end_time = Time('2020-02-01T00:00:05.000')
 
     wfi_image.meta.exposure.type = exptype
     wfi_image_model = ImageModel(wfi_image)

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -129,4 +129,9 @@ class JumpStep(RomanStep):
 
         result.meta.cal_step.jump = 'COMPLETE'
 
+        if self.save_results:
+            try:
+                self.suffix = 'jump'
+            except AttributeError:
+                self['suffix'] = 'jump'
         return result

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -35,6 +35,7 @@ logger.addHandler(logging.NullHandler())
 # add to the result it produces.
 SUFFIXES_TO_ADD = [
     'ca', 'crf',
+    'cal',
     'dark',
     'flat',
     'median',

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -36,16 +36,22 @@ logger.addHandler(logging.NullHandler())
 SUFFIXES_TO_ADD = [
     'ca', 'crf',
     'dark',
+    'flat',
     'median',
     'phot',
+    'photom',
     'ramp', 'rate',
     'uncal',
+    'assignwcs',
     'dq_init',
+    'dqinit',
     'assign_wcs',
     'linearity',
     'jump',
     'rampfit',
-    'dark_current'
+    'saturation',
+    'dark_current',
+    'darkcurrent'
 ]
 
 # Suffixes that are discovered but should not be considered.

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -67,4 +67,9 @@ class LinearityStep(RomanStep):
             lin_model.close()
             output_model.meta.cal_step['linearity'] = 'COMPLETE'
 
+        if self.save_results:
+            try:
+                self.suffix = 'linearity'
+            except AttributeError:
+                self['suffix'] = 'linearity'
         return output_model

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -71,4 +71,10 @@ class PhotomStep(RomanStep):
         except AttributeError:
             pass
 
+        if self.save_results:
+            try:
+                self.suffix = 'photom'
+            except AttributeError:
+                self['suffix'] = 'photom'
+
         return output_model

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -170,5 +170,10 @@ class RampFitStep(RomanStep):
             out_model = create_image_model(input_model, image_info)
             out_model.meta.cal_step.ramp_fit = 'COMPLETE'
 
+        if self.save_results:
+            try:
+                self.suffix = 'rampfit'
+            except AttributeError:
+                self['suffix'] = 'rampfit'
 
         return out_model

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -70,14 +70,14 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
     dark_output_name = \
-        "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
+        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
 
     args = ["romancal.step.DarkCurrentStep",
             rtdata.input,
             f"--dark_output={dark_output_name}"]
     RomanStep.from_cmdline(args)
     output =\
-        "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
+        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -54,7 +54,7 @@ def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
     args = ["romancal.step.DarkCurrentStep", rtdata.input,
             '--output_file=Test_dark', '--suffix="suffix_test"']
     RomanStep.from_cmdline(args)
-    output = "Test_suffix_test.asdf"
+    output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -34,9 +34,9 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input,
-            '--output_file=Test_darkcurrentstep']
+            '--output_file=Test_darkcurrent']
     RomanStep.from_cmdline(args)
-    output = "Test_darkcurrentstep.asdf"
+    output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -10,14 +10,14 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
     """ Function to run and compare Dark Current subtraction files. Note: This
         should include tests for overrides etc. """
 
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearitystep.asdf"
+    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
     RomanStep.from_cmdline(args)
     output =\
-        "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
+        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,
@@ -28,7 +28,7 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
 def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
     """ Function to run and compare Dark Current subtraction files. Here the
         test is for renaming the output file. """
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearitystep.asdf"
+    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.get_data(
         f'WFI/image/{input_datafile}')
     rtdata.input = input_datafile
@@ -47,9 +47,9 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
 def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
     """ Function to run and compare Dark Current subtraction files. Here the
         test is for renaming the output file. """
-    rtdata.get_data(
-        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearitystep.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearitystep.asdf"
+    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    rtdata.get_data(f"WFI/image/{input_datafile}")
+    rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input,
             '--output_file=Test_dark', '--suffix="suffix_test"']
@@ -66,9 +66,9 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
     """ Function to run and compare Dark Current subtraction files. Here the
         test for overriding the CRDS dark reference file. """
 
-    rtdata.get_data(
-        "WFI/image/r0000101001001001001_01101_0001_WFI01_linearitystep.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_linearitystep.asdf"
+    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    rtdata.get_data(f"WFI/image/{input_datafile}")
+    rtdata.input = input_datafile
     dark_output_name = \
         "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
 

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -10,7 +10,7 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
     """ Function to run and compare Jump Detection files. Note: This should
         include tests for overrides etc. """
 
-    input_file = "r0000101001001001001_01101_0001_WFI01_darkcurrentstep.asdf"
+    input_file = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -21,7 +21,7 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
             '--three_group_rejection_threshold=185.',
             '--four_group_rejection_threshold=190.']
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_jumpstep.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_jump.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -15,7 +15,7 @@ def test_linearity_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.LinearityStep", rtdata.input]
     RomanStep.from_cmdline(args)
     output =\
-        "r0000101001001001001_01101_0001_WFI01_linearitystep.asdf"
+        "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -8,9 +8,9 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_linearity_step(rtdata, ignore_asdf_paths):
     """ Function to run and compare linearity correction files."""
-    rtdata.get_data(
-        "WFI/image/r0000101001001001001_01101_0001_WFI01_saturationstep.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_saturationstep.asdf"
+    input_file = 'r0000101001001001001_01101_0001_WFI01_saturation.asdf'
+    rtdata.get_data(f"WFI/image/{input_file}")
+    rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input]
     RomanStep.from_cmdline(args)
@@ -26,9 +26,9 @@ def test_linearity_step(rtdata, ignore_asdf_paths):
 def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
     """ Function to run and linearity correction files. Here the
         test is for renaming the output file. """
-    rtdata.get_data(
-        "WFI/image/r0000101001001001001_01101_0001_WFI01_saturationstep.asdf")
-    rtdata.input = "r0000101001001001001_01101_0001_WFI01_saturationstep.asdf"
+    input_file = 'r0000101001001001001_01101_0001_WFI01_saturation.asdf'
+    rtdata.get_data(f"WFI/image/{input_file}")
+    rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input,
             '--output_file=Test_linearitystep']

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -31,9 +31,9 @@ def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input,
-            '--output_file=Test_linearitystep']
+            '--output_file=Test_linearity']
     RomanStep.from_cmdline(args)
-    output = "Test_linearitystep.asdf"
+    output = "Test_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert (compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -8,14 +8,14 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     """ Testing the ramp fitting step"""
-    input_data = "r0000101001001001001_01101_0001_WFI01_jumpstep.asdf"
+    input_data = "r0000101001001001001_01101_0001_WFI01_jump.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
     args = ["romancal.step.RampFitStep", rtdata.input, '--save_opt=True',
             '--opt_name=rampfit_opt.asdf']
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_rampfitstep.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     assert compare_asdf(rtdata.output, rtdata.truth,

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -35,7 +35,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_mask" in ref_file_name
 
     # Test DQInitStep
-    output = "r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
     step.log.info('DMS25 MSG: Running data quality initialization step.'
@@ -61,7 +61,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     """DMS26 Test: Testing retrieval of best ref file for grism data,
      and creation of a ramp file with CRDS selected mask file applied."""
 
-    input_file = "r0000101001001001001_01102_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -83,7 +83,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_mask" in ref_file_name
 
     # Test DQInitStep
-    output = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    output = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
     step.log.info('DMS26 MSG: Running data quality initialization step.'

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -48,10 +48,8 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     try:
         ref_file_path = step.get_reference_file(model, "flat")
         # Check for a valid reference file
-        if ref_file_path == 'N/A':
-            ref_file_path = None
-
-        ref_file_name = os.path.split(ref_file_path)[-1]
+        if ref_file_path != 'N/A':
+            ref_file_name = os.path.split(ref_file_path)[-1]
     except CrdsLookupError:
         ref_file_name = None
     assert ref_file_name == 'N/A'

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -50,7 +50,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
         ref_file_name = os.path.split(ref_file_path)[-1]
     except CrdsLookupError:
         ref_file_name = None
-    assert ref_file_name is None
+    assert ref_file_name == 'N/A'
 
     # Test FlatFieldStep
     output = "r0000201001001001002_01101_0001_WFI01_flat.asdf"

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -50,6 +50,8 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
         # Check for a valid reference file
         if ref_file_path != 'N/A':
             ref_file_name = os.path.split(ref_file_path)[-1]
+        elif ref_file_path == 'N/A':
+            ref_file_name = ref_file_path
     except CrdsLookupError:
         ref_file_name = None
     assert ref_file_name == 'N/A'

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -69,7 +69,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
        flat files and successfully make level 2 output"""
 
     # First file
-    input_l2_file = "r0000101001001001001_01101_0001_WFI01_assign_wcs.asdf"
+    input_l2_file = "r0000101001001001001_01101_0001_WFI01_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_l2_file}")
     rtdata.input = input_l2_file
 
@@ -113,7 +113,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     #  to separate flat files in CRDS.
 
     # Second file
-    input_file = "r0000101001001001001_01101_0002_WFI01_assign_wcs.asdf"
+    input_file = "r0000101001001001001_01101_0002_WFI01_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -47,6 +47,10 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     model = rdm.open(rtdata.input)
     try:
         ref_file_path = step.get_reference_file(model, "flat")
+        # Check for a valid reference file
+        if ref_file_path == 'N/A':
+            ref_file_path = None
+
         ref_file_name = os.path.split(ref_file_path)[-1]
     except CrdsLookupError:
         ref_file_name = None

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -36,7 +36,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
 
     # Test PhotomStep
-    output = "r0000201001001001001_01101_0001_WFI01_cal_photomstep.asdf"
+    output = "r0000201001001001001_01101_0001_WFI01_cal_photom.asdf"
     rtdata.output = output
     args = ["romancal.step.PhotomStep", rtdata.input]
     step.log.info('DMS140 MSG: Running photometric conversion step.'

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -14,7 +14,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     """DMS140 Test: Testing application of photometric correction using
        CRDS selected photom file."""
 
-    input_data = "r0000201001001001001_01101_0001_WFI01_cal.asdf"
+    input_data = "r0000201001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
@@ -36,7 +36,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
 
     # Test PhotomStep
-    output = "r0000201001001001001_01101_0001_WFI01_cal_photom.asdf"
+    output = "r0000201001001001001_01101_0001_WFI01_photom.asdf"
     rtdata.output = output
     args = ["romancal.step.PhotomStep", rtdata.input]
     step.log.info('DMS140 MSG: Running photometric conversion step.'

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -13,7 +13,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     """ Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected saturation file applied. """
 
-    input_file = "r0000101001001001001_01101_0001_WFI01_dqinitstep.asdf"
+    input_file = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -27,7 +27,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_saturation" in ref_file_name
 
     # Test SaturationStep
-    output = "r0000101001001001001_01101_0001_WFI01_saturationstep.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
@@ -46,7 +46,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     """ Testing retrieval of best ref file for grism data,
      and creation of a ramp file with CRDS selected saturation file applied."""
 
-    input_file = "r0000101001001001001_01102_0001_WFI01_dqinitstep.asdf"
+    input_file = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -60,7 +60,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_saturation" in ref_file_name
 
     # Test SaturationStep
-    output = "r0000101001001001001_01102_0001_WFI01_saturationstep.asdf"
+    output = "r0000201001001001002_01101_0001_WFI01_saturation.asdf"
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 
-from romancal.stpipe import RomanStep
 import roman_datamodels as rdm
 from roman_datamodels.datamodels import SaturationRefModel
+from romancal.stpipe import RomanStep
 from romancal.saturation import saturation
 
 
@@ -43,10 +43,10 @@ class SaturationStep(RomanStep):
             ref_model.close()
             sat.meta.cal_step.saturation = 'COMPLETE'
 
-        if self.save_results:
-            try:
-                self.suffix = 'saturation'
-            except AttributeError:
-                self['suffix'] = 'saturation'
+            if self.save_results:
+                try:
+                    self.suffix = 'saturation'
+                except AttributeError:
+                    self['suffix'] = 'saturation'
 
         return sat

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -43,4 +43,10 @@ class SaturationStep(RomanStep):
             ref_model.close()
             sat.meta.cal_step.saturation = 'COMPLETE'
 
+        if self.save_results:
+            try:
+                self.suffix = 'saturation'
+            except AttributeError:
+                self['suffix'] = 'saturation'
+
         return sat


### PR DESCRIPTION
<!-- These comments are hidden when you submit the PR,
so you do not need to remove them!

**Note: If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
RCAL-123: <Fix a bug>
**
-->

GitHub issue, Closes #455

Resolves [RCAL-310](https://jira.stsci.edu/browse/RCAL-310)

**Description**

This PR updates the suffix utility to replace the file suffix with the suffix appropriate for the given step. Updates the step code to create the correct suffix when needed and updates the regression tests and the reference data in artifactory to reflect the new names. 

Unit tests passing: 
pytest ~/src/Roman/romancal/romancal
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal, configfile: pytest.ini
plugins: xdist-2.5.0, remotedata-0.3.3, forked-1.4.0, astropy-header-0.2.1, mock-3.7.0, astropy-0.10.0, filter-subpackage-0.1.1, ci-watson-0.6.1, openfiles-0.5.0, doctestplus-0.12.0, asdf-2.11.1, hypothesis-6.46.11, cov-3.0.0, arraydiff-0.5.0
collected 137 items

../../../romancal/romancal/assign_wcs/tests/test_wcs.py ....                                                                  [  2%]
../../../romancal/romancal/dark_current/tests/test_dark.py ...                                                                [  5%]
../../../romancal/romancal/dq_init/tests/test_dq_init.py ......                                                               [  9%]
../../../romancal/romancal/flatfield/tests/test_flatfield.py ....                                                             [ 12%]
../../../romancal/romancal/jump/tests/test_jump_step.py ..............                                                        [ 22%]
../../../romancal/romancal/lib/tests/test_basic_utils.py ....                                                                 [ 25%]
../../../romancal/romancal/lib/tests/test_suffix.py .............................................................             [ 70%]
../../../romancal/romancal/photom/tests/test_photom.py .....                                                                  [ 73%]
../../../romancal/romancal/ramp_fitting/tests/test_ramp_fit.py x                                                              [ 74%]
../../../romancal/romancal/regtest/test_dark_current.py ssss                                                                  [ 77%]
../../../romancal/romancal/regtest/test_jump_det.py s                                                                         [ 78%]
../../../romancal/romancal/regtest/test_linearity.py ss                                                                       [ 79%]
../../../romancal/romancal/regtest/test_ramp_fitting.py s                                                                     [ 80%]
../../../romancal/romancal/regtest/test_wfi_dq_init.py ss                                                                     [ 81%]
../../../romancal/romancal/regtest/test_wfi_flat_field.py sss                                                                 [ 83%]
../../../romancal/romancal/regtest/test_wfi_photom.py s                                                                       [ 84%]
../../../romancal/romancal/regtest/test_wfi_pipeline.py ss                                                                    [ 86%]
../../../romancal/romancal/regtest/test_wfi_saturation.py ss                                                                  [ 87%]
../../../romancal/romancal/saturation/tests/test_saturation.py ........                                                       [ 93%]
../../../romancal/romancal/stpipe/tests/test_core.py ....ss.                                                                  [ 98%]
../../../romancal/romancal/stpipe/tests/test_integration.py ..                                                                [100%]

============================================ 116 passed, 20 skipped, 1 xfailed in 33.05s

In addition the regression tests all pass, 
https://plwishmaster.stsci.edu:8081/me/my-views/view/all/job/RT/job/Roman-Developers-Pull-Requests/44/

Checklist
- [x] Tests

- [x] Documentation

- [x] Change log

- [x] Milestone

- [x] Label(s)
