### PR TITLE
Add tests for SOC-587.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
+
+.python-version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,7 @@ tests
 -----
 
 - Updated tests to account for the change in dimensionality of the err variable in ramp datamodel. [#520]
+- Added SOC tests to check for information available in Level 2 images to correct for pixel geometric distortion. [#PR]
 
 
 0.7.1 (2022-05-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,7 @@ tests
 -----
 
 - Updated tests to account for the change in dimensionality of the err variable in ramp datamodel. [#520]
-- Added SOC tests to check for information available in Level 2 images to correct for pixel geometric distortion. [#PR]
+- Added SOC tests to check for information available in Level 2 images to correct for pixel geometric distortion. [#549]
 
 
 0.7.1 (2022-05-19)

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -35,7 +35,6 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
             "--steps.jump.rejection_threshold=180.0",
             "--steps.jump.three_group_rejection_threshold=185.0",
             "--steps.jump.four_group_rejection_threshold=190",
-            "--steps.photom.override_photom=/grp/roman/ddavis/roman/data/roman_wfi_photom_0034_test.asdf",
             "roman_elp", rtdata.input,
             ]
     ExposurePipeline.from_cmdline(args)
@@ -128,11 +127,6 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
         # (which means the distortion correction was actually applied to the model)
         assert (corrected_coords[0] != original_coords[0]).all()
         assert (corrected_coords[1] != original_coords[1]).all()
-        
-        pipeline.log.info('DMS-129 MSG: Checking that distortion correction has been applied in'
-                        'Level 2 image output.......' +
-                        passfail('v2v3' in model.meta.wcs.available_frames))
-        assert 'v2v3' in model.meta.wcs.available_frames
 
     # DMS87 data quality tests
     pipeline.log.info('DMS87 MSG: Testing existence of data quality array (dq)'

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -77,7 +77,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
                       passfail(model.meta.cal_step.jump == 'COMPLETE'))
     assert model.meta.cal_step.jump == 'COMPLETE'
     pipeline.log.info('Status of the step:             linearity     ' +
-                      str(model.meta.cal_step.assign_wcs))
+                      str(model.meta.cal_step.linearity))
     pipeline.log.info('DMS86 MSG: Testing completion of linearity correction'
                       ' in Level 2 image output.......' +
                       passfail(model.meta.cal_step.linearity == 'COMPLETE'))
@@ -94,6 +94,22 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
                       'in Level 2 image output.......' +
                       passfail(model.meta.cal_step.saturation == 'COMPLETE'))
     assert model.meta.cal_step.saturation == 'COMPLETE'
+
+    # SOC-587 tests for WFI mode
+    if model.meta.exposure.type == 'WFI_IMAGE':
+        # check if assign_wcs step is complete
+        pipeline.log.info('SOC-587 MSG: Status of the step:             assign_wcs    ' +
+                      str(model.meta.cal_step.assign_wcs))
+        pipeline.log.info('SOC-587 MSG: Testing completion of WCS assignment in'
+                        'Level 2 image output.......' +
+                        passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
+        assert model.meta.cal_step.assign_wcs == 'COMPLETE'
+        # check if WCS exists
+        pipeline.log.info('SOC-587 MSG: Testing that a WCS object exists    ')
+        pipeline.log.info('SOC-587 MSG: Testing that WCS exists in'
+                        'Level 2 image output.......' +
+                        passfail(model.meta.wcs is not None))
+        assert model.meta.wcs is not None
 
     # DMS87 data quality tests
     pipeline.log.info('DMS87 MSG: Testing existence of data quality array (dq)'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-364](https://jira.stsci.edu/browse/RCAL-364)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds tests for SOC-587: "_in Wide Field Imaging mode, the DMS shall generate Level 2 science data products that incorporate information needed to correct for pixel geometric distortion._"

For the time being, the test checks if `AssignWcsStep` is complete and if a WCS object has been created. Although not necessarily needed, we should also check if a distortion reference file was used by checking `meta.ref_file['distortion']`. This will be implemented soon after checking if the pipeline updates `meta.ref_file` with the reference file used after each step.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
