### PR TITLE
fix branch filter to trigger on release branches

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - '*.x'
+      - '*x'
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR widens the branch trigger for CI workflow runs, ensuring that release branches with a trailing `x` are always tested.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
