### PR TITLE
use `ruff` in place of `flake8`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,7 @@ general
 - New Roman's RTD page layout [#596]
 
 - pin ``numpy`` to ``>=1.20`` [#592]
-- replace `flake8` with `ruff` [#570]
+- replace ``flake8`` with ``ruff`` [#570]
 
 
 jump

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ general
 - New Roman's RTD page layout [#596]
 
 - pin ``numpy`` to ``>=1.20`` [#592]
+- replace `flake8` with `ruff` [#570]
 
 
 jump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,14 +89,14 @@ zip-safe = false
 [tool.setuptools.package-data]
 # package_data values are glob patterns relative to each specific subpackage.
 '*' = [
-    '*.fits',
-    '*.txt',
-    '*.inc',
-    '*.cfg',
-    '*.csv',
-    '*.yaml',
-    '*.json',
-    '*.asdf',
+    '**/*.fits',
+    '**/*.txt',
+    '**/*.inc',
+    '**/*.cfg',
+    '**/*.csv',
+    '**/*.yaml',
+    '**/*.json',
+    '**/*.asdf',
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,3 +150,18 @@ report = { exclude_lines = [
 
 [tool.bandit]
 skips = ["B101", "B307", "B404", "B603"]
+
+[tool.ruff]
+line-length = 130
+exclude = [
+    'jdocs',
+    '.tox',
+    '.eggs',
+]
+ignore = [
+    'A001', # Variable is shadowing a python builtin
+    'A002', # Argument is shadowing a python builtin
+    'A003', # class attribute is shadowing a python builtin
+    'E741', # ambiguous variable name
+    'SPR001', # Use `super()` instead of `super(__class__, self)`
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,9 +159,5 @@ exclude = [
     '.eggs',
 ]
 ignore = [
-    'A001', # Variable is shadowing a python builtin
-    'A002', # Argument is shadowing a python builtin
-    'A003', # class attribute is shadowing a python builtin
     'E741', # ambiguous variable name
-    'SPR001', # Use `super()` instead of `super(__class__, self)`
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ exclude = [
     'jdocs',
     '.tox',
     '.eggs',
+    'build',
 ]
 ignore = [
     'E741', # ambiguous variable name


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`ruff` is an in-development Python linter written in Rust that aims for rule-checking parity with Flake8 and Black: https://github.com/charliermarsh/ruff

It has several advantages over `flake8`, including significant speedups in linting and support for `pyproject.toml` configuration and PEP517 / PEP621.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
