### PR TITLE
add Datadog CI agent

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -83,7 +83,8 @@ jobs:
             os: ubuntu-latest
             python-version: '3.8'
     steps:
-      - uses: datadog/agent-github-action@v1
+      - if: contains(runner.os, 'Linux')
+        uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
         env:
@@ -109,7 +110,7 @@ jobs:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ steps.crds-context.outputs.pmap }}
       - run: tox -e ${{ matrix.toxenv }}-ddtrace
-      - if: ${{ contains(matrix.toxenv,'-cov') }}
+      - if: contains(matrix.toxenv, '-cov')
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -83,6 +83,12 @@ jobs:
             os: ubuntu-latest
             python-version: '3.8'
     steps:
+      - uses: datadog/agent-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+        env:
+          DD_INSIDE_CI: true
+          DD_HOSTNAME: none
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -102,7 +108,7 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ steps.crds-context.outputs.pmap }}
-      - run: tox -e ${{ matrix.toxenv }}
+      - run: tox -e ${{ matrix.toxenv }}-ddtrace
       - if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@v3
         with:

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -55,6 +55,8 @@ env_vars = [
     "CRDS_CONTEXT=roman_0039.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
+    'DD_ENV=ci',
+    'DD_SERVICE=romancal',
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))
@@ -83,13 +85,14 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
-    "pip install pytest-xdist pytest-sugar",
+    "pip install pytest-xdist pytest-sugar ddtrace",
     "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
+    --ddtrace \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     'codecov --token=${codecov_token} -F nightly',

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ description =
     regtests: with --bigdata and --slow flags
     cov: with coverage
     xdist: using parallel processing
+    ddtrace: passing test traces to DataDog agent
 passenv =
     HOME
     CI
@@ -65,6 +66,9 @@ passenv =
     CRDS_*
     TEST_BIGDATA
     CODECOV_*
+setenv =
+    ddtrace: DD_SERVICE=romancal
+    ddtrace: DD_ENV=ci
 args_are_paths = false
 change_dir = pyargs: {homedir}
 extras =
@@ -76,6 +80,7 @@ deps =
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
+    ddtrace: ddtrace
 commands_pre =
     pip freeze
 commands =
@@ -85,6 +90,7 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     pyargs: {toxinidir}/docs --pyargs {posargs:romancal} \
+    ddtrace: --ddtrace \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR adds tracers for Datadog

This is a copy of #606 , moved here to ensure that the CI tests have access to the `DD_API_KEY` organizational secret

It appears that Datadog requires CI runs to be run against the main branch in order to show on the dashboard

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
