### PR TITLE
automatically add labels to pull requests based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,10 +63,6 @@ ramp_fitting:
   - '**/*ramp_fitting*'
   - '**/*ramp_fitting*/**'
 
-regtest:
-  - '**/*regtest*'
-  - '**/*regtest*/**'
-
 saturation:
   - '**/*saturation*'
   - '**/*saturation*/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,92 @@
+documentation:
+  - 'docs/**/*'
+  - any: [ '*.rst', '!CHANGES.rst' ]
+  - '*.md'
+  - '.readthedocs.yml'
+  - 'LICENSE'
+
+dependencies:
+  - 'pyproject.toml'
+  - 'setup.*'
+  - 'requirements-*.txt'
+  - 'MANIFEST.in'
+
+# --------------------------------------- testing ---------------------------------------
+
+automation:
+  - '.github/**'
+  - '.bandit.yaml'
+  - '.codecov.yml'
+  - 'Jenkinsfile*'
+
+testing:
+  - '**/tests/**'
+  - '.github/workflows/*ci*.yml'
+  - 'conftest.py'
+  - 'tox.ini'
+
+regression_testing:
+  - '**/regtest/**'
+  - 'Jenkinsfile*'
+
+# --------------------------------------- modules ---------------------------------------
+
+assign_wcs:
+  - '**/*assign_wcs*'
+  - '**/*assign_wcs*/**'
+
+Dark Current:
+  - '**/*dark_current*'
+  - '**/*dark_current*/**'
+
+dq_init:
+  - '**/*dq_init*'
+  - '**/*dq_init*/**'
+
+flatfield:
+  - '**/*flatfield*'
+  - '**/*flatfield*/**'
+
+jump:
+  - '**/*jump*'
+  - '**/*jump*/**'
+
+linearity:
+  - '**/*linearity*'
+  - '**/*linearity*/**'
+
+photom:
+  - '**/*photom*'
+  - '**/*photom*/**'
+
+ramp_fitting:
+  - '**/*ramp_fitting*'
+  - '**/*ramp_fitting*/**'
+
+regtest:
+  - '**/*regtest*'
+  - '**/*regtest*/**'
+
+saturation:
+  - '**/*saturation*'
+  - '**/*saturation*/**'
+
+# --------------------------------------- pipelines ---------------------------------------
+
+stpipe:
+  - '**/*stpipe*'
+  - '**/*stpipe*/**'
+
+pipeline:
+  - '**/*pipeline*'
+  - '**/*pipeline*/**'
+
+# --------------------------------------- instruments ---------------------------------------
+
+Wide Field Instrument (WFI):
+  - '**/*wfi*'
+  - '**/*wfi*/**'
+
+Coronagraph:
+  - '**/*coron*'
+  - '**/*coron*/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -86,7 +86,3 @@ pipeline:
 Wide Field Instrument (WFI):
   - '**/*wfi*'
   - '**/*wfi*/**'
-
-Coronagraph:
-  - '**/*coron*'
-  - '**/*coron*/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,6 +35,10 @@ assign_wcs:
   - '**/*assign_wcs*'
   - '**/*assign_wcs*/**'
 
+associations:
+  - '**/*association*'
+  - '**/*association*/**'
+
 Dark Current:
   - '**/*dark_current*'
   - '**/*dark_current*/**'

--- a/.github/workflows/label_pull_request.yml
+++ b/.github/workflows/label_pull_request.yml
@@ -1,0 +1,16 @@
+name: label pull request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This GitHub workflow runs a labeler action on new / edited pull requests that scans the filenames of changed files and applies relevant labels. This process is configured in `.github/labeler.yml`, which I copied and modified from https://github.com/spacetelescope/jwst/pull/6933

An example of this labeler working can be seen here: https://github.com/spacetelescope/stsynphot_refactor/pull/153
<img width="590" alt="image" src="https://user-images.githubusercontent.com/16024299/180037630-8704dc7f-c415-40da-a24a-5a8409fb781f.png">

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
