### PR TITLE
Rcal-402 Add Flags for science data affected by guide window reads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,14 @@
 0.9.0 (2022-11-14)
 ==================
 
-- Additional changes to Roman's RTD page content [#600]
+general
+-------
 
 - New Roman's RTD page layout [#596]
 
 - pin ``numpy`` to ``>=1.20`` [#592]
+
+- DQ step flags science data affected by guide window read [#599]
 
 jump
 ----
@@ -28,6 +31,7 @@ photom
 ==================
 
 - pin ``asdf`` above ``2.12.1`` to fix issue with `jsonschema` release [#562]
+
 - pin `roman_datamodels` to newest feature version [#563]
 
 0.8.0 (2022-08-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.9.1 (unreleased)
 ==================
 
+general
+-------
+
+- DQ step flags science data affected by guide window read [#599]
+
+
 0.9.0 (2022-11-14)
 ==================
 
@@ -11,7 +17,6 @@ general
 
 - pin ``numpy`` to ``>=1.20`` [#592]
 
-- DQ step flags science data affected by guide window read [#599]
 
 jump
 ----

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from romancal.stpipe import RomanStep
 from romancal.dq_init import dq_initialization
+from romancal.lib import dqflags
 from roman_datamodels.datamodels import RampModel
 import roman_datamodels as rdm
 from roman_datamodels.testing import utils as testutil
@@ -42,7 +43,7 @@ class DQInitStep(RomanStep):
         input_model = self.open_model(input)
 
         # Convert to RampModel if needed
-        if not (isinstance(input_model, RampModel)):
+        if not isinstance(input_model, RampModel):
             # Create base ramp node with dummy values (for validation)
             input_ramp = testutil.mk_ramp(input_model.shape)
 
@@ -67,7 +68,7 @@ class DQInitStep(RomanStep):
         x_start = input_model.meta.guidestar.gw_window_xstart
         x_end = input_model.meta.guidestar.gw_window_xsize + x_start
         # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
-        init_model.pixeldq[int(x_start):int(x_end),:] = 2**4
+        init_model.pixeldq[int(x_start):int(x_end),:] = dqflags.pixel['GW_AFFECTED_DATA']
         self.log.info(f'Flagging rows from: {x_start} to {x_end} '
                       'as affected by guide window read')
 

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -63,6 +63,14 @@ class DQInitStep(RomanStep):
         else:
             init_model = input_model
 
+        # guide window range information
+        x_start = input_model.meta.guidestar.gw_window_xstart
+        x_end = input_model.meta.guidestar.gw_window_xsize + x_start
+        # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
+        init_model.pixeldq[int(x_start):int(x_end),:] = 2**4
+        self.log.info(f'Flagging rows from: {x_start} to {x_end} '
+                      'as affected by guide window read')
+
         # Get reference file path
         reference_file_name = self.get_reference_file(init_model, "mask")
 
@@ -102,7 +110,6 @@ class DQInitStep(RomanStep):
 
             output_model = init_model
             output_model.meta.cal_step.dq_init = 'SKIPPED'
-
 
         # Close the input and reference files
         input_model.close()

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -4,13 +4,13 @@ import numpy as np
 import pytest
 import warnings
 
-from romancal.lib import dqflags
-from romancal.dq_init import DQInitStep
-from romancal.dq_init.dq_initialization import do_dqinit
-
 from roman_datamodels import stnode
 from roman_datamodels.datamodels import MaskRefModel, ScienceRawModel
 from roman_datamodels.testing import utils as testutil
+
+from romancal.lib import dqflags
+from romancal.dq_init import DQInitStep
+from romancal.dq_init.dq_initialization import do_dqinit
 
 # Set parameters for multiple runs of data
 args = "xstart, ystart, xsize, ysize, ngroups, instrument, exp_type"
@@ -37,6 +37,7 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     dq[300, 100] = 8   # Dropout
     dq[400, 100] = 32  # Persistence
     dq[500, 100] = 1   # Do_not_use
+    dq[600, 100] = 16  # guide window affected data
     dq[100, 200] = 3   # Saturated pixel + do not use
     dq[200, 200] = 5   # Jump detected pixel + do not use
     dq[300, 200] = 9   # Dropout + do not use
@@ -60,6 +61,7 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     assert (dqdata[300, 100] == dqflags.pixel['DROPOUT'])
     assert (dqdata[400, 100] == dqflags.pixel['PERSISTENCE'])
     assert (dqdata[500, 100] == dqflags.pixel['DO_NOT_USE'])
+    assert (dqdata[600, 100] == dqflags.pixel['GW_AFFECTED_DATA'])
     assert (dqdata[100, 200] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
     assert (dqdata[200, 200] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
     assert (dqdata[300, 200] == dqflags.pixel['DROPOUT'] + dqflags.pixel['DO_NOT_USE'])

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -241,6 +241,8 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.meta.instrument.name = instrument
     wfi_sci_raw.meta.instrument.detector = 'WFI01'
     wfi_sci_raw.meta.instrument.optical_element = 'F158'
+    wfi_sci_raw.meta.guidestar.gw_window_xstart = 1012
+    wfi_sci_raw.meta.guidestar.gw_window_xsize = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -121,8 +121,8 @@ def test_err():
     # check that ERR array was created and initialized to zero
     errarr = outfile.err
 
-    assert (errarr.ndim == 3)  # check that output err array is 3-D
-    assert (np.all(errarr == 0))  # check that values are 0
+    assert errarr.ndim == 3  # check that output err array is 3-D
+    assert np.all(errarr == 0)  # check that values are 0
 
 
 def test_dq_add1_groupdq():
@@ -191,6 +191,8 @@ def test_dqinit_step_interface(instrument, exptype):
     wfi_sci_raw.meta.instrument.name = instrument
     wfi_sci_raw.meta.instrument.detector = 'WFI01'
     wfi_sci_raw.meta.instrument.optical_element = 'F158'
+    wfi_sci_raw.meta['guidestar']['gw_window_xstart'] = 1012
+    wfi_sci_raw.meta['guidestar']['gw_window_xsize'] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
@@ -241,8 +243,8 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.meta.instrument.name = instrument
     wfi_sci_raw.meta.instrument.detector = 'WFI01'
     wfi_sci_raw.meta.instrument.optical_element = 'F158'
-    wfi_sci_raw.meta.guidestar.gw_window_xstart = 1012
-    wfi_sci_raw.meta.guidestar.gw_window_xsize = 16
+    wfi_sci_raw.meta['guidestar']['gw_window_xstart'] = 1012
+    wfi_sci_raw.meta['guidestar']['gw_window_xsize'] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)

--- a/romancal/lib/dqflags.py
+++ b/romancal/lib/dqflags.py
@@ -26,7 +26,7 @@ pixel = {'GOOD':             0,      # No bits set, all is good
          'SATURATED':        2**1,   # Pixel saturated during exposure
          'JUMP_DET':         2**2,   # Jump detected during exposure
          'DROPOUT':          2**3,   # Data lost in transmission
-         'RESERVED_1':       2**4,   #
+         'GW_AFFECTED_DATA': 2**4,   # Data affected by the GW read window
          'PERSISTENCE':      2**5,   # High persistence (was RESERVED_2)
          'AD_FLOOR':         2**6,   # Below A/D floor (0 DN, was RESERVED_3)
          'RESERVED_4':       2**7,   #


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-402](https://jira.stsci.edu/browse/JP-402)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #579 

<!-- describe the changes comprising this PR here -->
This PR adds flagging for science data that is affected by the guide window reads and have enhanced noise. The flag is 'GW_AFFECTED_DATA': 2**4

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
