### PR TITLE
check whether `requirements-sdp.txt` is empty before publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,7 +5,13 @@ on:
     types: [released]
 
 jobs:
+  check:
+    name: check that `requirements-sdp.txt` is populated
+    runs-on: ubuntu-latest
+    steps:
+      - run: "[[ -z $(grep -v '^ *#' requirements-sdp.txt) ]] && { echo \"requirements-sdp.txt is empty\" ; exit 1; }"
   publish:
+    needs: [ check ]
     uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
     with:
       test: false


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This change ensures that `requirements-sdp.txt` has requirements in it (non-commented lines) before allowing the PyPI publish to occur. This can hopefully prevent releases without SDP requirements.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
