### PR TITLE
use `tox` and set up CRDS caching when server is accessible

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toxenv: [ test ]
+        toxenv: [ test-xdist ]
         python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ test-cov, test-devdeps, test-numpy120, test-numpy121, test-numpy122 ]
+        toxenv: [ test-cov, test-devdeps, test-numpy120-xdist, test-numpy121-xdist, test-numpy122-xdist ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
         exclude:
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        toxenv: [ test-pyargs ]
+        toxenv: [ test-pyargs-xdist ]
         python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -45,10 +45,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -67,10 +63,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
@@ -108,10 +100,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_older_numpy:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -148,10 +136,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }}
@@ -178,10 +162,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_with_coverage:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -209,10 +189,6 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -237,8 +213,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -64,11 +64,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
+      - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
-      - run: echo '${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}' > reference_files_hash.txt
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - run: echo ${{ env.REFERENCE_FILES_HASH }} > reference_files_hash.txt
       - uses: actions/upload-artifact@v3
         with:
           name: reference_files_hash

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 9 * * 1"
 
 env:
-  CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+  CRDS_SERVER_URL: https://roman-crds.stsci.edu
   CRDS_PATH: $HOME/crds_cache
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         toxenv: [ check-style, check-security, check-install ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
         include:
           - name: Code style check
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ test ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ test-pyargs ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
     strategy:
       matrix:
         toxenv: [ build-twine ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -185,7 +185,7 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-      - run: pytest -n auto ./docs --pyargs romancal
+      - run: pytest -n auto --pyargs romancal
   test_older_numpy:
     name: test Numpy ${{ matrix.numpy }} (Python ${{ matrix.python }})
     needs: [ test ]

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ test-cov, test-devdeps, test-numpy120-xdist, test-numpy121-xdist, test-numpy122-xdist ]
+        toxenv: [ test-cov, test-devdeps, test-numpy120, test-numpy121, test-numpy122 ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
         exclude:

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+      - run: echo '${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}' > reference_files_hash.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: reference_files_hash
+          path: reference_files_hash.txt
   test:
     name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
@@ -95,10 +100,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -123,10 +132,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
     name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -81,9 +81,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ test-cov, test-devdeps, test-numpy120, test-numpy121, test-numpy122 ]
+        toxenv: [ test-xdist, test-devdeps ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - run: tox -e ${{ matrix.toxenv }}
+  test_older_numpy:
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-numpy120, test-numpy121, test-numpy120 ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-latest ]
         exclude:
           - python-version: '3.10'
             toxenv: test-numpy120
@@ -110,15 +137,9 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
-      - if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }}
-    needs: [ quick_test ]
+    needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -142,6 +163,39 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
+  test_with_coverage:
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-cov ]
+        python-version: [ '3.x' ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/download-artifact@v3
+        with:
+          name: reference_files_hash
+      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unit
+          fail_ci_if_error: true
   build:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ test ]

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -46,37 +46,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
-  quick_test:
-    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ check ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        toxenv: [ test-xdist ]
-        python-version: [ '3.x' ]
-        os: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
-      - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
-      - run: echo ${{ env.REFERENCE_FILES_HASH }} > reference_files_hash.txt
-      - uses: actions/upload-artifact@v3
-        with:
-          name: reference_files_hash
-          path: reference_files_hash.txt
   test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ quick_test ]
+    needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -92,14 +64,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/download-artifact@v3
-        with:
-          name: reference_files_hash
-      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["roman"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+        id: crds-context
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
       - run: tox -e ${{ matrix.toxenv }}
   test_older_numpy:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -128,14 +104,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/download-artifact@v3
-        with:
-          name: reference_files_hash
-      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["roman"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+        id: crds-context
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
       - run: tox -e ${{ matrix.toxenv }}
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }}
@@ -154,14 +134,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/download-artifact@v3
-        with:
-          name: reference_files_hash
-      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["roman"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+        id: crds-context
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
       - run: tox -e ${{ matrix.toxenv }}
   test_with_coverage:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -181,14 +165,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
-      - uses: actions/download-artifact@v3
-        with:
-          name: reference_files_hash
-      - run: echo "REFERENCE_FILES_HASH=$(cat reference_files_hash.txt)" >> $GITHUB_ENV
+      - run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["roman"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+        id: crds-context
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+          key: crds-${{ steps.crds-context.outputs.pmap }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -63,6 +67,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - run: echo "REFERENCE_FILES_HASH=${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}" >> $GITHUB_ENV
       - uses: actions/cache@v3
@@ -100,6 +108,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_older_numpy:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -136,6 +148,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_pyargs:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }}
@@ -162,6 +178,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
   test_with_coverage:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -189,6 +209,10 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
@@ -213,4 +237,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ matrix.toxenv }}-${{ env.pythonLocation }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
       - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -93,10 +93,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto
   test_alldeps:
     name: test optional dependencies (${{ matrix.os }}, Python ${{ matrix.python }})
@@ -121,10 +123,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto
   test_devdeps:
     name: test developer versions (${{ matrix.os }}, Python ${{ matrix.python }})
@@ -150,10 +154,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto
   test_pyargs:
     name: test --pyargs (${{ matrix.os }}, Python ${{ matrix.python }})
@@ -181,10 +187,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto --pyargs romancal
   test_older_numpy:
     name: test Numpy ${{ matrix.numpy }} (${{ matrix.os }}, Python ${{ matrix.python }})
@@ -221,10 +229,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto
   test_with_coverage:
     name: test with coverage
@@ -244,10 +254,12 @@ jobs:
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
       - uses: actions/cache@v3.0.5
+        if: env.CRDS_CONTEXT != ''
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ env.CRDS_CONTEXT }}
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
+        if: env.CRDS_CONTEXT != ''
       - run: pytest -n auto --cov --cov-report xml --cov-report term-missing
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -16,8 +16,8 @@ on:
     - cron: '0 9 * * 1'
 
 env:
-  CRDS_SERVER_URL: "https://roman-crds-test.stsci.edu"
-  CRDS_PATH: "/tmp/crds_cache"
+  CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+  CRDS_PATH: $HOME/crds_cache
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -14,6 +14,12 @@ on:
     # Weekly Monday 9AM build
     # * is a special character in YAML so you have to quote this string
     - cron: '0 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      crds_context:
+        type: string
+        description: CRDS context(s) to use with tests (defaults to operational context)
+        required: false
 
 env:
   CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
@@ -92,6 +98,9 @@ jobs:
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:
@@ -122,6 +131,9 @@ jobs:
       - run: pip install ".[test,all]" pytest-xdist
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:
@@ -153,6 +165,9 @@ jobs:
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:
@@ -186,6 +201,9 @@ jobs:
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:
@@ -228,6 +246,9 @@ jobs:
       - run: pip install numpy==${{ matrix.numpy }}
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:
@@ -253,6 +274,9 @@ jobs:
       - run: pip install ".[test]" pytest-xdist pytest-cov
       - run: pip freeze
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context == ''
+      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
+        if: github.event.inputs.crds_context != ''
       - uses: actions/cache@v3.0.5
         if: env.CRDS_CONTEXT != ''
         with:

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -71,7 +71,7 @@ jobs:
       - run: pip freeze
       - run: verify_install_requires
   test:
-    name: test
+    name: test (${{ matrix.os }}, Python ${{ matrix.python }})
     needs: [ style, audit, dependencies ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -99,7 +99,7 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_alldeps:
-    name: test optional dependencies
+    name: test optional dependencies (${{ matrix.os }}, Python ${{ matrix.python }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -127,7 +127,7 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_devdeps:
-    name: test developer versions
+    name: test developer versions (${{ matrix.os }}, Python ${{ matrix.python }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -156,7 +156,7 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_pyargs:
-    name: test --pyargs
+    name: test --pyargs (${{ matrix.os }}, Python ${{ matrix.python }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -187,7 +187,7 @@ jobs:
       - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto --pyargs romancal
   test_older_numpy:
-    name: test Numpy ${{ matrix.numpy }} (Python ${{ matrix.python }})
+    name: test Numpy ${{ matrix.numpy }} (${{ matrix.os }}, Python ${{ matrix.python }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -12,14 +12,7 @@ on:
       - main
   schedule:
     # Weekly Monday 9AM build
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 9 * * 1'
-  workflow_dispatch:
-    inputs:
-      crds_context:
-        type: string
-        description: CRDS context(s) to use with tests (defaults to operational context)
-        required: false
+    - cron: "0 9 * * 1"
 
 env:
   CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
@@ -28,283 +21,128 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
-  style:
-    name: Code style checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install pyproject-flake8
-      - run: pip freeze
-      - run: pflake8
-  audit:
-    name: Bandit security audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: audit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install bandit
-      - run: pip freeze
-      - run: bandit romancal -r -x tests,regtest
-  dependencies:
-    name: verify dependencies are correct
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: dependencies-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install .
-      - run: pip freeze
-      - run: verify_install_requires
-  test:
-    name: test (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ style, audit, dependencies ]
+  check:
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ".[test]" pytest-xdist
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto
-  test_alldeps:
-    name: test optional dependencies (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-alldeps-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ".[test,all]" pytest-xdist
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto
-  test_devdeps:
-    name: test developer versions (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-devdeps-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install git+https://github.com/asdf-format/asdf git+https://github.com/spacetelescope/stpipe git+https://github.com/spacetelescope/stdatamodels --pre astropy numpy
-      - run: pip install ".[test]" pytest-xdist
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto
-  test_pyargs:
-    name: test --pyargs (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
-        exclude:
-          - os: macos-latest
-            python: '3.11'
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-pyargs-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ".[test]" pytest-xdist
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto --pyargs romancal
-  test_older_numpy:
-    name: test Numpy ${{ matrix.numpy }} (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
+        toxenv: [ check-style, check-security, check-install ]
+        python-version: [ '3.10' ]
         os: [ ubuntu-latest ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
-        numpy: [ '1.20.*', '1.21.*', '1.22.*' ]
+        include:
+          - name: Code style check
+            toxenv: check-style
+          - name: Security audit
+            toxenv: check-security
+          - name: Verify install_requires in setup.py
+            toxenv: check-install
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
+  quick_test:
+    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ check ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toxenv: [ test ]
+        python-version: [ '3.10' ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+  test:
+    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ quick_test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-cov, test-devdeps, test-numpy120, test-numpy121, test-numpy122 ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-latest, macos-latest ]
         exclude:
-          - python: '3.10'
-            numpy: '1.20.*'
-          - python: '3.11'
-            numpy: '1.20.*'
-          - python: '3.11'
-            numpy: '1.21.*'
-          - python: '3.11'
-            numpy: '1.22.*'
+          - python-version: '3.10'
+            toxenv: test-numpy120
+          - python-version: '3.11'
+            toxenv: test-numpy120
+          - python-version: '3.11'
+            toxenv: test-numpy121
+          - python-version: '3.11'
+            toxenv: test-numpy122
     steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
+      - uses: actions/checkout@v3
         with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: test-numpy${{ matrix.numpy }}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install -e ".[test]" pytest-xdist
-      - run: pip install numpy==${{ matrix.numpy }}
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto
-  test_with_coverage:
-    name: test with coverage
-    needs: [ test, test_alldeps, test_devdeps, test_pyargs, test_older_numpy ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3.0.5
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ".[test]" pytest-xdist pytest-cov
-      - run: pip freeze
-      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context == ''
-      - run: echo "CRDS_CONTEXT=${{ github.event.inputs.crds_context }}" >> $GITHUB_ENV
-        if: github.event.inputs.crds_context != ''
-      - uses: actions/cache@v3.0.5
-        if: env.CRDS_CONTEXT != ''
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ env.CRDS_CONTEXT }}
-      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
-        if: env.CRDS_CONTEXT != ''
-      - run: pytest -n auto --cov --cov-report xml --cov-report term-missing
-      - uses: codecov/codecov-action@v3
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unit
           fail_ci_if_error: true
-  build_docs:
-    name: build HTML docs
-    needs: [ test, test_alldeps, test_devdeps, test_pyargs, test_older_numpy ]
-    runs-on: ubuntu-latest
+  test_pyargs:
+    name: test installed package with `--pyargs` (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ quick_test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toxenv: [ test-pyargs ]
+        python-version: [ '3.10' ]
+        os: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
-        id: python
+      - uses: actions/checkout@v3
         with:
-          python-version: 3.9
-      - uses: actions/cache@v3.0.5
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: build-docs-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: sudo apt-get install graphviz texlive-latex-extra dvipng
-      - run: pip install ".[docs]"
-      - run: pip freeze
-      - run: sphinx-build -W docs docs/_build
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-reference-files-${{ hashFiles(format('{0}/references/*', env.CRDS_PATH)) }}
+      - run: tox -e ${{ matrix.toxenv }}
+  build:
+    name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ test ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toxenv: [ build-twine ]
+        python-version: [ '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -47,7 +47,7 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
   quick_test:
-    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -75,7 +75,7 @@ jobs:
           name: reference_files_hash
           path: reference_files_hash.txt
   test:
-    name: test (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -117,7 +117,7 @@ jobs:
           flags: unit
           fail_ci_if_error: true
   test_pyargs:
-    name: test installed package with `--pyargs` (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }}
     needs: [ quick_test ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -143,7 +143,7 @@ jobs:
           key: crds-reference-files-${{ env.REFERENCE_FILES_HASH }}
       - run: tox -e ${{ matrix.toxenv }}
   build:
-    name: build distribution (${{ matrix.toxenv }}, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     needs: [ test ]
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -91,6 +91,12 @@ jobs:
           key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_alldeps:
     name: test optional dependencies
@@ -113,6 +119,12 @@ jobs:
           key: test-alldeps-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install ".[test,all]" pytest-xdist
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_devdeps:
     name: test developer versions
@@ -136,6 +148,12 @@ jobs:
       - run: pip install git+https://github.com/asdf-format/asdf git+https://github.com/spacetelescope/stpipe git+https://github.com/spacetelescope/stdatamodels --pre astropy numpy
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_pyargs:
     name: test --pyargs
@@ -161,6 +179,12 @@ jobs:
           key: test-pyargs-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install ".[test]" pytest-xdist
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto ./docs --pyargs romancal
   test_older_numpy:
     name: test Numpy ${{ matrix.numpy }} (Python ${{ matrix.python }})
@@ -195,6 +219,12 @@ jobs:
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip install numpy==${{ matrix.numpy }}
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto
   test_with_coverage:
     name: test with coverage
@@ -212,6 +242,12 @@ jobs:
           key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install ".[test]" pytest-xdist pytest-cov
       - run: pip freeze
+      - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
+      - uses: actions/cache@v3.0.5
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ env.CRDS_CONTEXT }}
+      - run: crds sync --contexts ${{ env.CRDS_CONTEXT }}
       - run: pytest -n auto --cov --cov-report xml --cov-report term-missing
       - uses: codecov/codecov-action@v3
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,10 @@ photom
 
 - Change photom step to forcibly set the photometric keywords to ``None`` for spectroscopic data. [#591]
 
+tests
+-----
 
+- refactor `tox` environment factors and structure GitHub Actions into dependent workflow [#551]
 
 0.8.1 (2022-08-23)
 ==================
@@ -96,9 +99,6 @@ tests
 
 - Updated tests to account for the change in dimensionality of the err variable in ramp datamodel. [#520]
 - Added SOC tests to check for information available in Level 2 images to correct for pixel geometric distortion. [#549]
-
-- Cache CRDS from current operational context in test workflow [#551]
-
 
 0.7.1 (2022-05-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,8 @@ tests
 - Updated tests to account for the change in dimensionality of the err variable in ramp datamodel. [#520]
 - Added SOC tests to check for information available in Level 2 images to correct for pixel geometric distortion. [#549]
 
+- Cache CRDS from current operational context in test workflow [#551]
+
 
 0.7.1 (2022-05-19)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = romancal
 description = Library for calibration of science observations from the Nancy Grace Roman Space Telescope
 long_description = Library for calibration of science observations from the Nancy Grace Roman Space Telescope
+long_description_content_type = text/x-rst
 author = Roman calibration pipeline developers
 license = BSD-3-Clause
 url = https://github.com/spacetelescope/romancal

--- a/tox.ini
+++ b/tox.ini
@@ -69,13 +69,13 @@ commands =
 deps =
     pytest-xdist
     devdeps: -rrequirements-dev.txt
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
 setenv =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
 commands_pre =
     python -m pip install --upgrade pip
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
 # Don't treat positional arguments passed to tox as file system paths
 args_are_paths = false
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ description =
     warnings: treating warnings as errors
     regtests: with --bigdata and --slow flags
     cov: with coverage
+    xdist: using parallel processing
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
@@ -64,10 +65,11 @@ commands =
     pytest \
     cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
     warnings: -W error \
-    regtests: -n auto --bigdata --slow --basetemp={homedir}/test_outputs \
+    regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
+    xdist: -n auto \
     {posargs}
 deps =
-    pytest-xdist
+    xdist: pytest-xdist
     devdeps: -rrequirements-dev.txt
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,107 @@
+[tox]
+envlist =
+    check-{style,security,install}
+    test{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov}
+    test-numpy{120,121,122}
+    build-{twine,docs}
+isolated_build = true
+usedevelop = true
+
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+
+[testenv:check-style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 . {posargs}
+
+[testenv:check-security]
+description = run bandit to check security compliance
+deps =
+    bandit>=1.7
+commands =
+    bandit romancal -r -x tests,regtest
+
+[testenv:check-install]
+description = verify that install_requires in setup.cfg is correct
+extras =
+commands =
+    verify_install_requires
+
+[testenv]
+description =
+    run tests
+    alldeps: with all optional dependencies
+    devdeps: with the latest developer version of key dependencies
+    pyargs: with --pyargs on installed package
+    warnings: treating warnings as errors
+    regtests: with --bigdata and --slow flags
+    cov: with coverage
+# The following indicates which extras_require from setup.cfg will be installed
+extras =
+    test
+    alldeps: all
+# Pass through the following environment variables which may be needed for the CI
+passenv =
+    HOME
+    CI
+    TOXENV
+    CRDS_*
+    TEST_BIGDATA
+    CODECOV_*
+usedevelop = true
+commands =
+    pip freeze
+    pytest \
+    cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
+    warnings: -W error \
+    regtests: -n auto --bigdata --slow --basetemp={homedir}/test_outputs \
+    {posargs}
+deps =
+    pytest-xdist
+    devdeps: -rrequirements-dev.txt
+    devdeps: git+https://github.com/numpy/numpy
+    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/asdf-format/asdf
+    devdeps: git+https://github.com/spacetelescope/stpipe
+    devdeps: git+https://github.com/spacetelescope/stdatamodels
+setenv =
+    sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
+commands_pre =
+    python -m pip install --upgrade pip
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
+# Don't treat positional arguments passed to tox as file system paths
+args_are_paths = false
+
+[testenv:pyargs]
+changedir = {homedir}
+usedevelop = false
+commands =
+    pyargs: pytest {toxinidir}/docs --pyargs {posargs:romancal}
+
+[testenv:build-twine]
+description = check that the package builds sdist/wheel and that twine uploads
+deps =
+    twine>=3.3
+    pep517
+usedevelop = false
+commands =
+    python -m pep517.check .
+    twine check --strict {distdir}/*
+
+[testenv:build-docs]
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+commands =
+    sphinx-build -W docs docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -69,11 +69,6 @@ commands =
 deps =
     pytest-xdist
     devdeps: -rrequirements-dev.txt
-    devdeps: git+https://github.com/numpy/numpy
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
-    devdeps: git+https://github.com/asdf-format/asdf
-    devdeps: git+https://github.com/spacetelescope/stpipe
-    devdeps: git+https://github.com/spacetelescope/stdatamodels
 setenv =
     sdpdeps,regtests: CRDS_CONTEXT = jwst-edit
 commands_pre =


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR turns the existing dependent-workflow structure back into `tox`, and caches CRDS data for the same operational context, so it is not downloaded every time. This functionality is not currently useful (it is skipped currently) but will become useful when Roman CRDS becomes publicly available.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
