### PR TITLE
rename `toxenv`s to be more explicit

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -22,21 +22,14 @@ env:
 
 jobs:
   check:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [ check-style, check-security, check-install ]
+        toxenv: [ check-style, check-security, check-dependencies, check-build ]
         python-version: [ '3.x' ]
         os: [ ubuntu-latest ]
-        include:
-          - name: Code style check
-            toxenv: check-style
-          - name: Security audit
-            toxenv: check-security
-          - name: Verify install_requires in setup.py
-            toxenv: check-install
     steps:
       - uses: actions/checkout@v3
         with:
@@ -184,21 +177,3 @@ jobs:
           file: ./coverage.xml
           flags: unit
           fail_ci_if_error: true
-  build:
-    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ test ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        toxenv: [ build-twine ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
-        os: [ ubuntu-latest, macos-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,20 @@ deps =
 commands =
     bandit romancal -r -x tests,regtest
 
-[testenv:check-install]
-description = verify that dependencies are correct
-extras =
+[testenv:check-dependencies]
+description = verify that install_requires in setup.cfg has correct dependencies
 commands =
     verify_install_requires
+
+[testenv:check-build]
+description = check build sdist/wheel and a strict twine check for metadata
+skip_install = true
+deps =
+    twine>=3.3
+    build
+commands =
+    python -m build .
+    twine check --strict dist/*
 
 [testenv]
 description =
@@ -86,16 +95,6 @@ changedir = {homedir}
 usedevelop = false
 commands =
     pyargs: pytest {toxinidir}/docs --pyargs {posargs:romancal}
-
-[testenv:build-twine]
-description = check that the package builds sdist/wheel and that twine uploads
-deps =
-    twine>=3.3
-    pep517
-usedevelop = false
-commands =
-    python -m pep517.check .
-    twine check --strict {distdir}/*
 
 [testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR renames two `toxenv`s to be more explicit in their function, and makes changes to `roman_ci.yml` accordingly.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
