### PR TITLE
Rcal 295 compute s region

### DIFF
--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -170,7 +170,7 @@ def add_s_region(model):
     update_s_region_keyword(model, footprint)
 
 def update_s_region_keyword(model, footprint):
-    s_region = (f'POLYGON IRCS ' + ' '.join([str(x) for x in footprint.ravel()]) + ' ')
+    s_region = ('POLYGON IRCS ' + ' '.join([str(x) for x in footprint.ravel()]) + ' ')
     if "nan" in s_region:
         # do not update s_region if there are NaNs.
         log.info("There are NaNs in s_region, S_REGION not updated.")

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -171,6 +171,7 @@ def add_s_region(model):
 
 def update_s_region_keyword(model, footprint):
     s_region = ('POLYGON IRCS ' + ' '.join([str(x) for x in footprint.ravel()]) + ' ')
+    log.info("S_REGION VALUES: {}".format(s_region))
     if "nan" in s_region:
         # do not update s_region if there are NaNs.
         log.info("There are NaNs in s_region, S_REGION not updated.")

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-__all__ = ["AssignWcsStep", "load_wcs"]
+__all__ = ["AssignWcsStep", "load_wcs", "add_s_region"]
 
 
 class AssignWcsStep(RomanStep):
@@ -86,6 +86,10 @@ def load_wcs(input_model, reference_files=None):
         wcs.bounding_box = wcs_bbox_from_shape(output_model.data.shape)
 
     output_model.meta['wcs'] = wcs
+
+    # update S_REGION
+    add_s_region(output_model)
+
     output_model.meta.cal_step['assign_wcs'] = 'COMPLETE'
 
     return output_model
@@ -125,3 +129,43 @@ def wfi_distortion(model, reference_files):
         transform.bounding_box = bbox
 
     return transform
+
+def add_s_region(model):
+    """
+    Calculate the detector's footprint using ``WCS.footprint`` and save it in the ``S_REGION`` keyword
+
+    Args:
+        model : `~roman_datamodels.datamodels.ScienceRawModel`
+            The data model for processing
+
+    Returns:
+        str : A formatted string representing the detector's footprint
+    """
+
+    bbox = model.meta.wcs.bounding_box
+
+    if bbox is None:
+        bbox = wcs_bbox_from_shape(model.data.shape)
+
+    # footprint is an array of shape (2, 4) - i.e. 4 values for RA and 4 values for Dec - as we
+    # are interested only in the footprint on the sky
+    footprint = model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
+    # take only imaging footprint
+    footprint = footprint[:2, :]
+
+    # Make sure RA values are all positive
+    negative_ind = footprint[0] < 0
+    if negative_ind.any():
+        footprint[0][negative_ind] = 360 + footprint[0][negative_ind]
+
+    footprint = footprint.T
+    update_s_region_keyword(model, footprint)
+
+def update_s_region_keyword(model, footprint):
+    s_region = (f'POLYGON IRCS ' + ' '.join([str(x) for x in footprint.ravel()]) + ' ')
+    if "nan" in s_region:
+        # do not update s_region if there are NaNs.
+        log.info("There are NaNs in s_region, S_REGION not updated.")
+    else:
+        model.meta.wcsinfo.s_region = s_region
+        log.info("Update S_REGION to {}".format(model.meta.wcsinfo.s_region))

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -79,6 +79,9 @@ def test_wcs(tmpdir, distortion, step):
     assert s_region_list[0].lower() == 'polygon'
     assert s_region_list[1].lower() == 'ircs'
 
+    # check if BBOX is not None
+    assert l2_wcs.meta.bounding_box is not None
+
     # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)
     s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 == 0]
     s_region_delta_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 != 0]

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -12,6 +12,7 @@ from roman_datamodels.testing import utils as testutil
 
 from romancal.assign_wcs.utils import wcs_bbox_from_shape
 
+import pdb
 
 def create_image():
     l2 = testutil.mk_level2_image()
@@ -73,3 +74,15 @@ def test_wcs(tmpdir, distortion, step):
     ra, dec = l2_wcs.meta.wcs(-5, 3)
     assert np.isnan(ra)
     assert np.isnan(dec)
+
+    # check S_REGION length and format
+    s_region_list = l2_wcs.meta.wcsinfo.s_region.split()
+    assert len(s_region_list) == 10
+    assert s_region_list[0].lower() == 'polygon'
+    assert s_region_list[1].lower() == 'ircs'
+
+    # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)
+    s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 == 0]
+    s_region_delta_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 != 0]
+    assert_allclose(s_region_alpha_list, l2_wcs.meta.wcsinfo.ra_ref, rtol=1e-1, atol=0)
+    assert_allclose(s_region_delta_list, l2_wcs.meta.wcsinfo.dec_ref, rtol=1e-1, atol=0)

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -12,8 +12,6 @@ from roman_datamodels.testing import utils as testutil
 
 from romancal.assign_wcs.utils import wcs_bbox_from_shape
 
-import pdb
-
 def create_image():
     l2 = testutil.mk_level2_image()
 

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -1,4 +1,3 @@
-import pdb
 import numpy as np
 import os
 import pytest
@@ -81,7 +80,6 @@ def test_wcs(tmpdir, distortion, step):
     assert s_region_list[1].lower() == 'ircs'
 
     # check if BBOX is not None
-    pdb.set_trace()
     assert l2_wcs.meta.wcs.bounding_box is not None
 
     # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -1,3 +1,4 @@
+import pdb
 import numpy as np
 import os
 import pytest
@@ -80,7 +81,8 @@ def test_wcs(tmpdir, distortion, step):
     assert s_region_list[1].lower() == 'ircs'
 
     # check if BBOX is not None
-    assert l2_wcs.meta.bounding_box is not None
+    pdb.set_trace()
+    assert l2_wcs.meta.wcs.bounding_box is not None
 
     # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)
     s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 == 0]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-295](https://jira.stsci.edu/browse/RCAL-295)

<!-- describe the changes comprising this PR here -->
This PR addresses the creation of a detector's `S_REGION`. We use the same approach used by JWST to calculate the aperture's footprint from WCS. The result is saved under `meta.wcsinfo`.

A simple test was also implemented inside of `test_wcs.py` that verifies if the length and format of `S_REGION` are in accordance with the expectation. We also check for a $\le$ 10% accuracy between the `S_REGION` results and the ICRS reference coordinates for the aperture.

@ddavis-stsci to review.

_N.B._: There is a discrepancy in the footprint results that we get for our simulated images (based on the telescope pointing and WCS info available in the metadata) and the ones that we get from [this website](http://gsss.stsci.edu/webservices/footprints/webform.aspx); the results seem to be a mirror image over the $\alpha$ axis. As suggested by Nadia (@nden), since this issue does not affect the calculation of the footprint at this point, we are keeping it as it is and bringing it up in our next meeting with Tyler (@tddesjardins).
