### PR TITLE
fix deprecation warnings ahead of Pytest 8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ general
 - Update the suffix for the stored filename to match the filename [#609]
 
 - DQ step flags science data affected by guide window read [#599]
-
+- Fix deprecation warnings introduced by ``pytest`` ``7.2`` ahead of ``8.0`` [#597]
 
 0.9.0 (2022-11-14)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ norecursedirs = [
     'docs/_build',
     'scripts',
     '.tox',
+    '.eggs',
+    'build',
 ]
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -77,7 +77,7 @@ def jail(request, tmpdir_factory):
     os.chdir(old_dir)
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     terminal_reporter = config.pluginmanager.getplugin('terminalreporter')
     config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), 'testdescription')


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
resolves [SCSB-53](https://jira.stsci.edu/browse/SCSB-53)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the Pytest deprecations introduced in 7.2 ahead of the 8.0 release.



**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
