### PR TITLE
fix input file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ general
 
 - Update `stpipe` requirement to `>=0.4.2` [#545]
 
+- Fix input_filename when DataModel is input to ExposurePipeline [#553]
+
+
 photom
 ------
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -62,6 +62,8 @@ class ExposurePipeline(RomanPipeline):
         log.info('Starting Roman exposure calibration pipeline ...')
         if isinstance(input, str):
             input_filename = basename(input)
+        else:
+            input_filename = None
 
         # open the input file
         input = rdd.open(input)


### PR DESCRIPTION
The variable `input_filename` was only being assigned if the input to ExposurePipeline was a string, but it was being checked so inputting a model wasn't working.
