### PR TITLE
[hotfix] fix CI on PRs from forks

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -83,7 +83,7 @@ jobs:
             os: ubuntu-latest
             python-version: '3.8'
     steps:
-      - if: contains(runner.os, 'Linux')
+      - if: contains(runner.os, 'Linux') && github.repository_owner == 'spacetelescope'
         uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -83,13 +83,10 @@ jobs:
             os: ubuntu-latest
             python-version: '3.8'
     steps:
-      - if: contains(runner.os, 'Linux') && github.repository_owner == 'spacetelescope'
+      - if: contains(runner.os, 'Linux') && github.event_name != 'pull_request'
         uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
-        env:
-          DD_INSIDE_CI: true
-          DD_HOSTNAME: none
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where PRs from forks cannot run because they don't have access to the `DD_API_KEY` organizational secret.

Hotfix for #615 

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
