### PR TITLE
release `numpy` requirement

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -117,3 +117,35 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
+
+  test_older_numpy:
+    name: test Numpy ${{ matrix.numpy }} (Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python: [ 3.8, 3.9, '3.10' ]
+        numpy: [ '1.18.*', '1.19.*', '1.20.*', '1.21.*', '1.22.*' ]
+        exclude:
+          - python: '3.10'
+            numpy: '1.18.*'
+          - python: '3.10'
+            numpy: '1.19.*'
+          - python: '3.10'
+            numpy: '1.20.*'
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-python@main
+        id: python
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/cache@main
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-numpy${{ matrix.numpy }}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: pip install -e ".[test]" pytest-xdist
+      - run: pip install numpy==${{ matrix.numpy }}
+      - run: pip freeze
+      - run: pytest -n auto

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ general
 
 - Simplified reference file name and model storage in dq and flat steps. [#514]
 
+- Release ``numpy`` version requirement [#544]
+
 photom
 ------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     crds>=11.13.1
     gwcs>=0.18.1
     jsonschema>=3.0.2
-    numpy>=1.22.3
+    numpy
     pyparsing>=2.4.7
     requests>=2.22
     #roman_datamodels>=0.12.2


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
The `numpy` version defined at https://github.com/spacetelescope/romancal/blob/58937f347aef7019d8c93884d9ce04f7caa244ae/setup.cfg#L29 causes version conflicts when testing older `numpy` versions in `romancal` unit tests: https://github.com/spacetelescope/romancal/pull/511#issuecomment-1179176360.

However, it does not seem that this version requirement is necessary; as the checks introduced by this PR show, multiple older versions of `numpy` pass unit tests. 

Is there a reason to pin `numpy` to this version? Also, can these be tested in regression tests as well?

**blocked by https://github.com/spacetelescope/roman_datamodels/pull/84**

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
