### PR TITLE
RCAL-460 Update default CR rejections in jump_step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ general
 jump
 ----
 
-- Update default input CR thresholds to give reasonable results [#]
+- Update default input CR thresholds to give reasonable results [#625]
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,15 @@ general
 - DQ step flags science data affected by guide window read [#599]
 - Fix deprecation warnings introduced by ``pytest`` ``7.2`` ahead of ``8.0`` [#597]
 
-0.9.0 (2022-11-14)
+jump
+----
+
+- Update default input CR thresholds to give reasonable results [#]
+
+
+
+
+  0.9.0 (2022-11-14)
 ==================
 
 general

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -25,9 +25,9 @@ class JumpStep(RomanStep):
     """
 
     spec = """
-        rejection_threshold = float(default=4.0,min=0) # CR sigma rej thresh
-        three_group_rejection_threshold = float(default=6.0,min=0) # CR sigma rej thresh
-        four_group_rejection_threshold = float(default=5.0,min=0) # CR sigma rej thresh
+        rejection_threshold = float(default=180.0,min=0) # CR sigma rej thresh
+        three_group_rejection_threshold = float(default=185.0,min=0) # CR sigma rej thresh
+        four_group_rejection_threshold = float(default=190.0,min=0) # CR sigma rej thresh
         maximum_cores = option('none', 'quarter', 'half', 'all', default='none') # max number of processes to create
         flag_4_neighbors = boolean(default=True) # flag the four perpendicular neighbors of each CR
         max_jump_to_flag_neighbors = float(default=1000) # maximum jump sigma that will trigger neighbor flagging


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-460](https://jira.stsci.edu/browse/rcal-460)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses updates the default jump CR rejection threshold to give "reasonable" run times and approximately the correct number of cosmic rays. This is a known issue with the code in common with JWST and the JWST team is looking at why the parameters are not working as expected. We will adopt their solution once available. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
