### PR TITLE
RCAL-419 Update photom to use default suffix for spectral data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.8.2 (unreleased)
 ==================
 
+<<<<<<< HEAD
 - New Roman's RTD page layout [#596]
 
 - pin ``numpy`` to ``>=1.20`` [#592]
@@ -9,6 +10,18 @@ jump
 ----
 
 - Changes for new keywords (currently unused by Roman) to control snowball and shower flagging in jump detection. [#593]
+=======
+general
+-------
+
+- pin ``numpy`` to ``>=1.20`` [#592]
+
+photom
+------
+
+- Updates so that the default suffix is used for spectroscopic data. [#]
+
+>>>>>>> 2bc372b (RCAL-419 Update photom to use default suffix for spectral data)
 
 0.8.1 (2022-08-23)
 ==================
@@ -33,7 +46,7 @@ flat
 ----
 
 - Removed try/except condition on Flat Reference file CRDS lookup. [#528]
-  
+
 general
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,6 @@
 0.8.2 (unreleased)
 ==================
 
-<<<<<<< HEAD
 - New Roman's RTD page layout [#596]
 
 - pin ``numpy`` to ``>=1.20`` [#592]
@@ -10,18 +9,12 @@ jump
 ----
 
 - Changes for new keywords (currently unused by Roman) to control snowball and shower flagging in jump detection. [#593]
-=======
-general
--------
-
-- pin ``numpy`` to ``>=1.20`` [#592]
 
 photom
 ------
 
-- Updates so that the default suffix is used for spectroscopic data. [#]
+- Updates so that the default suffix is used for spectroscopic data. [#594]
 
->>>>>>> 2bc372b (RCAL-419 Update photom to use default suffix for spectral data)
 
 0.8.1 (2022-08-23)
 ==================

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -55,14 +55,14 @@ class PhotomStep(RomanStep):
                         photom_model.close()
                     except AttributeError:
                         pass
-                    return input_model
+                    output_model = input_model
 
             else:
                 # Skip Photom step if no photom file
                 self.log.warning('No PHOTOM reference file found')
                 self.log.warning('Photom step will be skipped')
                 input_model.meta.cal_step.photom = 'SKIPPED'
-                return input_model
+                output_model = input_model
 
         # Close the input and reference files
         input_model.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-419](https://jira.stsci.edu/browse/rcal-419)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates photom to use the default suffix when processing prism and grism data. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
