### PR TITLE
up `numpy` requirement to `1.20`

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -172,12 +172,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python: [ 3.8, 3.9, '3.10' ]
-        numpy: [ '1.18.*', '1.19.*', '1.20.*', '1.21.*', '1.22.*' ]
+        numpy: [ '1.20.*', '1.21.*', '1.22.*' ]
         exclude:
-          - python: '3.10'
-            numpy: '1.18.*'
-          - python: '3.10'
-            numpy: '1.19.*'
           - python: '3.10'
             numpy: '1.20.*'
     steps:
@@ -210,9 +206,8 @@ jobs:
           key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install ".[test]" pytest-xdist pytest-cov
       - run: pip freeze
-      - run: pytest -n auto --pyargs romancal --cov-report xml --cov
-      - run: coverage report -m
-      - uses: codecov/codecov-action@master
+      - run: pytest -n auto --cov --cov-report xml --cov-report term-missing
+      - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8.2 (unreleased)
 ==================
 
-- pin ``astropy`` to new version that pins ``numpy>=1.20`` [#592]
+- pin ``numpy`` to ``>=1.20`` [#592]
 
 0.8.1 (2022-08-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8.2 (unreleased)
 ==================
 
--
+- pin ``astropy`` to new version that pins ``numpy>=1.20`` [#592]
 
 0.8.1 (2022-08-23)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     crds>=11.13.1
     gwcs>=0.18.1
     jsonschema>=3.0.2
-    numpy
+    numpy>=1.20
     pyparsing>=2.4.7
     requests>=2.22
     roman_datamodels>=0.13.0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-52](https://jira.stsci.edu/browse/SCSB-52)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`astropy` is updating its `numpy` requirement to `1.20`, resulting in failures in CI jobs testing older `numpy` versions (https://github.com/spacetelescope/romancal/actions/runs/3311427058/jobs/5467138563).

Related to https://github.com/astropy/astropy/pull/13885

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
