### PR TITLE
Fix photom test

### DIFF
--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -61,10 +61,10 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
                   str((photom_out.meta.photometry.conversion_microjanskys.unit ==
                        u.uJy / u.arcsec ** 2) and
                       (math.isclose(photom_out.meta.photometry.conversion_microjanskys.value,
-                                    7.5549, abs_tol=0.0001))))
+                                    7.81320, abs_tol=0.0001))))
     assert photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec ** 2
     assert math.isclose(photom_out.meta.photometry.conversion_microjanskys.value,
-                        7.5549, abs_tol=0.0001)
+                        7.81320, abs_tol=0.0001)
 
     step.log.info('DMS140 MSG: Pixel area in steradians calculated? : ' +
                   str((photom_out.meta.photometry.pixelarea_steradians.unit == u.sr) and

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -52,10 +52,10 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     step.log.info('DMS140 MSG: Photom megajansky conversion calculated? : ' +
                   str((photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr) and
                        math.isclose(photom_out.meta.photometry.conversion_megajanskys.value,
-                                    0.3214, abs_tol=0.0001)))
+                                    0.3324, abs_tol=0.0001)))
     assert photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr
     assert math.isclose(photom_out.meta.photometry.conversion_megajanskys.value,
-                        0.3214, abs_tol=0.0001)
+                        0.3324, abs_tol=0.0001)
 
     step.log.info('DMS140 MSG: Photom microjanskys conversion calculated? : ' +
                   str((photom_out.meta.photometry.conversion_microjanskys.unit ==


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates some photom parameters and artifactory files for test_wfi_photom.py
and now,
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 1 passed, 18 deselected, 1 warning in 802.56s (0:13:22) ============


**Checklist**
- [N/A] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
