### PR TITLE
fix `flake8` warnings

### DIFF
--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -55,15 +55,15 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     dqdata = outfile['pixeldq']
 
     # assert that the pixels read back in match the mapping from ref data to science data
-    assert(dqdata[100, 100] == dqflags.pixel['SATURATED'])
-    assert(dqdata[200, 100] == dqflags.pixel['JUMP_DET'])
-    assert(dqdata[300, 100] == dqflags.pixel['DROPOUT'])
-    assert(dqdata[400, 100] == dqflags.pixel['PERSISTENCE'])
-    assert(dqdata[500, 100] == dqflags.pixel['DO_NOT_USE'])
-    assert(dqdata[100, 200] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
-    assert(dqdata[200, 200] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
-    assert(dqdata[300, 200] == dqflags.pixel['DROPOUT'] + dqflags.pixel['DO_NOT_USE'])
-    assert(dqdata[400, 200] == dqflags.pixel['PERSISTENCE'] + dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[100, 100] == dqflags.pixel['SATURATED'])
+    assert (dqdata[200, 100] == dqflags.pixel['JUMP_DET'])
+    assert (dqdata[300, 100] == dqflags.pixel['DROPOUT'])
+    assert (dqdata[400, 100] == dqflags.pixel['PERSISTENCE'])
+    assert (dqdata[500, 100] == dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[100, 200] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[200, 200] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[300, 200] == dqflags.pixel['DROPOUT'] + dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[400, 200] == dqflags.pixel['PERSISTENCE'] + dqflags.pixel['DO_NOT_USE'])
 
 
 def test_groupdq():
@@ -121,8 +121,8 @@ def test_err():
     # check that ERR array was created and initialized to zero
     errarr = outfile.err
 
-    assert(errarr.ndim == 3)  # check that output err array is 3-D
-    assert(np.all(errarr == 0))  # check that values are 0
+    assert (errarr.ndim == 3)  # check that output err array is 3-D
+    assert (np.all(errarr == 0))  # check that values are 0
 
 
 def test_dq_add1_groupdq():
@@ -165,9 +165,9 @@ def test_dq_add1_groupdq():
 
     # test if pixels in pixeldq were incremented in value by 1
     # check that previous dq flag is added to mask value
-    assert(outfile.pixeldq[505, 505] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
+    assert (outfile.pixeldq[505, 505] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
     # check two flags propagate correctly
-    assert(outfile.pixeldq[400, 500] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
+    assert (outfile.pixeldq[400, 500] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
 
 
 @pytest.mark.parametrize(

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -124,10 +124,10 @@ def test_apply_photom1():
     area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
 
     # Tests for pixel areas
-    assert(np.isclose(output_model.meta.photometry.pixelarea_steradians.value,
+    assert (np.isclose(output_model.meta.photometry.pixelarea_steradians.value,
                         area_ster.value, atol=1.e-7))
     assert output_model.meta.photometry.pixelarea_steradians.unit == area_ster.unit
-    assert(np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value,
+    assert (np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value,
                         area_a2.value, atol=1.e-7))
     assert output_model.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit
 
@@ -269,9 +269,9 @@ def test_photom_step_interface_spectroscopic(instrument, exptype):
     area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
 
     # Tests for pixel areas
-    assert(np.isclose(result.meta.photometry.pixelarea_steradians.value,
+    assert (np.isclose(result.meta.photometry.pixelarea_steradians.value,
                         area_ster.value, atol=1.e-7))
     assert result.meta.photometry.pixelarea_steradians.unit == area_ster.unit
-    assert(np.isclose(result.meta.photometry.pixelarea_arcsecsq.value,
+    assert (np.isclose(result.meta.photometry.pixelarea_arcsecsq.value,
                         area_a2.value, atol=1.e-7))
     assert result.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR fixes `flake8` warnings (`E275 missing whitespace after keyword`).

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
