### PR TITLE
Start using code formatters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 
 [flake8]
 select = F, W, E27, E70, E71, E101, E111, E112, E113, E201, E202, E221, E222, E241, E401, E402, E501, E704, E722
-max-line-length = 130
+max-line-length = 88
 exclude =
     docs,
     .tox,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
   hooks:
     - id: isort
 
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+    - id: black
+
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,12 @@ repos:
     - id: pyupgrade
       args: ["--py38-plus"]
 
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.255'
+  hooks:
+    - id: ruff
+      args: ["--fix"]
+
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:
@@ -40,11 +46,6 @@ repos:
   rev: 22.12.0
   hooks:
     - id: black
-
-- repo: https://github.com/pycqa/flake8
-  rev: '6.0.0'
-  hooks:
-  -   id: flake8
 
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
     - id: pyupgrade
       args: ["--py38-plus"]
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ general
 
 - Add ``pre-commit`` configuration to repository. [#622]
 
+- Use ``isort`` and ``black`` to format code, also upgrade all string
+  formats using ``flynt``. [#645]
+
 - Update the suffix for the stored filename to match the filename [#609]
 
 - DQ step flags science data affected by guide window read [#599]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,19 +32,19 @@ def setup(app):
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('romancal/'))
-sys.path.insert(0, os.path.abspath('exts/'))
+sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(0, os.path.abspath("romancal/"))
+sys.path.insert(0, os.path.abspath("exts/"))
 
 # -- General configuration ------------------------------------------------
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
     conf = tomli.load(configuration_file)
-setup_cfg = conf['project']
+setup_cfg = conf["project"]
 
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.3'
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 
 def check_sphinx_version(expected_version):
@@ -52,69 +52,69 @@ def check_sphinx_version(expected_version):
     expected_version = LooseVersion(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
-            f"At least Sphinx version {expected_version} is required to build this "
-            f"documentation.  Found {sphinx_version}.")
+            f"At least Sphinx version {expected_version} is required to build this documentation.  Found {sphinx_version}."
+        )
 
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://numpy.org/devdocs', None),
-    'scipy': ('http://scipy.github.io/devdocs', None),
-    'matplotlib': ('http://matplotlib.org/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/devdocs", None),
+    "scipy": ("http://scipy.github.io/devdocs", None),
+    "matplotlib": ("http://matplotlib.org/", None),
 }
 
 if sys.version_info[0] == 2:
-    intersphinx_mapping['python'] = ('http://docs.python.org/2/', None)
-    intersphinx_mapping['pythonloc'] = (
-        'http://docs.python.org/',
-        os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                     'local/python2_local_links.inv')))
+    intersphinx_mapping["python"] = ("http://docs.python.org/2/", None)
+    intersphinx_mapping["pythonloc"] = (
+        "http://docs.python.org/",
+        os.path.abspath(os.path.join(os.path.dirname(__file__), "local/python2_local_links.inv")),
+    )
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'numfig',
-    'pytest_doctestplus.sphinx.doctestplus',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-    'sphinx_automodapi.automodapi',
-    'sphinx_automodapi.automodsumm',
-    'sphinx_automodapi.autodoc_enhancements',
-    'sphinx_automodapi.smart_resolver',
-    'sphinx_asdf',
-'myst_parser',
-    ]
+    "numfig",
+    "pytest_doctestplus.sphinx.doctestplus",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.automodsumm",
+    "sphinx_automodapi.autodoc_enhancements",
+    "sphinx_automodapi.smart_resolver",
+    "sphinx_asdf",
+    "myst_parser",
+]
 
 if on_rtd:
-    extensions.append('sphinx.ext.mathjax')
+    extensions.append("sphinx.ext.mathjax")
 
-elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
-    extensions.append('sphinx.ext.pngmath')
+elif LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
+    extensions.append("sphinx.ext.pngmath")
 else:
-    extensions.append('sphinx.ext.imgmath')
+    extensions.append("sphinx.ext.imgmath")
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = {
-    '.rst': 'restructuredtext',
-    '.md': 'markdown',
+    ".rst": "restructuredtext",
+    ".md": "markdown",
 }
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # A list of warning types to suppress arbitrary warning messages. We mean to
 # override directives in astropy_helpers.sphinx.ext.autodoc_enhancements,
@@ -122,26 +122,28 @@ master_doc = 'index'
 # released in upstream Sphinx (https://github.com/sphinx-doc/sphinx/pull/1843).
 # Suppress the warnings requires Sphinx v1.4.2
 
-suppress_warnings = ['app.add_directive', ]
+suppress_warnings = [
+    "app.add_directive",
+]
 
 # General information about the project
-project = setup_cfg['name']
+project = setup_cfg["name"]
 author = f'{setup_cfg["authors"][0]["name"]} <{setup_cfg["authors"][0]["email"]}>'
-copyright = f'{datetime.datetime.now().year}, {author}'
+copyright = f"{datetime.datetime.now().year}, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-package = importlib.import_module(setup_cfg['name'])
+package = importlib.import_module(setup_cfg["name"])
 try:
-    version = package.__version__.split('-', 1)[0]
+    version = package.__version__.split("-", 1)[0]
     # The full version, including alpha/beta/rc tags.
     release = package.__version__
 except AttributeError:
-    version = 'dev'
-    release = 'dev'
+    version = "dev"
+    release = "dev"
 
 # The language for content autogenerated by Sphinx. Refer to documentation
 # for a list of supported languages.
@@ -155,7 +157,7 @@ except AttributeError:
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -163,7 +165,7 @@ rst_epilog = """.. _romancal: high-level_API.html"""
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = 'obj'
+default_role = "obj"
 
 # Don't show summaries of the members in each class along with the
 # class' docstring
@@ -171,7 +173,7 @@ numpydoc_show_class_members = False
 
 autosummary_generate = True
 
-automodapi_toctreedirnm = 'api'
+automodapi_toctreedirnm = "api"
 
 # Class documentation should contain *both* the class docstring and
 # the __init__ docstring
@@ -181,12 +183,12 @@ autoclass_content = "both"
 graphviz_output_format = "svg"
 
 graphviz_dot_args = [
-    '-Nfontsize=10',
-    '-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif',
-    '-Efontsize=10',
-    '-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif',
-    '-Gfontsize=10',
-    '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
+    "-Nfontsize=10",
+    "-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif",
+    "-Efontsize=10",
+    "-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif",
+    "-Gfontsize=10",
+    "-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif",
 ]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
@@ -201,7 +203,7 @@ graphviz_dot_args = [
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+pygments_style = "default"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -211,25 +213,21 @@ pygments_style = 'default'
 
 # Mapping for links to the ASDF Standard in ASDF schema documentation
 asdf_schema_reference_mappings = [
-    ('tag:stsci.edu:asdf',
-     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+    ("tag:stsci.edu:asdf", "http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/"),
 ]
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 html_logo = "_static/roman_logo_white_w100px.png"
-html_favicon = '_static/favicon.ico'
+html_favicon = "_static/favicon.ico"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "collapse_navigation": True,
-"display_version": True
-    }
+html_theme_options = {"collapse_navigation": True, "display_version": True}
 #        "nosidebar": "false",
 #        "sidebarbgcolor": "#4db8ff",
 #        "sidebartextcolor": "black",
@@ -258,7 +256,7 @@ html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -267,14 +265,14 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['globaltoc.html', 'relations.html', 'searchbox.html']}
+html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -307,7 +305,7 @@ html_use_index = True
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'romandoc'
+htmlhelp_basename = "romandoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -353,10 +351,7 @@ htmlhelp_basename = 'romandoc'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'romancal', 'Roman Pipeline Documentation',
-     ['romancal'], 1)
-]
+man_pages = [("index", "romancal", "Roman Pipeline Documentation", ["romancal"], 1)]
 
 # If true, show URL addresses after external links.
 man_show_urls = True
@@ -367,9 +362,15 @@ man_show_urls = True
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'romancal', 'Roman Pipeline Documentation',
-     'romancal', 'romancal', 'Roman Pipeline Documentation',
-     'Miscellaneous'),
+    (
+        "index",
+        "romancal",
+        "Roman Pipeline Documentation",
+        "romancal",
+        "romancal",
+        "Roman Pipeline Documentation",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -379,7 +380,7 @@ texinfo_documents = [
 texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-texinfo_show_urls = 'inline'
+texinfo_show_urls = "inline"
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
@@ -388,10 +389,10 @@ texinfo_show_urls = 'inline'
 # -- Options for Epub output ----------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = 'Roman'
-epub_author = 'STSCI'
-epub_publisher = 'STSCI'
-epub_copyright = '2017, AURA'
+epub_title = "Roman"
+epub_author = "STSCI"
+epub_publisher = "STSCI"
+epub_copyright = "2017, AURA"
 
 # The basename for the epub file. It defaults to the project name.
 # epub_basename = u'Roman'
@@ -400,7 +401,7 @@ epub_copyright = '2017, AURA'
 # optimized for small screen space, using the same theme for HTML and
 # epub output is usually not wise. This defaults to 'epub', a theme designed
 # to save visual space.
-epub_theme = 'epub'
+epub_theme = "epub"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.
@@ -431,7 +432,7 @@ epub_theme = 'epub'
 # epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
 # epub_tocdepth = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,8 @@ def check_sphinx_version(expected_version):
     expected_version = LooseVersion(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
-            f"At least Sphinx version {expected_version} is required to build this documentation.  Found {sphinx_version}."
+            f"At least Sphinx version {expected_version} is required to build this"
+            f" documentation.  Found {sphinx_version}."
         )
 
 
@@ -68,7 +69,9 @@ if sys.version_info[0] == 2:
     intersphinx_mapping["python"] = ("http://docs.python.org/2/", None)
     intersphinx_mapping["pythonloc"] = (
         "http://docs.python.org/",
-        os.path.abspath(os.path.join(os.path.dirname(__file__), "local/python2_local_links.inv")),
+        os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "local/python2_local_links.inv")
+        ),
     )
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -213,7 +216,10 @@ pygments_style = "default"
 
 # Mapping for links to the ASDF Standard in ASDF schema documentation
 asdf_schema_reference_mappings = [
-    ("tag:stsci.edu:asdf", "http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/"),
+    (
+        "tag:stsci.edu:asdf",
+        "http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/",
+    ),
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,7 +7,7 @@ def _docdir(request):
     # Trigger ONLY for doctestplus.
     doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
     if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-        tmpdir = request.getfixturevalue('tmpdir')
+        tmpdir = request.getfixturevalue("tmpdir")
         with tmpdir.as_cwd():
             yield
     else:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def _docdir(request):
 

--- a/docs/exts/numfig.py
+++ b/docs/exts/numfig.py
@@ -1,6 +1,5 @@
-from docutils.nodes import figure, caption, Text, reference, raw, SkipNode
+from docutils.nodes import SkipNode, Text, caption, figure, raw, reference
 from sphinx.roles import XRefRole
-
 
 # Element classes
 

--- a/docs/exts/numfig.py
+++ b/docs/exts/numfig.py
@@ -55,7 +55,9 @@ def doctree_resolved(app, doctree, docname):
     for figure_info in doctree.traverse(figure):
         if app.builder.name != "latex" and app.config.number_figures:
             for cap in figure_info.traverse(caption):
-                cap[0] = Text("%s %d: %s" % (app.config.figure_caption_prefix, i, cap[0]))
+                cap[0] = Text(
+                    "%s %d: %s" % (app.config.figure_caption_prefix, i, cap[0])
+                )
 
         for id in figure_info["ids"]:
             figids[id] = i
@@ -78,7 +80,9 @@ def doctree_resolved(app, doctree, docname):
             if app.builder.name == "html":
                 target_doc = app.builder.env.figid_docname_map[target]
                 link = f"{app.builder.get_relative_uri(docname, target_doc)}#{target}"
-                html = f'<a class="pageref" href="{link}">{labelfmt %(figids[target])}</a>'
+                html = (
+                    f'<a class="pageref" href="{link}">{labelfmt %(figids[target])}</a>'
+                )
                 ref_info.replace_self(raw(html, html, format="html"))
             else:
                 ref_info.replace_self(Text(labelfmt % (figids[target])))
@@ -93,7 +97,12 @@ def setup(app):
     app.add_config_value("number_figures", True, True)
     app.add_config_value("figure_caption_prefix", "Figure", True)
 
-    app.add_node(page_ref, text=(skip_page_ref, None), html=(skip_page_ref, None), latex=(latex_visit_page_ref, None))
+    app.add_node(
+        page_ref,
+        text=(skip_page_ref, None),
+        html=(skip_page_ref, None),
+        latex=(latex_visit_page_ref, None),
+    )
 
     app.add_role("page", XRefRole(nodeclass=page_ref))
 

--- a/docs/exts/numfig.py
+++ b/docs/exts/numfig.py
@@ -3,8 +3,10 @@ from sphinx.roles import XRefRole
 
 # Element classes
 
+
 class page_ref(reference):
     pass
+
 
 class num_ref(reference):
     pass
@@ -12,22 +14,25 @@ class num_ref(reference):
 
 # Visit/depart functions
 
+
 def skip_page_ref(self, node):
     raise SkipNode
 
+
 def latex_visit_page_ref(self, node):
-    self.body.append("\\pageref{{{}:{}}}".format(node['refdoc'], node['reftarget']))
+    self.body.append("\\pageref{{{}:{}}}".format(node["refdoc"], node["reftarget"]))
     raise SkipNode
 
+
 def latex_visit_num_ref(self, node):
-    fields = node['reftarget'].split('#')
+    fields = node["reftarget"].split("#")
     if len(fields) > 1:
         label, target = fields
-        ref_link = '{}:{}'.format(node['refdoc'], target)
+        ref_link = "{}:{}".format(node["refdoc"], target)
         latex = f"\\hyperref[{ref_link}]{{{label} \\ref*{{{ref_link}}}}}"
         self.body.append(latex)
     else:
-        self.body.append('\\ref{{{}:{}}}'.format(node['refdoc'], fields[0]))
+        self.body.append("\\ref{{{}:{}}}".format(node["refdoc"], fields[0]))
 
     raise SkipNode
 
@@ -35,10 +40,10 @@ def latex_visit_num_ref(self, node):
 def doctree_read(app, doctree):
     # first generate figure numbers for each figure
     env = app.builder.env
-    figid_docname_map = getattr(env, 'figid_docname_map', {})
+    figid_docname_map = getattr(env, "figid_docname_map", {})
 
     for figure_info in doctree.traverse(figure):
-        for id in figure_info['ids']:
+        for id in figure_info["ids"]:
             figid_docname_map[id] = env.docname
 
     env.figid_docname_map = figid_docname_map
@@ -48,59 +53,54 @@ def doctree_resolved(app, doctree, docname):
     i = 1
     figids = {}
     for figure_info in doctree.traverse(figure):
-        if app.builder.name != 'latex' and app.config.number_figures:
+        if app.builder.name != "latex" and app.config.number_figures:
             for cap in figure_info.traverse(caption):
                 cap[0] = Text("%s %d: %s" % (app.config.figure_caption_prefix, i, cap[0]))
 
-        for id in figure_info['ids']:
+        for id in figure_info["ids"]:
             figids[id] = i
 
         i += 1
 
-
     # replace numfig nodes with links
-    if app.builder.name != 'latex':
+    if app.builder.name != "latex":
         for ref_info in doctree.traverse(num_ref):
-            if '#' in ref_info['reftarget']:
-                label, target = ref_info['reftarget'].split('#')
+            if "#" in ref_info["reftarget"]:
+                label, target = ref_info["reftarget"].split("#")
                 labelfmt = label + " %d"
             else:
-                labelfmt = '%d'
-                target = ref_info['reftarget']
+                labelfmt = "%d"
+                target = ref_info["reftarget"]
 
             if target not in figids:
                 continue
 
-            if app.builder.name == 'html':
+            if app.builder.name == "html":
                 target_doc = app.builder.env.figid_docname_map[target]
-                link = "{}#{}".format(app.builder.get_relative_uri(docname, target_doc),
-                                  target)
+                link = f"{app.builder.get_relative_uri(docname, target_doc)}#{target}"
                 html = f'<a class="pageref" href="{link}">{labelfmt %(figids[target])}</a>'
-                ref_info.replace_self(raw(html, html, format='html'))
+                ref_info.replace_self(raw(html, html, format="html"))
             else:
                 ref_info.replace_self(Text(labelfmt % (figids[target])))
 
 
 def clean_env(app):
-    app.builder.env.i=1
+    app.builder.env.i = 1
     app.builder.env.figid_docname_map = {}
 
+
 def setup(app):
-    app.add_config_value('number_figures', True, True)
-    app.add_config_value('figure_caption_prefix', "Figure", True)
+    app.add_config_value("number_figures", True, True)
+    app.add_config_value("figure_caption_prefix", "Figure", True)
 
-    app.add_node(page_ref,
-                 text=(skip_page_ref, None),
-                 html=(skip_page_ref, None),
-                 latex=(latex_visit_page_ref, None))
+    app.add_node(page_ref, text=(skip_page_ref, None), html=(skip_page_ref, None), latex=(latex_visit_page_ref, None))
 
-    app.add_role('page', XRefRole(nodeclass=page_ref))
+    app.add_role("page", XRefRole(nodeclass=page_ref))
 
-    app.add_node(num_ref,
-                 latex=(latex_visit_num_ref, None))
+    app.add_node(num_ref, latex=(latex_visit_num_ref, None))
 
-    app.add_role('num', XRefRole(nodeclass=num_ref))
+    app.add_role("num", XRefRole(nodeclass=num_ref))
 
     app.connect("builder-inited", clean_env)
-    app.connect('doctree-read', doctree_read)
-    app.connect('doctree-resolved', doctree_resolved)
+    app.connect("doctree-read", doctree_read)
+    app.connect("doctree-resolved", doctree_resolved)

--- a/docs/exts/numfig.py
+++ b/docs/exts/numfig.py
@@ -20,7 +20,7 @@ def skip_page_ref(self, node):
 
 
 def latex_visit_page_ref(self, node):
-    self.body.append("\\pageref{{{}:{}}}".format(node["refdoc"], node["reftarget"]))
+    self.body.append(f"\\pageref{{{node['refdoc']}:{node['reftarget']}}}")
     raise SkipNode
 
 
@@ -28,11 +28,11 @@ def latex_visit_num_ref(self, node):
     fields = node["reftarget"].split("#")
     if len(fields) > 1:
         label, target = fields
-        ref_link = "{}:{}".format(node["refdoc"], target)
+        ref_link = f"{node['refdoc']}:{target}"
         latex = f"\\hyperref[{ref_link}]{{{label} \\ref*{{{ref_link}}}}}"
         self.body.append(latex)
     else:
-        self.body.append("\\ref{{{}:{}}}".format(node["refdoc"], fields[0]))
+        self.body.append(f"\\ref{{{node['refdoc']}:{fields[0]}}}")
 
     raise SkipNode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ report = { exclude_lines = [
 [tool.bandit]
 skips = ["B101", "B307", "B404", "B603"]
 
+[tool.isort]
+profile = "black"
+filter_files = true
+line_length = 130
+
 [tool.ruff]
 line-length = 130
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,10 @@ skips = ["B101", "B307", "B404", "B603"]
 [tool.isort]
 profile = "black"
 filter_files = true
-line_length = 130
+line_length = 88
 
 [tool.black]
-line-length = 130
+line-length = 88
 force-exclude = '''
 ^/(
   (
@@ -171,7 +171,7 @@ force-exclude = '''
 '''
 
 [tool.ruff]
-line-length = 130
+line-length = 88
 exclude = [
     'jdocs',
     '.tox',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,19 @@ profile = "black"
 filter_files = true
 line_length = 130
 
+[tool.black]
+line-length = 130
+force-exclude = '''
+^/(
+  (
+      \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+  )/
+)
+'''
+
 [tool.ruff]
 line-length = 130
 exclude = [

--- a/romancal/__init__.py
+++ b/romancal/__init__.py
@@ -4,7 +4,9 @@ import sys
 from pkg_resources import DistributionNotFound, get_distribution
 
 if sys.version_info < (3, 6):
-    raise ImportError("Romancal supports Python versions 3.6 and above.")  # pragma: no cover
+    raise ImportError(
+        "Romancal supports Python versions 3.6 and above."
+    )  # pragma: no cover
 
 try:
     __version__ = get_distribution(__name__).version

--- a/romancal/__init__.py
+++ b/romancal/__init__.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
-from pkg_resources import get_distribution, DistributionNotFound
+
+from pkg_resources import DistributionNotFound, get_distribution
+
 if sys.version_info < (3, 6):
     raise ImportError("Romancal supports Python versions 3.6 and above.")  # pragma: no cover
 

--- a/romancal/assign_wcs/__init__.py
+++ b/romancal/assign_wcs/__init__.py
@@ -1,3 +1,3 @@
 from .assign_wcs_step import AssignWcsStep
 
-__all__ = ['AssignWcsStep']
+__all__ = ["AssignWcsStep"]

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -4,17 +4,15 @@ Assign a gWCS object to a science image.
 """
 import logging
 
+import gwcs.coordinate_frames as cf
 from astropy import coordinates as coord
 from astropy import units as u
-import gwcs.coordinate_frames as cf
-
 from gwcs.wcs import WCS, Step
-
 from roman_datamodels import datamodels as rdm
+
 from ..stpipe import RomanStep
 from . import pointing
 from .utils import wcs_bbox_from_shape
-
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -75,7 +75,12 @@ def load_wcs(input_model, reference_files=None):
 
     # Frames
     detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name="v2v3", axes_order=(0, 1), axes_names=("v2", "v3"), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(
+        name="v2v3",
+        axes_order=(0, 1),
+        axes_names=("v2", "v3"),
+        unit=(u.arcsec, u.arcsec),
+    )
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name="world")
 
     # Transforms between frames

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -141,7 +141,8 @@ def wfi_distortion(model, reference_files):
 
 def add_s_region(model):
     """
-    Calculate the detector's footprint using ``WCS.footprint`` and save it in the ``S_REGION`` keyword
+    Calculate the detector's footprint using ``WCS.footprint`` and save it in the
+    ``S_REGION`` keyword
 
     Parameters
     ----------
@@ -158,8 +159,8 @@ def add_s_region(model):
     if bbox is None:
         bbox = wcs_bbox_from_shape(model.data.shape)
 
-    # footprint is an array of shape (2, 4) - i.e. 4 values for RA and 4 values for Dec - as we
-    # are interested only in the footprint on the sky
+    # footprint is an array of shape (2, 4) - i.e. 4 values for RA and 4 values for
+    # Dec - as we are interested only in the footprint on the sky
     footprint = model.meta.wcs.footprint(bbox, center=True, axis_type="spatial").T
     # take only imaging footprint
     footprint = footprint[:2, :]

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -22,32 +22,31 @@ __all__ = ["AssignWcsStep", "load_wcs"]
 
 
 class AssignWcsStep(RomanStep):
-    """ Assign a gWCS object to a science image.
-    """
+    """Assign a gWCS object to a science image."""
 
-    reference_file_types = ['distortion']
+    reference_file_types = ["distortion"]
 
     def process(self, input):
         reference_file_names = {}
         with rdm.open(input) as input_model:
             for reftype in self.reference_file_types:
-                log.info(f'reftype, {reftype}')
+                log.info(f"reftype, {reftype}")
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
-            log.debug(f'reference files used in assign_wcs: {reference_file_names}')
+            log.debug(f"reference files used in assign_wcs: {reference_file_names}")
             result = load_wcs(input_model, reference_file_names)
 
         if self.save_results:
             try:
-                self.suffix = 'assignwcs'
+                self.suffix = "assignwcs"
             except AttributeError:
-                self['suffix'] = 'assignwcs'
+                self["suffix"] = "assignwcs"
 
         return result
 
 
 def load_wcs(input_model, reference_files=None):
-    """ Create a gWCS object and store it in ``Model.meta``.
+    """Create a gWCS object and store it in ``Model.meta``.
 
     Parameters
     ----------
@@ -75,27 +74,25 @@ def load_wcs(input_model, reference_files=None):
         reference_files = {}
 
     # Frames
-    detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), axes_names=('v2', 'v3'), unit=(u.arcsec, u.arcsec))
-    world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
+    detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
+    v2v3 = cf.Frame2D(name="v2v3", axes_order=(0, 1), axes_names=("v2", "v3"), unit=(u.arcsec, u.arcsec))
+    world = cf.CelestialFrame(reference_frame=coord.ICRS(), name="world")
 
     # Transforms between frames
     distortion = wfi_distortion(output_model, reference_files)
     tel2sky = pointing.v23tosky(output_model)
 
-    pipeline = [Step(detector, distortion),
-                Step(v2v3, tel2sky),
-                Step(world, None)]
+    pipeline = [Step(detector, distortion), Step(v2v3, tel2sky), Step(world, None)]
     wcs = WCS(pipeline)
     if wcs.bounding_box is None:
         wcs.bounding_box = wcs_bbox_from_shape(output_model.data.shape)
 
-    output_model.meta['wcs'] = wcs
+    output_model.meta["wcs"] = wcs
 
     # update S_REGION
     add_s_region(output_model)
 
-    output_model.meta.cal_step['assign_wcs'] = 'COMPLETE'
+    output_model.meta.cal_step["assign_wcs"] = "COMPLETE"
 
     return output_model
 
@@ -117,7 +114,7 @@ def wfi_distortion(model, reference_files):
     The transform model
     """
 
-    dist = rdm.DistortionRefModel(reference_files['distortion'])
+    dist = rdm.DistortionRefModel(reference_files["distortion"])
     transform = dist.coordinate_distortion_transform
 
     try:
@@ -135,6 +132,7 @@ def wfi_distortion(model, reference_files):
         transform.bounding_box = bbox
 
     return transform
+
 
 def add_s_region(model):
     """
@@ -169,8 +167,9 @@ def add_s_region(model):
     footprint = footprint.T
     update_s_region_keyword(model, footprint)
 
+
 def update_s_region_keyword(model, footprint):
-    s_region = ('POLYGON IRCS ' + ' '.join([str(x) for x in footprint.ravel()]) + ' ')
+    s_region = "POLYGON IRCS " + " ".join([str(x) for x in footprint.ravel()]) + " "
     log.info(f"S_REGION VALUES: {s_region}")
     if "nan" in s_region:
         # do not update s_region if there are NaNs.

--- a/romancal/assign_wcs/pointing.py
+++ b/romancal/assign_wcs/pointing.py
@@ -4,7 +4,7 @@ from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
 
 
 def v23tosky(input_model, wrap_v2_at=180, wrap_lon_at=360):
-    """ Create the transform from telescope to sky.
+    """Create the transform from telescope to sky.
 
     The transform is defined with a reference point in a Frame
     associated tih the telescope (V2, V3) in arcsec, the corresponding
@@ -37,7 +37,11 @@ def v23tosky(input_model, wrap_v2_at=180, wrap_lon_at=360):
 
     # The sky rotation expects values in deg.
     # This should be removed when models work with quantities.
-    model = ((Scale(1 / 3600) & Scale(1 / 3600)) | SphericalToCartesian(wrap_lon_at=wrap_v2_at)
-         | rot | CartesianToSpherical(wrap_lon_at=wrap_lon_at))
-    model.name = 'v23tosky'
+    model = (
+        (Scale(1 / 3600) & Scale(1 / 3600))
+        | SphericalToCartesian(wrap_lon_at=wrap_v2_at)
+        | rot
+        | CartesianToSpherical(wrap_lon_at=wrap_lon_at)
+    )
+    model.name = "v23tosky"
     return model

--- a/romancal/assign_wcs/pointing.py
+++ b/romancal/assign_wcs/pointing.py
@@ -1,6 +1,6 @@
 import numpy as np
 from astropy.modeling.models import RotationSequence3D, Scale
-from gwcs.geometry import SphericalToCartesian, CartesianToSpherical
+from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
 
 
 def v23tosky(input_model, wrap_v2_at=180, wrap_lon_at=360):

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -30,7 +30,9 @@ def create_distortion():
 
     model = create_image()
     dist = maker_utils.mk_distortion()
-    dist.coordinate_distortion_transform.bounding_box = wcs_bbox_from_shape(model.data.shape)
+    dist.coordinate_distortion_transform.bounding_box = wcs_bbox_from_shape(
+        model.data.shape
+    )
     distortions.append(dist)
 
     return distortions
@@ -42,7 +44,10 @@ def create_step():
 
     def assign_wcs_step(image, file_name):
         if os.environ.get("CI") == "true":
-            pytest.skip("Roman CRDS servers are not currently available outside the internal network")
+            pytest.skip(
+                "Roman CRDS servers are not currently available outside the internal"
+                " network"
+            )
         return AssignWcsStep.call(image, override_distortion=file_name)
 
     return [load_wcs_step, assign_wcs_step]
@@ -82,7 +87,11 @@ def test_wcs(tmpdir, distortion, step):
     assert l2_wcs.meta.wcs.bounding_box is not None
 
     # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)
-    s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 == 0]
-    s_region_delta_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 != 0]
+    s_region_alpha_list = [
+        float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 == 0
+    ]
+    s_region_delta_list = [
+        float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 != 0
+    ]
     assert_allclose(s_region_alpha_list, l2_wcs.meta.wcsinfo.ra_ref, rtol=1e-1, atol=0)
     assert_allclose(s_region_delta_list, l2_wcs.meta.wcsinfo.dec_ref, rtol=1e-1, atol=0)

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -1,16 +1,15 @@
-import numpy as np
 import os
+
+import numpy as np
 import pytest
-
-from numpy.testing import assert_allclose
-
 from gwcs.wcstools import grid_from_bounding_box
-
-from romancal.assign_wcs.assign_wcs_step import AssignWcsStep, load_wcs
+from numpy.testing import assert_allclose
 from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
+from romancal.assign_wcs.assign_wcs_step import AssignWcsStep, load_wcs
 from romancal.assign_wcs.utils import wcs_bbox_from_shape
+
 
 def create_image():
     l2 = maker_utils.mk_level2_image()

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -38,7 +38,7 @@ def create_distortion():
 
 def create_step():
     def load_wcs_step(image, file_name):
-        return load_wcs(image, {'distortion': file_name})
+        return load_wcs(image, {"distortion": file_name})
 
     def assign_wcs_step(image, file_name):
         if os.environ.get("CI") == "true":
@@ -51,7 +51,7 @@ def create_step():
 @pytest.mark.parametrize("distortion", create_distortion())
 @pytest.mark.parametrize("step", create_step())
 def test_wcs(tmpdir, distortion, step):
-    file_name = str(tmpdir / 'distortion.asdf')
+    file_name = str(tmpdir / "distortion.asdf")
     dist = rdm.DistortionRefModel(distortion)
     dist.save(file_name)
 
@@ -59,7 +59,7 @@ def test_wcs(tmpdir, distortion, step):
     l2_wcs = step(l2im, file_name)
 
     assert l2_wcs.meta.wcs is not None
-    assert l2_wcs.meta.cal_step.assign_wcs == 'COMPLETE'
+    assert l2_wcs.meta.cal_step.assign_wcs == "COMPLETE"
 
     x, y = grid_from_bounding_box(l2_wcs.meta.wcs.bounding_box)
 
@@ -75,14 +75,14 @@ def test_wcs(tmpdir, distortion, step):
     # check S_REGION length and format
     s_region_list = l2_wcs.meta.wcsinfo.s_region.split()
     assert len(s_region_list) == 10
-    assert s_region_list[0].lower() == 'polygon'
-    assert s_region_list[1].lower() == 'ircs'
+    assert s_region_list[0].lower() == "polygon"
+    assert s_region_list[1].lower() == "ircs"
 
     # check if BBOX is not None
     assert l2_wcs.meta.wcs.bounding_box is not None
 
     # check if footprint solution for each detector is within 10% of (RA_REF, DEC_REF)
-    s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 == 0]
-    s_region_delta_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i%2 != 0]
+    s_region_alpha_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 == 0]
+    s_region_delta_list = [float(x) for i, x in enumerate(s_region_list[2:]) if i % 2 != 0]
     assert_allclose(s_region_alpha_list, l2_wcs.meta.wcsinfo.ra_ref, rtol=1e-1, atol=0)
     assert_allclose(s_region_delta_list, l2_wcs.meta.wcsinfo.dec_ref, rtol=1e-1, atol=0)

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -26,14 +26,22 @@ def wcs_bbox_from_shape(shape):
     bbox : tuple
         Bounding box in x, y order.
     """
-    bbox = ((-0.5, shape[-1] - 0.5),
-            (-0.5, shape[-2] - 0.5))
+    bbox = ((-0.5, shape[-1] - 0.5), (-0.5, shape[-2] - 0.5))
     return bbox
 
-def wcs_from_footprints(dmodels, refmodel=None,
-                        transform=None, bounding_box=None,
-                        pscale_ratio=None, pscale=None, rotation=None, shape=None,
-                        ref_pixel:Tuple[float, float]=None, ref_coord:Tuple[float, float]=None):
+
+def wcs_from_footprints(
+    dmodels,
+    refmodel=None,
+    transform=None,
+    bounding_box=None,
+    pscale_ratio=None,
+    pscale=None,
+    rotation=None,
+    shape=None,
+    ref_pixel: Tuple[float, float] = None,
+    ref_coord: Tuple[float, float] = None,
+):
     """
     Create a WCS from a list of input data models.
 
@@ -112,7 +120,7 @@ def wcs_from_footprints(dmodels, refmodel=None,
         # overwrite spatial axes with user-provided ref_coord:
         i = 0
         for k, axt in enumerate(wcslist[0].output_frame.axes_type):
-            if axt == 'SPATIAL':
+            if axt == "SPATIAL":
                 fiducial[k] = ref_coord[i]
                 i += 1
 
@@ -134,27 +142,22 @@ def wcs_from_footprints(dmodels, refmodel=None,
         else:
             roll_ref = np.deg2rad(rotation) + (vparity * v3yangle)
 
-        pc = np.reshape(
-            calc_rotation_matrix(roll_ref, v3yangle, vparity=vparity),
-            (2, 2)
-        )
+        pc = np.reshape(calc_rotation_matrix(roll_ref, v3yangle, vparity=vparity), (2, 2))
 
-        rotation = astmodels.AffineTransformation2D(pc, name='pc_rotation_matrix')
+        rotation = astmodels.AffineTransformation2D(pc, name="pc_rotation_matrix")
         transform.append(rotation)
 
         if sky_axes:
             if not pscale:
-                pscale = compute_scale(refmodel.meta.wcs, ref_fiducial,
-                                       pscale_ratio=pscale_ratio)
-            transform.append(astmodels.Scale(pscale, name='cdelt1') & astmodels.Scale(pscale, name='cdelt2'))
+                pscale = compute_scale(refmodel.meta.wcs, ref_fiducial, pscale_ratio=pscale_ratio)
+            transform.append(astmodels.Scale(pscale, name="cdelt1") & astmodels.Scale(pscale, name="cdelt2"))
 
         if transform:
             transform = functools.reduce(lambda x, y: x | y, transform)
 
     out_frame = refmodel.meta.wcs.output_frame
     input_frame = refmodel.meta.wcs.input_frame
-    wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj,
-                             transform=transform, input_frame=input_frame)
+    wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj, transform=transform, input_frame=input_frame)
 
     footprints = [w.footprint().T for w in wcslist]
     domain_bounds = np.hstack([wnew.backward_transform(*f) for f in footprints])
@@ -173,9 +176,9 @@ def wcs_from_footprints(dmodels, refmodel=None,
         offset2 -= axis_min_values[1]
     else:
         offset1, offset2 = ref_pixel
-    offsets = astmodels.Shift(-offset1, name='ref_pixel1') & astmodels.Shift(-offset2, name='ref_pixel2')
+    offsets = astmodels.Shift(-offset1, name="ref_pixel1") & astmodels.Shift(-offset2, name="ref_pixel2")
 
-    wnew.insert_transform('detector', offsets, after=True)
+    wnew.insert_transform("detector", offsets, after=True)
     wnew.bounding_box = output_bounding_box
 
     if shape is None:
@@ -186,8 +189,8 @@ def wcs_from_footprints(dmodels, refmodel=None,
 
     return wnew
 
-def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray],
-                  disp_axis: int = None, pscale_ratio: float = None) -> float:
+
+def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray], disp_axis: int = None, pscale_ratio: float = None) -> float:
     """Compute scaling transform.
 
     Parameters
@@ -210,25 +213,21 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray],
         Scaling factor for x and y or cross-dispersion direction.
 
     """
-    spectral = 'SPECTRAL' in wcs.output_frame.axes_type
+    spectral = "SPECTRAL" in wcs.output_frame.axes_type
 
     if spectral and disp_axis is None:
-        raise ValueError('If input WCS is spectral, a disp_axis must be given')
+        raise ValueError("If input WCS is spectral, a disp_axis must be given")
 
     crpix = np.array(wcs.invert(*fiducial))
 
     delta = np.zeros_like(crpix)
-    spatial_idx = np.where(np.array(wcs.output_frame.axes_type) == 'SPATIAL')[0]
+    spatial_idx = np.where(np.array(wcs.output_frame.axes_type) == "SPATIAL")[0]
     delta[spatial_idx[0]] = 1
 
     crpix_with_offsets = np.vstack((crpix, crpix + delta, crpix + np.roll(delta, 1))).T
     crval_with_offsets = wcs(*crpix_with_offsets, with_bounding_box=False)
 
-    coords = SkyCoord(
-        ra=crval_with_offsets[spatial_idx[0]],
-        dec=crval_with_offsets[spatial_idx[1]],
-        unit="deg"
-    )
+    coords = SkyCoord(ra=crval_with_offsets[spatial_idx[0]], dec=crval_with_offsets[spatial_idx[1]], unit="deg")
     xscale = np.abs(coords[0].separation(coords[1]).value)
     yscale = np.abs(coords[0].separation(coords[2]).value)
 
@@ -243,6 +242,7 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray],
         return yscale if disp_axis == 1 else xscale
 
     return np.sqrt(xscale * yscale)
+
 
 def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> List[float]:
     """Calculate the rotation matrix.
@@ -275,7 +275,7 @@ def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> 
 
     """
     if vparity not in (1, -1):
-        raise ValueError(f'vparity should be 1 or -1. Input was: {vparity}')
+        raise ValueError(f"vparity should be 1 or -1. Input was: {vparity}")
 
     rel_angle = roll_ref - (vparity * v3i_yang)
 
@@ -286,6 +286,7 @@ def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> 
 
     return [pc1_1, pc1_2, pc2_1, pc2_2]
 
+
 def compute_fiducial(wcslist, bounding_box=None):
     """
     For a celestial footprint this is the center.
@@ -295,8 +296,8 @@ def compute_fiducial(wcslist, bounding_box=None):
     """
 
     axes_types = wcslist[0].output_frame.axes_type
-    spatial_axes = np.array(axes_types) == 'SPATIAL'
-    spectral_axes = np.array(axes_types) == 'SPECTRAL'
+    spatial_axes = np.array(axes_types) == "SPATIAL"
+    spectral_axes = np.array(axes_types) == "SPECTRAL"
     footprints = np.hstack([w.footprint(bounding_box=bounding_box).T for w in wcslist])
     spatial_footprint = footprints[spatial_axes]
     spectral_footprint = footprints[spectral_axes]
@@ -309,11 +310,11 @@ def compute_fiducial(wcslist, bounding_box=None):
         y = np.cos(lat) * np.sin(lon)
         z = np.sin(lat)
 
-        x_mid = (np.max(x) + np.min(x)) / 2.
-        y_mid = (np.max(y) + np.min(y)) / 2.
-        z_mid = (np.max(z) + np.min(z)) / 2.
+        x_mid = (np.max(x) + np.min(x)) / 2.0
+        y_mid = (np.max(y) + np.min(y)) / 2.0
+        z_mid = (np.max(z) + np.min(z)) / 2.0
         lon_fiducial = np.rad2deg(np.arctan2(y_mid, x_mid)) % 360.0
-        lat_fiducial = np.rad2deg(np.arctan2(z_mid, np.sqrt(x_mid ** 2 + y_mid ** 2)))
+        lat_fiducial = np.rad2deg(np.arctan2(z_mid, np.sqrt(x_mid**2 + y_mid**2)))
         fiducial[spatial_axes] = lon_fiducial, lat_fiducial
     if spectral_footprint.any():
         fiducial[spectral_axes] = spectral_footprint.min()

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -1,13 +1,13 @@
 import functools
-import numpy as np
+from typing import List, Tuple, Union
 
+import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.utils.misc import isiterable
-from roman_datamodels.datamodels import DataModel
 from astropy.modeling import models as astmodels
+from astropy.utils.misc import isiterable
 from gwcs import WCS
 from gwcs.wcstools import wcs_from_fiducial
-from typing import Union, List, Tuple
+from roman_datamodels.datamodels import DataModel
 
 _MAX_SIP_DEGREE = 6
 

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -221,10 +221,12 @@ def compute_scale(
         Reference WCS object from which to compute a scaling factor.
 
     fiducial : tuple
-        Input fiducial of (RA, DEC) or (RA, DEC, Wavelength) used in calculating reference points.
+        Input fiducial of (RA, DEC) or (RA, DEC, Wavelength) used in calculating
+        reference points.
 
     disp_axis : int
-        Dispersion axis integer. Assumes the same convention as `wcsinfo.dispersion_direction`
+        Dispersion axis integer. Assumes the same convention as
+        `wcsinfo.dispersion_direction`
 
     pscale_ratio : int
         Ratio of input to output pixel scale

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -124,7 +124,9 @@ def wcs_from_footprints(
                 fiducial[k] = ref_coord[i]
                 i += 1
 
-    ref_fiducial = np.array([refmodel.meta.wcsinfo.ra_ref, refmodel.meta.wcsinfo.dec_ref])
+    ref_fiducial = np.array(
+        [refmodel.meta.wcsinfo.ra_ref, refmodel.meta.wcsinfo.dec_ref]
+    )
 
     prj = astmodels.Pix2Sky_TAN()
 
@@ -142,22 +144,35 @@ def wcs_from_footprints(
         else:
             roll_ref = np.deg2rad(rotation) + (vparity * v3yangle)
 
-        pc = np.reshape(calc_rotation_matrix(roll_ref, v3yangle, vparity=vparity), (2, 2))
+        pc = np.reshape(
+            calc_rotation_matrix(roll_ref, v3yangle, vparity=vparity), (2, 2)
+        )
 
         rotation = astmodels.AffineTransformation2D(pc, name="pc_rotation_matrix")
         transform.append(rotation)
 
         if sky_axes:
             if not pscale:
-                pscale = compute_scale(refmodel.meta.wcs, ref_fiducial, pscale_ratio=pscale_ratio)
-            transform.append(astmodels.Scale(pscale, name="cdelt1") & astmodels.Scale(pscale, name="cdelt2"))
+                pscale = compute_scale(
+                    refmodel.meta.wcs, ref_fiducial, pscale_ratio=pscale_ratio
+                )
+            transform.append(
+                astmodels.Scale(pscale, name="cdelt1")
+                & astmodels.Scale(pscale, name="cdelt2")
+            )
 
         if transform:
             transform = functools.reduce(lambda x, y: x | y, transform)
 
     out_frame = refmodel.meta.wcs.output_frame
     input_frame = refmodel.meta.wcs.input_frame
-    wnew = wcs_from_fiducial(fiducial, coordinate_frame=out_frame, projection=prj, transform=transform, input_frame=input_frame)
+    wnew = wcs_from_fiducial(
+        fiducial,
+        coordinate_frame=out_frame,
+        projection=prj,
+        transform=transform,
+        input_frame=input_frame,
+    )
 
     footprints = [w.footprint().T for w in wcslist]
     domain_bounds = np.hstack([wnew.backward_transform(*f) for f in footprints])
@@ -176,7 +191,9 @@ def wcs_from_footprints(
         offset2 -= axis_min_values[1]
     else:
         offset1, offset2 = ref_pixel
-    offsets = astmodels.Shift(-offset1, name="ref_pixel1") & astmodels.Shift(-offset2, name="ref_pixel2")
+    offsets = astmodels.Shift(-offset1, name="ref_pixel1") & astmodels.Shift(
+        -offset2, name="ref_pixel2"
+    )
 
     wnew.insert_transform("detector", offsets, after=True)
     wnew.bounding_box = output_bounding_box
@@ -190,7 +207,12 @@ def wcs_from_footprints(
     return wnew
 
 
-def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray], disp_axis: int = None, pscale_ratio: float = None) -> float:
+def compute_scale(
+    wcs: WCS,
+    fiducial: Union[tuple, np.ndarray],
+    disp_axis: int = None,
+    pscale_ratio: float = None,
+) -> float:
     """Compute scaling transform.
 
     Parameters
@@ -227,7 +249,11 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray], disp_axis: int =
     crpix_with_offsets = np.vstack((crpix, crpix + delta, crpix + np.roll(delta, 1))).T
     crval_with_offsets = wcs(*crpix_with_offsets, with_bounding_box=False)
 
-    coords = SkyCoord(ra=crval_with_offsets[spatial_idx[0]], dec=crval_with_offsets[spatial_idx[1]], unit="deg")
+    coords = SkyCoord(
+        ra=crval_with_offsets[spatial_idx[0]],
+        dec=crval_with_offsets[spatial_idx[1]],
+        unit="deg",
+    )
     xscale = np.abs(coords[0].separation(coords[1]).value)
     yscale = np.abs(coords[0].separation(coords[2]).value)
 
@@ -244,7 +270,9 @@ def compute_scale(wcs: WCS, fiducial: Union[tuple, np.ndarray], disp_axis: int =
     return np.sqrt(xscale * yscale)
 
 
-def calc_rotation_matrix(roll_ref: float, v3i_yang: float, vparity: int = 1) -> List[float]:
+def calc_rotation_matrix(
+    roll_ref: float, v3i_yang: float, vparity: int = 1
+) -> List[float]:
     """Calculate the rotation matrix.
 
     Parameters

--- a/romancal/associations/__init__.py
+++ b/romancal/associations/__init__.py
@@ -12,14 +12,11 @@ For more, see the :ref:`documentation overview <asn-overview>`.
 # Take version from the upstream package
 from .. import __version__
 
+
 # Utility
 def libpath(filepath):
     '''Return the full path to the module library.'''
-    from os.path import (
-        abspath,
-        dirname,
-        join
-    )
+    from os.path import abspath, dirname, join
     return join(dirname(abspath(__file__)),
                 'lib',
                 filepath)
@@ -29,7 +26,7 @@ from .association_io import *
 from .exceptions import *
 from .generate import *
 from .lib.process_list import *
-from .pool import *
-from .registry import *
 from .load_asn import load_asn
 from .main import *
+from .pool import *
+from .registry import *

--- a/romancal/associations/__init__.py
+++ b/romancal/associations/__init__.py
@@ -15,11 +15,11 @@ from .. import __version__
 
 # Utility
 def libpath(filepath):
-    '''Return the full path to the module library.'''
+    """Return the full path to the module library."""
     from os.path import abspath, dirname, join
-    return join(dirname(abspath(__file__)),
-                'lib',
-                filepath)
+
+    return join(dirname(abspath(__file__)), "lib", filepath)
+
 
 from .association import *
 from .association_io import *

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -2,8 +2,8 @@
 import argparse
 import sys
 
-from romancal.associations import AssociationRegistry
-from romancal.associations.lib.rules_elpp_base import DMS_ELPP_Base
+from .lib.rules_elpp_base import DMS_ELPP_Base
+from .registry import AssociationRegistry
 
 __all__ = ['asn_from_list']
 

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -63,25 +63,44 @@ class Main:
             usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.fits",
         )
 
-        parser.add_argument("-o", "--output-file", type=str, required=True, help="File to write association to")
-
         parser.add_argument(
-            "-f", "--format", type=str, default="json", help='Format of the association files. Default: "%(default)s"'
+            "-o",
+            "--output-file",
+            type=str,
+            required=True,
+            help="File to write association to",
         )
 
-        parser.add_argument("--product-name", type=str, help="The product name when creating a Level 3 association")
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            default="json",
+            help='Format of the association files. Default: "%(default)s"',
+        )
+
+        parser.add_argument(
+            "--product-name",
+            type=str,
+            help="The product name when creating a Level 3 association",
+        )
 
         parser.add_argument(
             "-r",
             "--rule",
             type=str,
             default="DMS_ELPP_Base",
-            help='The rule to base the association structure on. Default: "%(default)s"',
+            help=(
+                'The rule to base the association structure on. Default: "%(default)s"'
+            ),
         )
         parser.add_argument(
             "--ruledefs",
             action="append",
-            help="Association rules definition file(s) If not specified, the default rules will be searched.",
+            help=(
+                "Association rules definition file(s) If not specified, the default"
+                " rules will be searched."
+            ),
         )
         parser.add_argument(
             "-i",
@@ -92,7 +111,12 @@ class Main:
             dest="acid",
         )
 
-        parser.add_argument("filelist", type=str, nargs="+", help="File list to include in the association")
+        parser.add_argument(
+            "filelist",
+            type=str,
+            nargs="+",
+            help="File list to include in the association",
+        )
 
         parsed = parser.parse_args(args=args)
         print("Parsed args:", parsed)
@@ -101,6 +125,11 @@ class Main:
         rule = AssociationRegistry(parsed.ruledefs, include_bases=True)[parsed.rule]
 
         with open(parsed.output_file, "w") as outfile:
-            asn = asn_from_list(parsed.filelist, rule=rule, product_name=parsed.product_name, acid=parsed.acid)
+            asn = asn_from_list(
+                parsed.filelist,
+                rule=rule,
+                product_name=parsed.product_name,
+                acid=parsed.acid,
+            )
             _, serialized = asn.dump(format=parsed.format)
             outfile.write(serialized)

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -5,7 +5,7 @@ import sys
 from .lib.rules_elpp_base import DMS_ELPP_Base
 from .registry import AssociationRegistry
 
-__all__ = ['asn_from_list']
+__all__ = ["asn_from_list"]
 
 
 def asn_from_list(items, rule=DMS_ELPP_Base, **kwargs):
@@ -39,7 +39,7 @@ def asn_from_list(items, rule=DMS_ELPP_Base, **kwargs):
     return asn
 
 
-class Main():
+class Main:
     """Command-line interface for list_to_asn
 
     Parameters
@@ -50,83 +50,57 @@ class Main():
             - `[str, ...]`: A list of strings which create the command line
               with the similar structure as `sys.argv`
     """
+
     def __init__(self, args=None):
 
         if args is None:
             args = sys.argv[1:]
         if isinstance(args, str):
-            args = args.split(' ')
+            args = args.split(" ")
 
         parser = argparse.ArgumentParser(
-            description='Create an association from a list of files',
-            usage='asn_from_list -o mosaic_asn.json \
-            --product-name my_mosaic *.fits'
+            description="Create an association from a list of files",
+            usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.fits",
         )
 
-        parser.add_argument(
-            '-o', '--output-file',
-            type=str,
-            required=True,
-            help='File to write association to'
-        )
+        parser.add_argument("-o", "--output-file", type=str, required=True, help="File to write association to")
 
         parser.add_argument(
-            '-f', '--format',
-            type=str,
-            default='json',
-            help='Format of the association files. Default: "%(default)s"'
+            "-f", "--format", type=str, default="json", help='Format of the association files. Default: "%(default)s"'
         )
 
-        parser.add_argument(
-            '--product-name',
-            type=str,
-            help='The product name when creating a Level 3 association'
-        )
+        parser.add_argument("--product-name", type=str, help="The product name when creating a Level 3 association")
 
         parser.add_argument(
-            '-r', '--rule',
+            "-r",
+            "--rule",
             type=str,
-            default='DMS_ELPP_Base',
-            help=(
-                'The rule to base the association structure on.'
-                ' Default: "%(default)s"'
-            )
+            default="DMS_ELPP_Base",
+            help='The rule to base the association structure on. Default: "%(default)s"',
         )
         parser.add_argument(
-            '--ruledefs', action='append',
-            help=(
-                'Association rules definition file(s)'
-                ' If not specified, the default rules will be searched.'
-            )
+            "--ruledefs",
+            action="append",
+            help="Association rules definition file(s) If not specified, the default rules will be searched.",
         )
         parser.add_argument(
-            '-i', '--id',
+            "-i",
+            "--id",
             type=str,
-            default='o999',
+            default="o999",
             help='The association candidate id to use. Default: "%(default)s"',
-            dest='acid'
+            dest="acid",
         )
 
-        parser.add_argument(
-            'filelist',
-            type=str,
-            nargs='+',
-            help='File list to include in the association'
-        )
+        parser.add_argument("filelist", type=str, nargs="+", help="File list to include in the association")
 
         parsed = parser.parse_args(args=args)
         print("Parsed args:", parsed)
 
         # Get the rule
-        rule = AssociationRegistry(parsed.ruledefs,
-                                   include_bases=True)[parsed.rule]
+        rule = AssociationRegistry(parsed.ruledefs, include_bases=True)[parsed.rule]
 
-        with open(parsed.output_file, 'w') as outfile:
-            asn = asn_from_list(
-                parsed.filelist,
-                rule=rule,
-                product_name=parsed.product_name,
-                acid=parsed.acid
-            )
+        with open(parsed.output_file, "w") as outfile:
+            asn = asn_from_list(parsed.filelist, rule=rule, product_name=parsed.product_name, acid=parsed.acid)
             _, serialized = asn.dump(format=parsed.format)
             outfile.write(serialized)

--- a/romancal/associations/association.py
+++ b/romancal/associations/association.py
@@ -15,7 +15,7 @@ from .exceptions import AssociationNotValidError
 from .lib.constraint import Constraint, meets_conditions
 from .lib.ioregistry import IORegistry
 
-__all__ = ['Association']
+__all__ = ["Association"]
 
 
 # Configure logging
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # Timestamp template
-_TIMESTAMP_TEMPLATE = '%Y%m%dt%H%M%S'
+_TIMESTAMP_TEMPLATE = "%Y%m%dt%H%M%S"
 
 
 class Association(MutableMapping):
@@ -85,8 +85,8 @@ class Association(MutableMapping):
     """The association IO registry"""
 
     def __init__(
-            self,
-            version_id=None,
+        self,
+        version_id=None,
     ):
 
         self.data = dict()
@@ -95,12 +95,14 @@ class Association(MutableMapping):
 
         self.version_id = version_id
 
-        self.data.update({
-            'asn_type': 'None',
-            'asn_rule': self.asn_rule,
-            'version_id': self.version_id,
-            'code_version': __version__,
-        })
+        self.data.update(
+            {
+                "asn_type": "None",
+                "asn_rule": self.asn_rule,
+                "version_id": self.version_id,
+                "code_version": __version__,
+            }
+        )
 
         # Setup constraints
         # These may be predefined by a rule.
@@ -142,7 +144,7 @@ class Association(MutableMapping):
     @property
     def asn_name(self):
         """Suggest filename for the association"""
-        return 'unnamed_association'
+        return "unnamed_association"
 
     @classmethod
     def _asn_rule(cls):
@@ -178,10 +180,8 @@ class Association(MutableMapping):
         If the rule class does not define a schema, a warning is issued
         but the routine will return True.
         """
-        if not hasattr(cls, 'schema_file'):
-            logger.warning(
-                f'Cannot validate: {cls} has no schema. Presuming OK.'
-            )
+        if not hasattr(cls, "schema_file"):
+            logger.warning(f"Cannot validate: {cls} has no schema. Presuming OK.")
             return True
 
         if isinstance(asn, cls):
@@ -195,11 +195,11 @@ class Association(MutableMapping):
         try:
             jsonschema.validate(asn_data, asn_schema)
         except (AttributeError, jsonschema.ValidationError) as err:
-            logger.debug('Validation failed:\n%s', err)
-            raise AssociationNotValidError('Validation failed') from err
+            logger.debug("Validation failed:\n%s", err)
+            raise AssociationNotValidError("Validation failed") from err
         return True
 
-    def dump(self, format='json', **kwargs):
+    def dump(self, format="json", **kwargs):
         """Serialize the association
 
         Parameters
@@ -229,18 +229,10 @@ class Association(MutableMapping):
         if self.is_valid:
             return self.ioregistry[format].dump(self, **kwargs)
         else:
-            raise AssociationNotValidError(
-                 f'Association {self} is not valid'
-            )
+            raise AssociationNotValidError(f"Association {self} is not valid")
 
     @classmethod
-    def load(
-            cls,
-            serialized,
-            format=None,
-            validate=True,
-            **kwargs
-    ):
+    def load(cls, serialized, format=None, validate=True, **kwargs):
         """Marshall a previously serialized association
 
         Parameters
@@ -275,26 +267,19 @@ class Association(MutableMapping):
         a file object containing the string.
         """
         if format is None:
-            formats = [
-                format_func
-                for format_name, format_func in cls.ioregistry.items()
-            ]
+            formats = [format_func for format_name, format_func in cls.ioregistry.items()]
         else:
             formats = [cls.ioregistry[format]]
 
         for format_func in formats:
             try:
-                asn = format_func.load(
-                    cls, serialized, **kwargs
-                )
+                asn = format_func.load(cls, serialized, **kwargs)
             except AssociationNotValidError:
                 continue
             else:
                 break
         else:
-            raise AssociationNotValidError(
-                f'Cannot translate "{serialized}" to an association'
-            )
+            raise AssociationNotValidError(f'Cannot translate "{serialized}" to an association')
 
         # Validate
         if validate:
@@ -346,7 +331,7 @@ class Association(MutableMapping):
         # If a constraint `force_match` exists, set the `match`
         # result to the value of the constraint.
         try:
-            force_match = self.constraints['force_match'].value
+            force_match = self.constraints["force_match"].value
         except (KeyError, TypeError):
             pass
         else:
@@ -407,21 +392,18 @@ class Association(MutableMapping):
                 - [ProcessList[, ...]]: List of items to process again.
         """
         reprocess = []
-        evaled_str = conditions['inputs'](item)
-        if conditions['value'] is not None:
-            if not meets_conditions(
-                    evaled_str, conditions['value']
-            ):
+        evaled_str = conditions["inputs"](item)
+        if conditions["value"] is not None:
+            if not meets_conditions(evaled_str, conditions["value"]):
                 return False, reprocess
 
         # At this point, the constraint has passed.
         # Fix the conditions.
         escaped_value = re.escape(evaled_str)
-        conditions['found_values'].add(escaped_value)
-        if conditions['value'] is None or \
-           conditions.get('force_unique', self.DEFAULT_FORCE_UNIQUE):
-            conditions['value'] = escaped_value
-            conditions['force_unique'] = False
+        conditions["found_values"].add(escaped_value)
+        if conditions["value"] is None or conditions.get("force_unique", self.DEFAULT_FORCE_UNIQUE):
+            conditions["value"] = escaped_value
+            conditions["force_unique"] = False
 
         # That's all folks
         return True, reprocess
@@ -459,9 +441,7 @@ class Association(MutableMapping):
         is_item_member : bool
             True if item is a member.
         """
-        raise NotImplementedError(
-            'Association.is_item_member must be implemented by a specific association rule.'
-        )
+        raise NotImplementedError("Association.is_item_member must be implemented by a specific association rule.")
 
     def _init_hook(self, item):
         """Post-check and pre-item-adding initialization."""
@@ -469,12 +449,10 @@ class Association(MutableMapping):
 
     def _add(self, item):
         """Add a item, association-specific"""
-        raise NotImplementedError(
-            'Association._add must be implemented by a specific association rule.'
-        )
+        raise NotImplementedError("Association._add must be implemented by a specific association rule.")
 
     def _add_items(self, items, **kwargs):
-        """ Force adding items to the association
+        """Force adding items to the association
 
         Parameters
         ----------
@@ -488,9 +466,9 @@ class Association(MutableMapping):
         by-passed, resulting in a potentially unusable association.
         """
         try:
-            self['members'].update(items)
+            self["members"].update(items)
         except KeyError:
-            self['members'] = items
+            self["members"] = items
 
     # #################################################
     # Methods required for implementing MutableMapping
@@ -539,17 +517,12 @@ def finalize(asns):
        from jwst.associations.association import finalize as generic_finalize
        RegistryMarker.callback('finalize')(generic_finalize)
     """
-    finalized_asns = list(filter(
-        lambda asn: asn is not None,
-        map(lambda asn: asn.finalize(), asns)
-    ))
+    finalized_asns = list(filter(lambda asn: asn is not None, map(lambda asn: asn.finalize(), asns)))
     return finalized_asns
 
 
 def make_timestamp():
-    timestamp = datetime.utcnow().strftime(
-        _TIMESTAMP_TEMPLATE
-    )
+    timestamp = datetime.utcnow().strftime(_TIMESTAMP_TEMPLATE)
     return timestamp
 
 

--- a/romancal/associations/association.py
+++ b/romancal/associations/association.py
@@ -1,22 +1,18 @@
 """ Main module for associations """
 
+import json
+import logging
+import re
 from collections.abc import MutableMapping
 from copy import deepcopy
 from datetime import datetime
-import logging
-import re
-import json
+
 import jsonschema
+from stpipe.format_template import FormatTemplate
 
 from . import __version__
-from .exceptions import (
-    AssociationNotValidError
-)
-from .lib.constraint import (
-    Constraint,
-    meets_conditions
-)
-from stpipe.format_template import FormatTemplate
+from .exceptions import AssociationNotValidError
+from .lib.constraint import Constraint, meets_conditions
 from .lib.ioregistry import IORegistry
 
 __all__ = ['Association']

--- a/romancal/associations/association.py
+++ b/romancal/associations/association.py
@@ -267,7 +267,9 @@ class Association(MutableMapping):
         a file object containing the string.
         """
         if format is None:
-            formats = [format_func for format_name, format_func in cls.ioregistry.items()]
+            formats = [
+                format_func for format_name, format_func in cls.ioregistry.items()
+            ]
         else:
             formats = [cls.ioregistry[format]]
 
@@ -279,7 +281,9 @@ class Association(MutableMapping):
             else:
                 break
         else:
-            raise AssociationNotValidError(f'Cannot translate "{serialized}" to an association')
+            raise AssociationNotValidError(
+                f'Cannot translate "{serialized}" to an association'
+            )
 
         # Validate
         if validate:
@@ -401,7 +405,9 @@ class Association(MutableMapping):
         # Fix the conditions.
         escaped_value = re.escape(evaled_str)
         conditions["found_values"].add(escaped_value)
-        if conditions["value"] is None or conditions.get("force_unique", self.DEFAULT_FORCE_UNIQUE):
+        if conditions["value"] is None or conditions.get(
+            "force_unique", self.DEFAULT_FORCE_UNIQUE
+        ):
             conditions["value"] = escaped_value
             conditions["force_unique"] = False
 
@@ -441,7 +447,10 @@ class Association(MutableMapping):
         is_item_member : bool
             True if item is a member.
         """
-        raise NotImplementedError("Association.is_item_member must be implemented by a specific association rule.")
+        raise NotImplementedError(
+            "Association.is_item_member must be implemented by a specific association"
+            " rule."
+        )
 
     def _init_hook(self, item):
         """Post-check and pre-item-adding initialization."""
@@ -449,7 +458,9 @@ class Association(MutableMapping):
 
     def _add(self, item):
         """Add a item, association-specific"""
-        raise NotImplementedError("Association._add must be implemented by a specific association rule.")
+        raise NotImplementedError(
+            "Association._add must be implemented by a specific association rule."
+        )
 
     def _add_items(self, items, **kwargs):
         """Force adding items to the association
@@ -517,7 +528,9 @@ def finalize(asns):
        from jwst.associations.association import finalize as generic_finalize
        RegistryMarker.callback('finalize')(generic_finalize)
     """
-    finalized_asns = list(filter(lambda asn: asn is not None, map(lambda asn: asn.finalize(), asns)))
+    finalized_asns = list(
+        filter(lambda asn: asn is not None, map(lambda asn: asn.finalize(), asns))
+    )
     return finalized_asns
 
 

--- a/romancal/associations/association_io.py
+++ b/romancal/associations/association_io.py
@@ -3,6 +3,7 @@ Define the I/O methods for Level 3 associations
 """
 import json as json_lib
 import logging
+
 import numpy as np
 import yaml as yaml_lib
 

--- a/romancal/associations/association_io.py
+++ b/romancal/associations/association_io.py
@@ -21,6 +21,7 @@ __all__ = []
 # Define JSON encoder to convert `Member` to `dict`
 class AssociationEncoder(json_lib.JSONEncoder):
     """Encode to handle Associations"""
+
     def default(self, obj):
 
         # Convert Member to a simple dict
@@ -29,7 +30,7 @@ class AssociationEncoder(json_lib.JSONEncoder):
 
 
 @Association.ioregistry
-class json():
+class json:
     """Load and store associations as JSON"""
 
     @staticmethod
@@ -65,9 +66,7 @@ class json():
             asn = loader(serialized)
         except Exception as err:
             logger.debug(f'Error unserializing: "{err}"')
-            raise AssociationNotValidError(
-                f'Container is not JSON: "{serialized}"'
-            )
+            raise AssociationNotValidError(f'Container is not JSON: "{serialized}"')
 
         return asn
 
@@ -88,17 +87,13 @@ class json():
             Second item is the string containing the JSON serialization.
         """
         asn_filename = asn.asn_name
-        if not asn_filename.endswith('.json'):
-            asn_filename = asn_filename+'.json'
-        return (
-            asn_filename,
-            json_lib.dumps(asn.data, cls=AssociationEncoder, indent=4,
-                           separators=(',', ': '))
-        )
+        if not asn_filename.endswith(".json"):
+            asn_filename = asn_filename + ".json"
+        return (asn_filename, json_lib.dumps(asn.data, cls=AssociationEncoder, indent=4, separators=(",", ": ")))
 
 
 @Association.ioregistry
-class yaml():
+class yaml:
     """Load and store associations as YAML"""
 
     @staticmethod
@@ -132,9 +127,7 @@ class yaml():
             asn = yaml_lib.safe_load(serialized)
         except Exception as err:
             logger.debug(f'Error unserializing: "{err}"')
-            raise AssociationNotValidError(
-                f'Container is not YAML: "{serialized}"'
-            )
+            raise AssociationNotValidError(f'Container is not YAML: "{serialized}"')
         return asn
 
     @staticmethod
@@ -155,18 +148,15 @@ class yaml():
             Second item is the string containing the YAML serialization.
         """
         asn_filename = asn.asn_name
-        if not asn.asn_name.endswith('.yaml'):
-            asn_filename = asn.asn_name+'.yaml'
-        return (
-            asn_filename,
-            yaml_lib.dump(asn.data, default_flow_style=False)
-        )
+        if not asn.asn_name.endswith(".yaml"):
+            asn_filename = asn.asn_name + ".yaml"
+        return (asn_filename, yaml_lib.dump(asn.data, default_flow_style=False))
 
 
 # Register YAML representers
 def np_str_representer(dumper, data):
     """Convert numpy.str_ into standard YAML string"""
-    return dumper.represent_scalar('tag:yaml.org,2002:str', str(data))
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
 
 
 yaml_lib.add_representer(np.str_, np_str_representer)

--- a/romancal/associations/association_io.py
+++ b/romancal/associations/association_io.py
@@ -89,7 +89,12 @@ class json:
         asn_filename = asn.asn_name
         if not asn_filename.endswith(".json"):
             asn_filename = asn_filename + ".json"
-        return (asn_filename, json_lib.dumps(asn.data, cls=AssociationEncoder, indent=4, separators=(",", ": ")))
+        return (
+            asn_filename,
+            json_lib.dumps(
+                asn.data, cls=AssociationEncoder, indent=4, separators=(",", ": ")
+            ),
+        )
 
 
 @Association.ioregistry

--- a/romancal/associations/exceptions.py
+++ b/romancal/associations/exceptions.py
@@ -1,7 +1,7 @@
 __all__ = [
-    'AssociationError',
-    'AssociationNotAConstraint',
-    'AssociationNotValidError',
+    "AssociationError",
+    "AssociationNotAConstraint",
+    "AssociationNotValidError",
 ]
 
 

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -10,7 +10,7 @@ from .pool import PoolRow
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-__all__ = ['generate']
+__all__ = ["generate"]
 
 
 def generate(pool, rules, version_id=None):
@@ -43,32 +43,20 @@ def generate(pool, rules, version_id=None):
     associations = []
     if type(version_id) is bool:
         version_id = make_timestamp()
-    process_queue = ProcessQueueSorted([
-        ProcessList(
-            items=pool,
-            rules=[rule for _, rule in rules.items()]
-        )
-    ])
+    process_queue = ProcessQueueSorted([ProcessList(items=pool, rules=[rule for _, rule in rules.items()])])
 
-    logger.debug('Initial process queue: %s', process_queue)
+    logger.debug("Initial process queue: %s", process_queue)
     for process_list in process_queue:
-        logger.debug('** Working process list: %s', process_list)
+        logger.debug("** Working process list: %s", process_list)
         time_start = timer()
         total_mod_existing = 0
         total_new = 0
         total_reprocess = 0
-        with Bar('Processing items', log_level=logger.getEffectiveLevel(),
-                 max=len(process_list.items)) as bar:
+        with Bar("Processing items", log_level=logger.getEffectiveLevel(), max=len(process_list.items)) as bar:
             for item in process_list.items:
                 item = PoolRow(item)
 
-                existing_asns, new_asns, to_process = generate_from_item(
-                    item,
-                    version_id,
-                    associations,
-                    rules,
-                    process_list
-                )
+                existing_asns, new_asns, to_process = generate_from_item(item, version_id, associations, rules, process_list)
                 total_mod_existing += len(existing_asns)
                 total_new += len(new_asns)
                 associations.extend(new_asns)
@@ -85,28 +73,23 @@ def generate(pool, rules, version_id=None):
                 total_reprocess += len(to_process_modified)
                 bar.next()
 
-        logger.debug('Existing associations modified: %d New associations created: %d', total_mod_existing, total_new)
-        logger.debug('New process lists: %d', total_reprocess)
-        logger.debug('Updated process queue: %s', process_queue)
-        logger.debug('# associations: %d', len(associations))
-        logger.debug('Seconds to process: %.2f\n', timer() - time_start)
+        logger.debug("Existing associations modified: %d New associations created: %d", total_mod_existing, total_new)
+        logger.debug("New process lists: %d", total_reprocess)
+        logger.debug("Updated process queue: %s", process_queue)
+        logger.debug("# associations: %d", len(associations))
+        logger.debug("Seconds to process: %.2f\n", timer() - time_start)
 
     # Finalize found associations
-    logger.debug('# associations before finalization: %d', len(associations))
+    logger.debug("# associations before finalization: %d", len(associations))
     try:
-        finalized_asns = rules.callback.reduce('finalize', associations)
+        finalized_asns = rules.callback.reduce("finalize", associations)
     except KeyError:
         finalized_asns = associations
 
     return finalized_asns
 
 
-def generate_from_item(
-        item,
-        version_id,
-        associations,
-        rules,
-        process_list):
+def generate_from_item(item, version_id, associations, rules, process_list):
     """Either match or generate a new association
 
     Parameters
@@ -152,28 +135,26 @@ def generate_from_item(
     existing_asns = []
     reprocess_list = []
     if process_list.work_over in (
-            ListCategory.BOTH,
-            ListCategory.EXISTING,
-            ListCategory.NONSCIENCE,
+        ListCategory.BOTH,
+        ListCategory.EXISTING,
+        ListCategory.NONSCIENCE,
     ):
-        associations = [
-            asn
-            for asn in associations
-            if type(asn) in allowed_rules
-        ]
-        existing_asns, reprocess_list = match_item(
-            item, associations
-        )
+        associations = [asn for asn in associations if type(asn) in allowed_rules]
+        existing_asns, reprocess_list = match_item(item, associations)
 
     # Now see if this item will create new associations.
     # By default, a item will not be allowed to create
     # an association based on rules of existing associations.
     reprocess = []
     new_asns = []
-    if process_list.work_over in (
+    if (
+        process_list.work_over
+        in (
             ListCategory.BOTH,
             ListCategory.RULES,
-    ) and rules is not None:
+        )
+        and rules is not None
+    ):
         ignore_asns = {type(asn) for asn in existing_asns}
         new_asns, reprocess = rules.match(
             item,

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -1,15 +1,10 @@
 import logging
 from timeit import default_timer as timer
 
-from .association import make_timestamp
-from .lib.process_list import (
-    ListCategory,
-    ProcessList,
-    ProcessQueueSorted,
-    workover_filter
-)
-from .pool import PoolRow
 from ..lib.progress import Bar
+from .association import make_timestamp
+from .lib.process_list import ListCategory, ProcessList, ProcessQueueSorted, workover_filter
+from .pool import PoolRow
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -3,7 +3,12 @@ from timeit import default_timer as timer
 
 from ..lib.progress import Bar
 from .association import make_timestamp
-from .lib.process_list import ListCategory, ProcessList, ProcessQueueSorted, workover_filter
+from .lib.process_list import (
+    ListCategory,
+    ProcessList,
+    ProcessQueueSorted,
+    workover_filter,
+)
 from .pool import PoolRow
 
 # Configure logging
@@ -43,7 +48,9 @@ def generate(pool, rules, version_id=None):
     associations = []
     if type(version_id) is bool:
         version_id = make_timestamp()
-    process_queue = ProcessQueueSorted([ProcessList(items=pool, rules=[rule for _, rule in rules.items()])])
+    process_queue = ProcessQueueSorted(
+        [ProcessList(items=pool, rules=[rule for _, rule in rules.items()])]
+    )
 
     logger.debug("Initial process queue: %s", process_queue)
     for process_list in process_queue:
@@ -52,11 +59,17 @@ def generate(pool, rules, version_id=None):
         total_mod_existing = 0
         total_new = 0
         total_reprocess = 0
-        with Bar("Processing items", log_level=logger.getEffectiveLevel(), max=len(process_list.items)) as bar:
+        with Bar(
+            "Processing items",
+            log_level=logger.getEffectiveLevel(),
+            max=len(process_list.items),
+        ) as bar:
             for item in process_list.items:
                 item = PoolRow(item)
 
-                existing_asns, new_asns, to_process = generate_from_item(item, version_id, associations, rules, process_list)
+                existing_asns, new_asns, to_process = generate_from_item(
+                    item, version_id, associations, rules, process_list
+                )
                 total_mod_existing += len(existing_asns)
                 total_new += len(new_asns)
                 associations.extend(new_asns)
@@ -73,7 +86,11 @@ def generate(pool, rules, version_id=None):
                 total_reprocess += len(to_process_modified)
                 bar.next()
 
-        logger.debug("Existing associations modified: %d New associations created: %d", total_mod_existing, total_new)
+        logger.debug(
+            "Existing associations modified: %d New associations created: %d",
+            total_mod_existing,
+            total_new,
+        )
         logger.debug("New process lists: %d", total_reprocess)
         logger.debug("Updated process queue: %s", process_queue)
         logger.debug("# associations: %d", len(associations))

--- a/romancal/associations/lib/acid.py
+++ b/romancal/associations/lib/acid.py
@@ -1,6 +1,6 @@
 """Association Candidate Identifier"""
-from ast import literal_eval
 import re
+from ast import literal_eval
 
 from .counter import Counter
 

--- a/romancal/associations/lib/acid.py
+++ b/romancal/associations/lib/acid.py
@@ -4,15 +4,13 @@ from ast import literal_eval
 
 from .counter import Counter
 
-__all__ = [
-    'ACID'
-]
+__all__ = ["ACID"]
 
 # Start of the discovered association ids.
 _DISCOVERED_ID_START = 3001
 
 
-class ACID():
+class ACID:
     """Association Candidate Identifer
 
     Parameters
@@ -41,6 +39,7 @@ class ACID():
         other PPS-defined candidates, and 'a3XXX' for
         'DISCOVERED' associations.
     """
+
     def __init__(self, input):
         try:
             self.id, self.type = literal_eval(input)
@@ -51,8 +50,9 @@ class ACID():
         return self.id
 
 
-class ACIDMixin():
+class ACIDMixin:
     """Enable ACID for rules"""
+
     def __init__(self, *args, **kwargs):
 
         # Initialize discovered association ID
@@ -63,12 +63,8 @@ class ACIDMixin():
     def acid_from_constraints(self):
         """Determine ACID from constraints"""
         for constraint in self.constraints:
-            if getattr(constraint, 'is_acid', False):
-                value = re.sub(
-                    '\\\\',
-                    '',
-                    '-'.join(constraint.found_values)
-                )
+            if getattr(constraint, "is_acid", False):
+                value = re.sub("\\\\", "", "-".join(constraint.found_values))
                 try:
                     acid = ACID(value)
                 except ValueError:
@@ -76,7 +72,7 @@ class ACIDMixin():
                 else:
                     break
         else:
-            id = f'a{self.discovered_id.value:0>3}'
-            acid = ACID((id, 'DISCOVERED'))
+            id = f"a{self.discovered_id.value:0>3}"
+            acid = ACID((id, "DISCOVERED"))
 
         return acid

--- a/romancal/associations/lib/association_rules.py
+++ b/romancal/associations/lib/association_rules.py
@@ -4,8 +4,7 @@ Notes
 -----
 These associations are specifically defined for use in DMS.
 """
+from romancal.associations.lib import rules_level2
 from romancal.associations.registry import RegistryMarker
-
-from romancal.associations.lib import (rules_level2)
 
 RegistryMarker.mark(rules_level2)

--- a/romancal/associations/lib/callback_registry.py
+++ b/romancal/associations/lib/callback_registry.py
@@ -2,10 +2,10 @@
 
 from romancal.lib.signal_slot import Signal
 
-__all__ = ['CallbackRegistry']
+__all__ = ["CallbackRegistry"]
 
 
-class CallbackRegistry():
+class CallbackRegistry:
     """Callback registry"""
 
     def __init__(self):
@@ -58,9 +58,11 @@ class CallbackRegistry():
         event : str
             The name of event to attach the object to.
         """
+
         def decorator(func):
             self.add(event, func)
             return func
+
         return decorator
 
     __call__ = add_decorator

--- a/romancal/associations/lib/constraint.py
+++ b/romancal/associations/lib/constraint.py
@@ -143,8 +143,8 @@ class SimpleConstraintABC(abc.ABC):
         return result
 
     def __str__(self):
-        result = f"{self.__class__.__name__}({dict({str_attr: getattr(self, str_attr) for str_attr in self._str_attrs})})"
-        return result
+        attrs = {str_attr: getattr(self, str_attr) for str_attr in self._str_attrs}
+        return f"{self.__class__.__name__}({attrs})"
 
 
 class ConstraintTrue(SimpleConstraintABC):
@@ -602,7 +602,7 @@ class Constraint:
                       'value': 'a_value',
                       'name': 'simple',
                       'matched': False})
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/romancal/associations/lib/constraint.py
+++ b/romancal/associations/lib/constraint.py
@@ -78,7 +78,9 @@ class SimpleConstraintABC(abc.ABC):
         return self.matched, []
 
     @property
-    def dup_names(self):  #  -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]
+    def dup_names(
+        self,
+    ):  #  -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]
         """Return dictionary of constraints with duplicate names
 
         This method is meant to be overridden by classes
@@ -107,7 +109,9 @@ class SimpleConstraintABC(abc.ABC):
         """Copy ourselves"""
         return deepcopy(self)
 
-    def get_all_attr(self, attribute: str):  # -> list[tuple[SimpleConstraint, typing.Any]]:
+    def get_all_attr(
+        self, attribute: str
+    ):  # -> list[tuple[SimpleConstraint, typing.Any]]:
         """Return the specified attribute
 
         This method is meant to be overridden by classes
@@ -301,9 +305,16 @@ class SimpleConstraint(SimpleConstraintABC):
 
         # Determine reprocessing
         reprocess = []
-        if (self.matched and self.reprocess_on_match) or (not self.matched and self.reprocess_on_fail):
+        if (self.matched and self.reprocess_on_match) or (
+            not self.matched and self.reprocess_on_fail
+        ):
             reprocess.append(
-                ProcessList(items=[item], work_over=self.work_over, rules=self.reprocess_rules, trigger_constraints=[self.id])
+                ProcessList(
+                    items=[item],
+                    work_over=self.work_over,
+                    rules=self.reprocess_rules,
+                    trigger_constraints=[self.id],
+                )
             )
 
         return self.matched, reprocess
@@ -443,7 +454,9 @@ class AttrConstraint(SimpleConstraintABC):
 
         # Get the condition information.
         try:
-            source, value = getattr_from_list(item, self.sources, invalid_values=self.invalid_values)
+            source, value = getattr_from_list(
+                item, self.sources, invalid_values=self.invalid_values
+            )
         except KeyError:
             if self.required and not self.force_undefined:
                 self.matched = False
@@ -510,7 +523,10 @@ class AttrConstraint(SimpleConstraintABC):
         if self.force_reprocess:
             reprocess.append(
                 ProcessList(
-                    items=[item], work_over=self.force_reprocess, only_on_match=self.only_on_match, trigger_constraints=[self.id]
+                    items=[item],
+                    work_over=self.force_reprocess,
+                    only_on_match=self.only_on_match,
+                    trigger_constraints=[self.id],
                 )
             )
 
@@ -625,9 +641,8 @@ class Constraint:
             self.constraints = [init]
         else:
             raise TypeError(
-                "Invalid initialization value type {}.\nValid types are `SimpleConstraint`, `Constraint`,\nor subclass.".format(
-                    type(init)
-                )
+                "Invalid initialization value type {}.\nValid types are"
+                " `SimpleConstraint`, `Constraint`,\nor subclass.".format(type(init))
             )
 
         # Give some defaults real meaning.
@@ -636,7 +651,9 @@ class Constraint:
             self.reduce = self.all
 
     @property
-    def dup_names(self):  # -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]:
+    def dup_names(
+        self,
+    ):  # -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]:
         """Return dictionary of constraints with duplicate names
 
         This method is meant to be overridden by classes
@@ -693,9 +710,18 @@ class Constraint:
         self.matched, reprocess = self.reduce(item, self.constraints)
 
         # Determine reprocessing
-        if (self.matched and self.reprocess_on_match) or (not self.matched and self.reprocess_on_fail):
+        if (self.matched and self.reprocess_on_match) or (
+            not self.matched and self.reprocess_on_fail
+        ):
             reprocess.append(
-                [ProcessList(items=[item], work_over=self.work_over, rules=self.reprocess_rules, trigger_constraints=[self.id])]
+                [
+                    ProcessList(
+                        items=[item],
+                        work_over=self.work_over,
+                        rules=self.reprocess_rules,
+                        trigger_constraints=[self.id],
+                    )
+                ]
             )
 
         return self.matched, list(chain(*reprocess))
@@ -704,7 +730,9 @@ class Constraint:
         """Copy ourselves"""
         return deepcopy(self)
 
-    def get_all_attr(self, attribute: str):  # -> list[tuple[typing.Union[SimpleConstraint, Constraint], typing.Any]]:
+    def get_all_attr(
+        self, attribute: str
+    ):  # -> list[tuple[typing.Union[SimpleConstraint, Constraint], typing.Any]]:
         """Return the specified attribute
 
         This method is meant to be overridden by classes
@@ -843,7 +871,9 @@ class Constraint:
         raise NotImplementedError("Cannot set constraints by index.")
 
     def __str__(self):
-        result = "\n".join([str(constraint) for constraint in self if constraint.name is not None])
+        result = "\n".join(
+            [str(constraint) for constraint in self if constraint.name is not None]
+        )
         return result
 
 
@@ -903,5 +933,7 @@ def reprocess_multivalue(item, source, values, constraint):
         new_item = PoolRow(item)
         new_item[source] = str(value)
         reprocess_items.append(new_item)
-    process_list = ProcessList(items=reprocess_items, trigger_constraints=[constraint.id])
+    process_list = ProcessList(
+        items=reprocess_items, trigger_constraints=[constraint.id]
+    )
     return process_list

--- a/romancal/associations/lib/constraint.py
+++ b/romancal/associations/lib/constraint.py
@@ -2,18 +2,14 @@
 """
 import abc
 import collections
-from copy import deepcopy
-from itertools import chain
 import logging
 import re
+from copy import deepcopy
+from itertools import chain
 
-from .process_list import ListCategory, ProcessList
-from .utilities import (
-    evaluate,
-    getattr_from_list,
-    is_iterable
-)
 from ..pool import PoolRow
+from .process_list import ListCategory, ProcessList
+from .utilities import evaluate, getattr_from_list, is_iterable
 
 __all__ = [
     'AttrConstraint',

--- a/romancal/associations/lib/constraint.py
+++ b/romancal/associations/lib/constraint.py
@@ -12,10 +12,10 @@ from .process_list import ListCategory, ProcessList
 from .utilities import evaluate, getattr_from_list, is_iterable
 
 __all__ = [
-    'AttrConstraint',
-    'Constraint',
-    'ConstraintTrue',
-    'SimpleConstraint',
+    "AttrConstraint",
+    "Constraint",
+    "ConstraintTrue",
+    "SimpleConstraint",
 ]
 
 # Configure logging
@@ -48,7 +48,7 @@ class SimpleConstraintABC(abc.ABC):
     """
 
     # Attributes to show in the string representation.
-    _str_attrs = ('name', 'value')
+    _str_attrs = ("name", "value")
 
     def __init__(self, init=None, value=None, name=None, **kwargs):
 
@@ -78,7 +78,7 @@ class SimpleConstraintABC(abc.ABC):
         return self.matched, []
 
     @property
-    def dup_names(self): #  -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]
+    def dup_names(self):  #  -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]
         """Return dictionary of constraints with duplicate names
 
         This method is meant to be overridden by classes
@@ -101,13 +101,13 @@ class SimpleConstraintABC(abc.ABC):
         id : str
             The identifyer
         """
-        return f'{self.__class__.__name__}:{self.name}'
+        return f"{self.__class__.__name__}:{self.name}"
 
     def copy(self):
         """Copy ourselves"""
         return deepcopy(self)
 
-    def get_all_attr(self, attribute: str): # -> list[tuple[SimpleConstraint, typing.Any]]:
+    def get_all_attr(self, attribute: str):  # -> list[tuple[SimpleConstraint, typing.Any]]:
         """Return the specified attribute
 
         This method is meant to be overridden by classes
@@ -135,20 +135,11 @@ class SimpleConstraintABC(abc.ABC):
         yield self
 
     def __repr__(self):
-        result = '{}({})'.format(
-            self.__class__.__name__,
-            str(self.__dict__)
-        )
+        result = f"{self.__class__.__name__}({str(self.__dict__)})"
         return result
 
     def __str__(self):
-        result = '{}({})'.format(
-            self.__class__.__name__,
-            {
-                str_attr: getattr(self, str_attr)
-                for str_attr in self._str_attrs
-            }
-        )
+        result = f"{self.__class__.__name__}({dict({str_attr: getattr(self, str_attr) for str_attr in self._str_attrs})})"
         return result
 
 
@@ -258,16 +249,16 @@ class SimpleConstraint(SimpleConstraintABC):
     """
 
     def __init__(
-            self,
-            init=None,
-            sources=None,
-            force_unique=True,
-            test=None,
-            reprocess_on_match=False,
-            reprocess_on_fail=False,
-            work_over=ListCategory.BOTH,
-            reprocess_rules=None,
-            **kwargs
+        self,
+        init=None,
+        sources=None,
+        force_unique=True,
+        test=None,
+        reprocess_on_match=False,
+        reprocess_on_fail=False,
+        work_over=ListCategory.BOTH,
+        reprocess_rules=None,
+        **kwargs,
     ):
 
         # Defined attributes
@@ -310,14 +301,10 @@ class SimpleConstraint(SimpleConstraintABC):
 
         # Determine reprocessing
         reprocess = []
-        if ((self.matched and self.reprocess_on_match) or
-                (not self.matched and self.reprocess_on_fail)):
-            reprocess.append(ProcessList(
-                items=[item],
-                work_over=self.work_over,
-                rules=self.reprocess_rules,
-                trigger_constraints=[self.id]
-            ))
+        if (self.matched and self.reprocess_on_match) or (not self.matched and self.reprocess_on_fail):
+            reprocess.append(
+                ProcessList(items=[item], work_over=self.work_over, rules=self.reprocess_rules, trigger_constraints=[self.id])
+            )
 
         return self.matched, reprocess
 
@@ -383,20 +370,22 @@ class AttrConstraint(SimpleConstraintABC):
     """
 
     # Attributes to show in the string representation.
-    _str_attrs = ('name', 'sources', 'value')
+    _str_attrs = ("name", "sources", "value")
 
-    def __init__(self,
-                 init=None,
-                 sources=None,
-                 evaluate=False,
-                 force_reprocess=False,
-                 force_undefined=False,
-                 force_unique=True,
-                 invalid_values=None,
-                 only_on_match=False,
-                 onlyif=None,
-                 required=True,
-                 **kwargs):
+    def __init__(
+        self,
+        init=None,
+        sources=None,
+        evaluate=False,
+        force_reprocess=False,
+        force_undefined=False,
+        force_unique=True,
+        invalid_values=None,
+        only_on_match=False,
+        onlyif=None,
+        required=True,
+        **kwargs,
+    ):
 
         # Attributes
         self.sources = sources
@@ -446,7 +435,7 @@ class AttrConstraint(SimpleConstraintABC):
                         items=[item],
                         work_over=self.force_reprocess,
                         only_on_match=self.only_on_match,
-                        trigger_constraints=[self.id]
+                        trigger_constraints=[self.id],
                     )
                 )
             self.matched = True
@@ -454,11 +443,7 @@ class AttrConstraint(SimpleConstraintABC):
 
         # Get the condition information.
         try:
-            source, value = getattr_from_list(
-                item,
-                self.sources,
-                invalid_values=self.invalid_values
-            )
+            source, value = getattr_from_list(item, self.sources, invalid_values=self.invalid_values)
         except KeyError:
             if self.required and not self.force_undefined:
                 self.matched = False
@@ -525,10 +510,7 @@ class AttrConstraint(SimpleConstraintABC):
         if self.force_reprocess:
             reprocess.append(
                 ProcessList(
-                    items=[item],
-                    work_over=self.force_reprocess,
-                    only_on_match=self.only_on_match,
-                    trigger_constraints=[self.id]
+                    items=[item], work_over=self.force_reprocess, only_on_match=self.only_on_match, trigger_constraints=[self.id]
                 )
             )
 
@@ -605,15 +587,16 @@ class Constraint:
                       'name': 'simple',
                       'matched': False})
     """
+
     def __init__(
-            self,
-            init=None,
-            reduce=None,
-            name=None,
-            reprocess_on_match=False,
-            reprocess_on_fail=False,
-            work_over=ListCategory.BOTH,
-            reprocess_rules=None
+        self,
+        init=None,
+        reduce=None,
+        name=None,
+        reprocess_on_match=False,
+        reprocess_on_fail=False,
+        work_over=ListCategory.BOTH,
+        reprocess_rules=None,
     ):
         self.constraints = []
 
@@ -642,9 +625,9 @@ class Constraint:
             self.constraints = [init]
         else:
             raise TypeError(
-                'Invalid initialization value type {}.'
-                '\nValid types are `SimpleConstraint`, `Constraint`,'
-                '\nor subclass.'.format(type(init))
+                "Invalid initialization value type {}.\nValid types are `SimpleConstraint`, `Constraint`,\nor subclass.".format(
+                    type(init)
+                )
             )
 
         # Give some defaults real meaning.
@@ -653,7 +636,7 @@ class Constraint:
             self.reduce = self.all
 
     @property
-    def dup_names(self): # -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]:
+    def dup_names(self):  # -> dict[str, list[typing.Union[SimpleConstraint, Constraint]]]:
         """Return dictionary of constraints with duplicate names
 
         This method is meant to be overridden by classes
@@ -665,7 +648,7 @@ class Constraint:
             Returns a mapping between the duplicated name
             and all the constraints that define that name.
         """
-        attrs = self.get_all_attr('name')
+        attrs = self.get_all_attr("name")
         constraints, names = zip(*attrs)
         dups = [name for name, count in collections.Counter(names).items() if count > 1]
         result = collections.defaultdict(list)
@@ -686,7 +669,7 @@ class Constraint:
         id : str
             The identifyer
         """
-        return f'{self.__class__.__name__}:{self.name}'
+        return f"{self.__class__.__name__}:{self.name}"
 
     def append(self, constraint):
         """Append a new constraint"""
@@ -710,14 +693,10 @@ class Constraint:
         self.matched, reprocess = self.reduce(item, self.constraints)
 
         # Determine reprocessing
-        if ((self.matched and self.reprocess_on_match) or
-                (not self.matched and self.reprocess_on_fail)):
-            reprocess.append([ProcessList(
-                items=[item],
-                work_over=self.work_over,
-                rules=self.reprocess_rules,
-                trigger_constraints=[self.id]
-            )])
+        if (self.matched and self.reprocess_on_match) or (not self.matched and self.reprocess_on_fail):
+            reprocess.append(
+                [ProcessList(items=[item], work_over=self.work_over, rules=self.reprocess_rules, trigger_constraints=[self.id])]
+            )
 
         return self.matched, list(chain(*reprocess))
 
@@ -725,7 +704,7 @@ class Constraint:
         """Copy ourselves"""
         return deepcopy(self)
 
-    def get_all_attr(self, attribute: str): # -> list[tuple[typing.Union[SimpleConstraint, Constraint], typing.Any]]:
+    def get_all_attr(self, attribute: str):  # -> list[tuple[typing.Union[SimpleConstraint, Constraint], typing.Any]]:
         """Return the specified attribute
 
         This method is meant to be overridden by classes
@@ -829,7 +808,7 @@ class Constraint:
 
     def __delitem__(self, key):
         """Not implemented"""
-        raise NotImplementedError('Cannot delete a constraint by index.')
+        raise NotImplementedError("Cannot delete a constraint by index.")
 
     # Make iterable
     def __iter__(self):
@@ -839,7 +818,7 @@ class Constraint:
     def __getitem__(self, key):
         """Retrieve a named constraint"""
         for constraint in self.constraints:
-            name = getattr(constraint, 'name', None)
+            name = getattr(constraint, "name", None)
             if name is not None and name == key:
                 return constraint
             try:
@@ -848,30 +827,23 @@ class Constraint:
                 pass
             else:
                 return found
-        raise KeyError(f'Constraint {key} not found')
+        raise KeyError(f"Constraint {key} not found")
 
     def __repr__(self):
-        result = '{}(name={}).{}([{}])'.format(
+        result = "{}(name={}).{}([{}])".format(
             self.__class__.__name__,
-            str(getattr(self, 'name', None)),
+            str(getattr(self, "name", None)),
             str(self.reduce.__name__),
-            ''.join([
-                repr(constraint)
-                for constraint in self.constraints
-            ])
+            "".join([repr(constraint) for constraint in self.constraints]),
         )
         return result
 
     def __setitem__(self, key, value):
         """Not implemented"""
-        raise NotImplementedError('Cannot set constraints by index.')
+        raise NotImplementedError("Cannot set constraints by index.")
 
     def __str__(self):
-        result = '\n'.join([
-            str(constraint)
-            for constraint in self
-            if constraint.name is not None
-        ])
+        result = "\n".join([str(constraint) for constraint in self if constraint.name is not None])
         return result
 
 
@@ -897,11 +869,7 @@ def meets_conditions(value, conditions):
     if not is_iterable(conditions):
         conditions = [conditions]
     for condition in conditions:
-        condition = ''.join([
-            '^',
-            condition,
-            '$'
-        ])
+        condition = "".join(["^", condition, "$"])
         match = re.match(condition, value, flags=re.IGNORECASE)
         if match:
             return True
@@ -935,5 +903,5 @@ def reprocess_multivalue(item, source, values, constraint):
         new_item = PoolRow(item)
         new_item[source] = str(value)
         reprocess_items.append(new_item)
-    process_list = (ProcessList(items=reprocess_items, trigger_constraints=[constraint.id]))
+    process_list = ProcessList(items=reprocess_items, trigger_constraints=[constraint.id])
     return process_list

--- a/romancal/associations/lib/counter.py
+++ b/romancal/associations/lib/counter.py
@@ -1,5 +1,6 @@
-class Counter():
+class Counter:
     """Like itertools.count but access to the current value"""
+
     def __init__(self, start=0, step=1, end=None):
         self.value = start
         self.step = step
@@ -9,8 +10,7 @@ class Counter():
         return self
 
     def __next__(self):
-        if self.end is not None and \
-           abs(self.value) > abs(self.end):
+        if self.end is not None and abs(self.value) > abs(self.end):
             raise StopIteration
         self.value += self.step
         return self.value

--- a/romancal/associations/lib/diff.py
+++ b/romancal/associations/lib/diff.py
@@ -1,9 +1,9 @@
 """"Diff and compare associations"""
 
-from collections import Counter, UserList
-from copy import copy
 import logging
 import re
+from collections import Counter, UserList
+from copy import copy
 
 from romancal.associations.load_asn import load_asn
 

--- a/romancal/associations/lib/diff.py
+++ b/romancal/associations/lib/diff.py
@@ -40,16 +40,15 @@ class TypeMismatchError(DiffError):
 
 class MultiDiffError(UserList, DiffError):
     """List of diff errors"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def __str__(self):
-        message = ['Following diffs found:\n']
+        message = ["Following diffs found:\n"]
         for diff in self:
-            message.extend([
-                '\n****\n', str(diff), '\n'
-            ])
-        return ''.join(message)
+            message.extend(["\n****\n", str(diff), "\n"])
+        return "".join(message)
 
 
 def compare_asn_files(left_paths, right_paths):
@@ -121,31 +120,18 @@ def compare_asn_lists(left_asns, right_asns):
     left_product_names, left_duplicates = get_product_names(left_asns)
     right_product_names, right_duplicates = get_product_names(right_asns)
     if left_duplicates:
-        diffs.append(DuplicateProductError(
-            f'Left associations have duplicate products {left_duplicates}'
-        ))
+        diffs.append(DuplicateProductError(f"Left associations have duplicate products {left_duplicates}"))
     if right_duplicates:
-        diffs.append(DuplicateProductError(
-            f'Right associations have duplicate products {right_duplicates}'
-        ))
+        diffs.append(DuplicateProductError(f"Right associations have duplicate products {right_duplicates}"))
 
     # Ensure that the product name lists are the same.
     name_diff = left_product_names ^ right_product_names
     if name_diff:
-        diffs.append(DifferentProductSetsError(
-            'Left and right associations do not share a common set of products: {}'
-            ''.format(name_diff)
-        ))
+        diffs.append(DifferentProductSetsError(f"Left and right associations do not share a common set of products: {name_diff}"))
 
     # Compare like product associations
-    left_asns_by_product = {
-        asn['products'][0]['name']: asn
-        for asn in left_asns
-    }
-    right_asns_by_product = {
-        asn['products'][0]['name']: asn
-        for asn in right_asns
-    }
+    left_asns_by_product = {asn["products"][0]["name"]: asn for asn in left_asns}
+    right_asns_by_product = {asn["products"][0]["name"]: asn for asn in right_asns}
     for product_name in left_product_names:
         try:
             compare_asns(left_asns_by_product[product_name], right_asns_by_product[product_name])
@@ -213,17 +199,13 @@ def _compare_asns(left, right):
     diffs = MultiDiffError()
 
     # Assert that the same result type is the same.
-    if left['asn_type'] != right['asn_type']:
-        diffs.append(TypeMismatchError(
-            'Type mismatch {} != {}'.format(left['asn_type'], right['asn_type'])
-        ))
+    if left["asn_type"] != right["asn_type"]:
+        diffs.append(TypeMismatchError("Type mismatch {} != {}".format(left["asn_type"], right["asn_type"])))
 
     # Assert that the level of association candidate is the same.
     # Cannot guarantee value, but that the 'a'/'c'/'o' levels are similar.
-    if left['asn_id'][0] != right['asn_id'][0]:
-        diffs.append(CandidateLevelError(
-            f"Candidate level mismatch left '{left['asn_id'][0]}' != right '{right['asn_id'][0]}'"
-        ))
+    if left["asn_id"][0] != right["asn_id"][0]:
+        diffs.append(CandidateLevelError(f"Candidate level mismatch left '{left['asn_id'][0]}' != right '{right['asn_id'][0]}'"))
 
     # Membership
     try:
@@ -250,19 +232,16 @@ def compare_membership(left, right):
         all the differences.
     """
     diffs = MultiDiffError()
-    products_left = left['products']
-    products_right = copy(right['products'])
+    products_left = left["products"]
+    products_right = copy(right["products"])
 
     if len(products_left) != len(products_right):
-        diffs.append(DifferentProductSetsError(
-            '# products differ: {left_len} != {right_len}'
-            ''.format(left_len=len(products_left), right_len=len(products_right))
-        ))
+        diffs.append(DifferentProductSetsError(f"# products differ: {len(products_left)} != {len(products_right)}"))
 
     for left_idx, left_product in enumerate(products_left):
-        left_product_name = components(left_product['name'])
+        left_product_name = components(left_product["name"])
         for right_idx, right_product in enumerate(products_right):
-            if components(right_product['name']) != left_product_name:
+            if components(right_product["name"]) != left_product_name:
                 continue
             try:
                 compare_product_membership(left_product, right_product)
@@ -271,17 +250,10 @@ def compare_membership(left, right):
             products_right.remove(right_product)
             break
         else:
-            diffs.append(DifferentProductSetsError(
-                'Left has {n_products} left over'
-                ''.format(n_products=len(products_left))
-            ))
-
+            diffs.append(DifferentProductSetsError(f"Left has {len(products_left)} left over"))
 
     if len(products_right) != 0:
-        diffs.append(DifferentProductSetsError(
-            'Right has {n_products} left over'
-            ''.format(n_products=len(products_right))
-        ))
+        diffs.append(DifferentProductSetsError(f"Right has {len(products_right)} left over"))
 
     if diffs:
         raise diffs
@@ -302,46 +274,60 @@ def compare_product_membership(left, right):
         all the differences.
     """
     diffs = MultiDiffError()
-    if len(right['members']) != len(left['members']):
-        diffs.append(MemberMismatchError(
-            'Product Member length differs:'
-            ' Left Product {left_product_name} len {left_len} !=  '
-            ' Right Product {right_product_name} len {right_len}'
-            ''.format(left_product_name=left['name'], left_len=len(left['members']),
-                      right_product_name=right['name'], right_len=len(right['members']))
-        ))
+    if len(right["members"]) != len(left["members"]):
+        diffs.append(
+            MemberMismatchError(
+                "Product Member length differs:"
+                " Left Product {left_product_name} len {left_len} !=  "
+                " Right Product {right_product_name} len {right_len}"
+                "".format(
+                    left_product_name=left["name"],
+                    left_len=len(left["members"]),
+                    right_product_name=right["name"],
+                    right_len=len(right["members"]),
+                )
+            )
+        )
 
-    members_right = copy(right['members'])
-    for left_member in left['members']:
+    members_right = copy(right["members"])
+    for left_member in left["members"]:
         for right_member in members_right:
-            if left_member['expname'] != right_member['expname']:
+            if left_member["expname"] != right_member["expname"]:
                 continue
 
-            if left_member['exptype'] != right_member['exptype']:
-                diffs.append(MemberMismatchError(
-                    'Left {left_expname}:{left_exptype}'
-                    ' != Right {right_expname}:{right_exptype}'
-                    ''.format(left_expname=left_member['expname'], left_exptype=left_member['exptype'],
-                          right_expname=right_member['expname'], right_exptype=right_member['exptype'])
-                ))
+            if left_member["exptype"] != right_member["exptype"]:
+                diffs.append(
+                    MemberMismatchError(
+                        "Left {left_expname}:{left_exptype} != Right {right_expname}:{right_exptype}".format(
+                            left_expname=left_member["expname"],
+                            left_exptype=left_member["exptype"],
+                            right_expname=right_member["expname"],
+                            right_exptype=right_member["exptype"],
+                        )
+                    )
+                )
 
             members_right.remove(right_member)
             break
         else:
-            diffs.append(MemberMismatchError(
-                'Left {left_expname}:{left_exptype} has no counterpart in right'
-                ''.format(left_expname=left_member['expname'], left_exptype=left_member['exptype'])
-            ))
+            diffs.append(
+                MemberMismatchError(
+                    "Left {left_expname}:{left_exptype} has no counterpart in right".format(
+                        left_expname=left_member["expname"], left_exptype=left_member["exptype"]
+                    )
+                )
+            )
 
     if len(members_right) != 0:
-        diffs.append(MemberMismatchError(
-            'Right has {len_over} unaccounted for members starting with'
-            ' {right_expname}:{right_exptype}'
-            ''.format(len_over=len(members_right),
-                      right_expname=members_right[0]['expname'],
-                      right_exptype=members_right[0]['exptype']
+        diffs.append(
+            MemberMismatchError(
+                "Right has {len_over} unaccounted for members starting with {right_expname}:{right_exptype}".format(
+                    len_over=len(members_right),
+                    right_expname=members_right[0]["expname"],
+                    right_exptype=members_right[0]["exptype"],
+                )
             )
-        ))
+        )
 
     if diffs:
         raise diffs
@@ -349,7 +335,7 @@ def compare_product_membership(left, right):
 
 def components(s):
     """split string into its components"""
-    return set(re.split('[_-]', s))
+    return set(re.split("[_-]", s))
 
 
 def separate_products(asn):
@@ -366,9 +352,9 @@ def separate_products(asn):
         The list of separated associations
     """
     separated = []
-    for product in asn['products']:
+    for product in asn["products"]:
         new_asn = copy(asn)
-        new_asn['products'] = [product]
+        new_asn["products"] = [product]
         separated.append(new_asn)
     return separated
 
@@ -385,19 +371,10 @@ def get_product_names(asns):
     product_names, duplicates: set(str[, ...]), [str[,...]]
         2-tuple consisting of the set of product names and the list of duplicates.
     """
-    product_names = [
-        asn['products'][0]['name']
-        for asn in asns
-    ]
+    product_names = [asn["products"][0]["name"] for asn in asns]
 
-    dups = [
-        name
-        for name, count in Counter(product_names).items()
-        if count > 1
-    ]
+    dups = [name for name, count in Counter(product_names).items() if count > 1]
     if dups:
-        logger.debug(
-            'Duplicate product names: %s', dups
-        )
+        logger.debug("Duplicate product names: %s", dups)
 
     return set(product_names), dups

--- a/romancal/associations/lib/diff.py
+++ b/romancal/associations/lib/diff.py
@@ -69,7 +69,8 @@ def compare_asn_files(left_paths, right_paths):
         all the differences.
     """
     __tracebackhide__ = True
-    # Read in all the associations, separating out the products into separate associations.
+    # Read in all the associations, separating out the products into separate
+    # associations.
     left_asns = []
     for path in left_paths:
         with open(path) as fh:

--- a/romancal/associations/lib/diff.py
+++ b/romancal/associations/lib/diff.py
@@ -200,7 +200,7 @@ def _compare_asns(left, right):
 
     # Assert that the same result type is the same.
     if left["asn_type"] != right["asn_type"]:
-        diffs.append(TypeMismatchError("Type mismatch {} != {}".format(left["asn_type"], right["asn_type"])))
+        diffs.append(TypeMismatchError(f"Type mismatch {left['asn_type']} != {right['asn_type']}"))
 
     # Assert that the level of association candidate is the same.
     # Cannot guarantee value, but that the 'a'/'c'/'o' levels are similar.

--- a/romancal/associations/lib/diff.py
+++ b/romancal/associations/lib/diff.py
@@ -120,21 +120,36 @@ def compare_asn_lists(left_asns, right_asns):
     left_product_names, left_duplicates = get_product_names(left_asns)
     right_product_names, right_duplicates = get_product_names(right_asns)
     if left_duplicates:
-        diffs.append(DuplicateProductError(f"Left associations have duplicate products {left_duplicates}"))
+        diffs.append(
+            DuplicateProductError(
+                f"Left associations have duplicate products {left_duplicates}"
+            )
+        )
     if right_duplicates:
-        diffs.append(DuplicateProductError(f"Right associations have duplicate products {right_duplicates}"))
+        diffs.append(
+            DuplicateProductError(
+                f"Right associations have duplicate products {right_duplicates}"
+            )
+        )
 
     # Ensure that the product name lists are the same.
     name_diff = left_product_names ^ right_product_names
     if name_diff:
-        diffs.append(DifferentProductSetsError(f"Left and right associations do not share a common set of products: {name_diff}"))
+        diffs.append(
+            DifferentProductSetsError(
+                "Left and right associations do not share a common set of products:"
+                f" {name_diff}"
+            )
+        )
 
     # Compare like product associations
     left_asns_by_product = {asn["products"][0]["name"]: asn for asn in left_asns}
     right_asns_by_product = {asn["products"][0]["name"]: asn for asn in right_asns}
     for product_name in left_product_names:
         try:
-            compare_asns(left_asns_by_product[product_name], right_asns_by_product[product_name])
+            compare_asns(
+                left_asns_by_product[product_name], right_asns_by_product[product_name]
+            )
         except MultiDiffError as compare_diffs:
             diffs.extend(compare_diffs)
         except KeyError:
@@ -200,12 +215,21 @@ def _compare_asns(left, right):
 
     # Assert that the same result type is the same.
     if left["asn_type"] != right["asn_type"]:
-        diffs.append(TypeMismatchError(f"Type mismatch {left['asn_type']} != {right['asn_type']}"))
+        diffs.append(
+            TypeMismatchError(
+                f"Type mismatch {left['asn_type']} != {right['asn_type']}"
+            )
+        )
 
     # Assert that the level of association candidate is the same.
     # Cannot guarantee value, but that the 'a'/'c'/'o' levels are similar.
     if left["asn_id"][0] != right["asn_id"][0]:
-        diffs.append(CandidateLevelError(f"Candidate level mismatch left '{left['asn_id'][0]}' != right '{right['asn_id'][0]}'"))
+        diffs.append(
+            CandidateLevelError(
+                f"Candidate level mismatch left '{left['asn_id'][0]}' != right"
+                f" '{right['asn_id'][0]}'"
+            )
+        )
 
     # Membership
     try:
@@ -236,7 +260,11 @@ def compare_membership(left, right):
     products_right = copy(right["products"])
 
     if len(products_left) != len(products_right):
-        diffs.append(DifferentProductSetsError(f"# products differ: {len(products_left)} != {len(products_right)}"))
+        diffs.append(
+            DifferentProductSetsError(
+                f"# products differ: {len(products_left)} != {len(products_right)}"
+            )
+        )
 
     for left_idx, left_product in enumerate(products_left):
         left_product_name = components(left_product["name"])
@@ -250,10 +278,14 @@ def compare_membership(left, right):
             products_right.remove(right_product)
             break
         else:
-            diffs.append(DifferentProductSetsError(f"Left has {len(products_left)} left over"))
+            diffs.append(
+                DifferentProductSetsError(f"Left has {len(products_left)} left over")
+            )
 
     if len(products_right) != 0:
-        diffs.append(DifferentProductSetsError(f"Right has {len(products_right)} left over"))
+        diffs.append(
+            DifferentProductSetsError(f"Right has {len(products_right)} left over")
+        )
 
     if diffs:
         raise diffs
@@ -298,7 +330,8 @@ def compare_product_membership(left, right):
             if left_member["exptype"] != right_member["exptype"]:
                 diffs.append(
                     MemberMismatchError(
-                        "Left {left_expname}:{left_exptype} != Right {right_expname}:{right_exptype}".format(
+                        "Left {left_expname}:{left_exptype} != Right"
+                        " {right_expname}:{right_exptype}".format(
                             left_expname=left_member["expname"],
                             left_exptype=left_member["exptype"],
                             right_expname=right_member["expname"],
@@ -312,16 +345,16 @@ def compare_product_membership(left, right):
         else:
             diffs.append(
                 MemberMismatchError(
-                    "Left {left_expname}:{left_exptype} has no counterpart in right".format(
-                        left_expname=left_member["expname"], left_exptype=left_member["exptype"]
-                    )
+                    f"Left {left_member['expname']}:{left_member['exptype']} has no"
+                    " counterpart in right"
                 )
             )
 
     if len(members_right) != 0:
         diffs.append(
             MemberMismatchError(
-                "Right has {len_over} unaccounted for members starting with {right_expname}:{right_exptype}".format(
+                "Right has {len_over} unaccounted for members starting with"
+                " {right_expname}:{right_exptype}".format(
                     len_over=len(members_right),
                     right_expname=members_right[0]["expname"],
                     right_exptype=members_right[0]["exptype"],

--- a/romancal/associations/lib/dms_base.py
+++ b/romancal/associations/lib/dms_base.py
@@ -1,15 +1,10 @@
 """Association attributes common to DMS-based Rules"""
 
-from romancal.associations.lib.counter import Counter
-
-from romancal.associations.exceptions import (
-    AssociationNotValidError,
-)
+from romancal.associations.exceptions import AssociationNotValidError
 from romancal.associations.lib.acid import ACIDMixin
-from romancal.associations.lib.constraint import (Constraint, AttrConstraint,
-                                                  SimpleConstraint)
+from romancal.associations.lib.constraint import AttrConstraint, Constraint, SimpleConstraint
+from romancal.associations.lib.counter import Counter
 from romancal.associations.lib.utilities import getattr_from_list
-
 
 __all__ = ['Constraint_TargetAcq', 'Constraint_WFSC', 'DMSBaseMixin']
 

--- a/romancal/associations/lib/dms_base.py
+++ b/romancal/associations/lib/dms_base.py
@@ -6,134 +6,126 @@ from romancal.associations.lib.constraint import AttrConstraint, Constraint, Sim
 from romancal.associations.lib.counter import Counter
 from romancal.associations.lib.utilities import getattr_from_list
 
-__all__ = ['Constraint_TargetAcq', 'Constraint_WFSC', 'DMSBaseMixin']
+__all__ = ["Constraint_TargetAcq", "Constraint_WFSC", "DMSBaseMixin"]
 
 # Default product name
-PRODUCT_NAME_DEFAULT = 'undefined'
+PRODUCT_NAME_DEFAULT = "undefined"
 
 # DMS file name templates
-_ASN_NAME_TEMPLATE_STAMP = 'r{program}-{acid}_{stamp}_{type}_{sequence:03d}_asn'
-_ASN_NAME_TEMPLATE = 'r{program}-{acid}_{type}_{sequence:03d}_asn'
+_ASN_NAME_TEMPLATE_STAMP = "r{program}-{acid}_{stamp}_{type}_{sequence:03d}_asn"
+_ASN_NAME_TEMPLATE = "r{program}-{acid}_{type}_{sequence:03d}_asn"
 
 # Acquisition and Confirmation images
 ACQ_EXP_TYPES = (
-    'mir_tacq',
-    'mir_taconfirm',
-    'nis_taconfirm',
-    'nis_tacq',
-    'nrc_taconfirm',
-    'nrc_tacq',
-    'nrs_confirm',
-    'nrs_msata',
-    'nrs_taconfirm',
-    'nrs_tacq',
-    'nrs_taslit',
-    'nrs_verify',
-    'nrs_wata',
+    "mir_tacq",
+    "mir_taconfirm",
+    "nis_taconfirm",
+    "nis_tacq",
+    "nrc_taconfirm",
+    "nrc_tacq",
+    "nrs_confirm",
+    "nrs_msata",
+    "nrs_taconfirm",
+    "nrs_tacq",
+    "nrs_taslit",
+    "nrs_verify",
+    "nrs_wata",
 )
 
 # Exposure EXP_TYPE to Association EXPTYPE mapping
 # flake8: noqa: E241
 EXPTYPE_MAP = {
-    'mir_darkall':       'dark',
-    'mir_darkimg':       'dark',
-    'mir_darkmrs':       'dark',
-    'mir_flatimage':     'flat',
-    'mir_flatmrs':       'flat',
-    'mir_flatimage-ext': 'flat',
-    'mir_flatmrs-ext':   'flat',
-    'mir_tacq':          'target_acquisition',
-    'mir_taconfirm':     'target_acquisition',
-    'nis_dark':          'dark',
-    'nis_focus':         'engineering',
-    'nis_lamp':          'engineering',
-    'nis_tacq':          'target_acquisition',
-    'nis_taconfirm':     'target_acquisition',
-    'nrc_dark':          'dark',
-    'nrc_flat':          'flat',
-    'nrc_focus':         'engineering',
-    'nrc_led':           'engineering',
-    'nrc_tacq':          'target_acquisition',
-    'nrc_taconfirm':     'target_acquisition',
-    'nrs_autoflat':      'autoflat',
-    'nrs_autowave':      'autowave',
-    'nrs_confirm':       'target_acquisition',
-    'nrs_dark':          'dark',
-    'nrs_focus':         'engineering',
-    'nrs_image':         'engineering',
-    'nrs_lamp':          'engineering',
-    'nrs_msata':         'target_acquisition',
-    'nrs_tacq':          'target_acquisition',
-    'nrs_taconfirm':     'target_acquisition',
-    'nrs_taslit':        'target_acquisition',
-    'nrs_wata':          'target_acquisition',
+    "mir_darkall": "dark",
+    "mir_darkimg": "dark",
+    "mir_darkmrs": "dark",
+    "mir_flatimage": "flat",
+    "mir_flatmrs": "flat",
+    "mir_flatimage-ext": "flat",
+    "mir_flatmrs-ext": "flat",
+    "mir_tacq": "target_acquisition",
+    "mir_taconfirm": "target_acquisition",
+    "nis_dark": "dark",
+    "nis_focus": "engineering",
+    "nis_lamp": "engineering",
+    "nis_tacq": "target_acquisition",
+    "nis_taconfirm": "target_acquisition",
+    "nrc_dark": "dark",
+    "nrc_flat": "flat",
+    "nrc_focus": "engineering",
+    "nrc_led": "engineering",
+    "nrc_tacq": "target_acquisition",
+    "nrc_taconfirm": "target_acquisition",
+    "nrs_autoflat": "autoflat",
+    "nrs_autowave": "autowave",
+    "nrs_confirm": "target_acquisition",
+    "nrs_dark": "dark",
+    "nrs_focus": "engineering",
+    "nrs_image": "engineering",
+    "nrs_lamp": "engineering",
+    "nrs_msata": "target_acquisition",
+    "nrs_tacq": "target_acquisition",
+    "nrs_taconfirm": "target_acquisition",
+    "nrs_taslit": "target_acquisition",
+    "nrs_wata": "target_acquisition",
 }
 
 # Coronographic exposures
-CORON_EXP_TYPES = [
-    'mir_4qpm',
-    'mir_lyot',
-    'nrc_coron'
-]
+CORON_EXP_TYPES = ["mir_4qpm", "mir_lyot", "nrc_coron"]
 
 # Exposures that get Level2b processing
 IMAGE2_SCIENCE_EXP_TYPES = [
-    'wfi_image',
-    'mir_4qpm',
-    'mir_image',
-    'mir_lyot',
-    'nis_ami',
-    'nis_image',
-    'nrc_coron',
-    'nrc_image',
-    'nrs_mimf',
-    'nrc_tsimage',
+    "wfi_image",
+    "mir_4qpm",
+    "mir_image",
+    "mir_lyot",
+    "nis_ami",
+    "nis_image",
+    "nrc_coron",
+    "nrc_image",
+    "nrs_mimf",
+    "nrc_tsimage",
 ]
 
 IMAGE2_NONSCIENCE_EXP_TYPES = [
-    'mir_coroncal',
-    'nis_focus',
-    'nrc_focus',
-    'nrs_focus',
-    'nrs_image',
+    "mir_coroncal",
+    "nis_focus",
+    "nrc_focus",
+    "nrs_focus",
+    "nrs_image",
 ]
 IMAGE2_NONSCIENCE_EXP_TYPES.extend(ACQ_EXP_TYPES)
 
 SPEC2_SCIENCE_EXP_TYPES = [
-    'mir_lrs-fixedslit',
-    'mir_lrs-slitless',
-    'mir_mrs',
-    'nis_soss',
-    'nis_wfss',
-    'nrc_tsgrism',
-    'nrc_wfss',
-    'nrs_fixedslit',
-    'nrs_ifu',
-    'nrs_msaspec',
-    'nrs_brightobj',
+    "mir_lrs-fixedslit",
+    "mir_lrs-slitless",
+    "mir_mrs",
+    "nis_soss",
+    "nis_wfss",
+    "nrc_tsgrism",
+    "nrc_wfss",
+    "nrs_fixedslit",
+    "nrs_ifu",
+    "nrs_msaspec",
+    "nrs_brightobj",
 ]
 
 SPECIAL_EXPOSURE_MODIFIERS = {
-    'background': ['bkgdtarg'],
-    'imprint': ['is_imprt'],
-    'psf': ['is_psf'],
+    "background": ["bkgdtarg"],
+    "imprint": ["is_imprt"],
+    "psf": ["is_psf"],
 }
 
 #
 # Key that uniquely identifies members.
-MEMBER_KEY = 'expname'
+MEMBER_KEY = "expname"
 
 # Non-specified values found in DMS Association Pools
-_EMPTY = (None, '', 'NULL', 'Null', 'null', '--', 'N', 'n',
-          'F', 'f', 'FALSE', 'false', 'False', 'N/A', 'n/a')
+_EMPTY = (None, "", "NULL", "Null", "null", "--", "N", "n", "F", "f", "FALSE", "false", "False", "N/A", "n/a")
 
 # Degraded status information
-_DEGRADED_STATUS_OK = (
-    'No known degraded exposures in association.'
-)
+_DEGRADED_STATUS_OK = "No known degraded exposures in association."
 _DEGRADED_STATUS_NOTOK = (
-    'One or more members have an error associated with them.'
-    '\nDetails can be found in the member.exposerr attribute.'
+    "One or more members have an error associated with them.\nDetails can be found in the member.exposerr attribute."
 )
 
 
@@ -155,10 +147,10 @@ class DMSBaseMixin(ACIDMixin):
         self._acid = None
         self._asn_name = None
         self.sequence = None
-        if 'degraded_status' not in self.data:
-            self.data['degraded_status'] = _DEGRADED_STATUS_OK
-        if 'program' not in self.data:
-            self.data['program'] = 'noprogram'
+        if "degraded_status" not in self.data:
+            self.data["degraded_status"] = _DEGRADED_STATUS_OK
+        if "program" not in self.data:
+            self.data["program"] = "noprogram"
 
     @classmethod
     def create(cls, item, version_id=None):
@@ -209,9 +201,9 @@ class DMSBaseMixin(ACIDMixin):
         if self._asn_name:
             return self._asn_name
 
-        program = self.data['program']
+        program = self.data["program"]
         version_id = self.version_id
-        asn_type = self.data['asn_type']
+        asn_type = self.data["asn_type"]
         sequence = self.sequence
 
         if version_id:
@@ -239,17 +231,13 @@ class DMSBaseMixin(ACIDMixin):
     @property
     def current_product(self):
         """Return currnet products"""
-        return self.data['products'][-1]
+        return self.data["products"][-1]
 
     @property
     def from_items(self):
         """The list of items that contributed to the association."""
         try:
-            items = [
-                member.item
-                for product in self['products']
-                for member in product['members']
-            ]
+            items = [member.item for product in self["products"] for member in product["members"]]
         except KeyError:
             items = []
         return items
@@ -257,11 +245,7 @@ class DMSBaseMixin(ACIDMixin):
     @property
     def member_ids(self):
         """Set of all member ids in all products of this association"""
-        member_ids = {
-            member[MEMBER_KEY]
-            for product in self['products']
-            for member in product['members']
-        }
+        member_ids = {member[MEMBER_KEY] for product in self["products"] for member in product["members"]}
         return member_ids
 
     @property
@@ -279,7 +263,7 @@ class DMSBaseMixin(ACIDMixin):
         """Set validity dict"""
         self._validity = item
 
-    def get_exposure_type(self, item, default='science'):
+    def get_exposure_type(self, item, default="science"):
         """Determine the exposure type of a pool item
 
         Parameters
@@ -319,7 +303,7 @@ class DMSBaseMixin(ACIDMixin):
             The member to check for
         """
         try:
-            current_members = self.current_product['members']
+            current_members = self.current_product["members"]
         except KeyError:
             return False
 
@@ -342,7 +326,6 @@ class DMSBaseMixin(ACIDMixin):
             True if item is a member.
         """
         return item in self.from_items
-
 
     def item_getattr(self, item, attributes):
         """Return value from any of a list of attributes
@@ -370,14 +353,11 @@ class DMSBaseMixin(ACIDMixin):
 
     def new_product(self, product_name=PRODUCT_NAME_DEFAULT):
         """Start a new product"""
-        product = {
-            'name': product_name,
-            'members': []
-        }
+        product = {"name": product_name, "members": []}
         try:
-            self.data['products'].append(product)
+            self.data["products"].append(product)
         except (AttributeError, KeyError):
-            self.data['products'] = [product]
+            self.data["products"] = [product]
 
     def update_asn(self, item=None, member=None):
         """Update association meta information
@@ -403,22 +383,22 @@ class DMSBaseMixin(ACIDMixin):
     def update_degraded_status(self):
         """Update association degraded status"""
 
-        if self.data['degraded_status'] == _DEGRADED_STATUS_OK:
-            for product in self.data['products']:
-                for member in product['members']:
+        if self.data["degraded_status"] == _DEGRADED_STATUS_OK:
+            for product in self.data["products"]:
+                for member in product["members"]:
                     try:
-                        exposerr = member['exposerr']
+                        exposerr = member["exposerr"]
                     except KeyError:
                         continue
                     else:
                         if exposerr not in _EMPTY:
-                            self.data['degraded_status'] = _DEGRADED_STATUS_NOTOK
+                            self.data["degraded_status"] = _DEGRADED_STATUS_NOTOK
                             break
 
     def update_validity(self, entry):
         for test in self.validity.values():
-            if not test['validated']:
-                test['validated'] = test['check'](entry)
+            if not test["validated"]:
+                test["validated"] = test["check"](entry)
 
     @classmethod
     def reset_sequence(cls):
@@ -431,16 +411,11 @@ class DMSBaseMixin(ACIDMixin):
         if isinstance(asn, DMSBaseMixin):
             result = False
             try:
-                result = all(
-                    test['validated']
-                    for test in asn.validity.values()
-                )
+                result = all(test["validated"] for test in asn.validity.values())
             except (AttributeError, KeyError):
-                raise AssociationNotValidError('Validation failed')
+                raise AssociationNotValidError("Validation failed")
             if not result:
-                raise AssociationNotValidError(
-                    'Validation failed validity tests.'
-                )
+                raise AssociationNotValidError("Validation failed validity tests.")
         return True
 
     def _get_exposure(self):
@@ -452,16 +427,14 @@ class DMSBaseMixin(ACIDMixin):
             The Level3 Product name representation
             of the exposure & activity id.
         """
-        exposure = ''
+        exposure = ""
         try:
-            activity_id = format_list(
-                self.constraints['activity_id'].found_values
-            )
+            activity_id = format_list(self.constraints["activity_id"].found_values)
         except KeyError:
             pass
         else:
             if activity_id not in _EMPTY:
-                exposure = f'{activity_id:0>2s}'
+                exposure = f"{activity_id:0>2s}"
         return exposure
 
     def _get_instrument(self):
@@ -473,7 +446,7 @@ class DMSBaseMixin(ACIDMixin):
             The Level3 Product name representation
             of the instrument
         """
-        instrument = format_list(self.constraints['instrument'].found_values)
+        instrument = format_list(self.constraints["instrument"].found_values)
         return instrument
 
     def _get_opt_element(self):
@@ -487,7 +460,7 @@ class DMSBaseMixin(ACIDMixin):
         """
         # Retrieve all the optical elements
         opt_elems = []
-        for opt_elem in ['opt_elem', 'opt_elem2', 'opt_elem3']:
+        for opt_elem in ["opt_elem", "opt_elem2", "opt_elem3"]:
             try:
                 values = list(self.constraints[opt_elem].found_values)
             except KeyError:
@@ -501,9 +474,9 @@ class DMSBaseMixin(ACIDMixin):
         # Build the string. Sort the elements in order to
         # create data-independent results
         opt_elems.sort(key=str.lower)
-        opt_elem = '-'.join(opt_elems)
-        if opt_elem == '':
-            opt_elem = 'clear'
+        opt_elem = "-".join(opt_elems)
+        if opt_elem == "":
+            opt_elem = "clear"
 
         return opt_elem
 
@@ -516,12 +489,12 @@ class DMSBaseMixin(ACIDMixin):
             The Level3 Product name representation
             of the subarray.
         """
-        result = ''
+        result = ""
         try:
-            subarray = format_list(self.constraints['subarray'].found_values)
+            subarray = format_list(self.constraints["subarray"].found_values)
         except KeyError:
             subarray = None
-        if subarray == 'full':
+        if subarray == "full":
             subarray = None
         if subarray is not None:
             result = subarray
@@ -537,8 +510,8 @@ class DMSBaseMixin(ACIDMixin):
             The Level3 Product name representation
             of the target or source ID.
         """
-        target_id = format_list(self.constraints['target'].found_values)
-        target = f't{str(target_id):0>3s}'
+        target_id = format_list(self.constraints["target"].found_values)
+        target = f"t{str(target_id):0>3s}"
         return target
 
     def _get_grating(self):
@@ -550,8 +523,8 @@ class DMSBaseMixin(ACIDMixin):
             The Level3 Product name representation
             of the grating in use.
         """
-        grating_id = format_list(self.constraints['grating'].found_values)
-        grating = f'{str(grating_id):0>3s}'
+        grating_id = format_list(self.constraints["grating"].found_values)
+        grating = f"{str(grating_id):0>3s}"
         return grating
 
 
@@ -563,10 +536,11 @@ class DMSAttrConstraint(AttrConstraint):
 
     Forces definition of invalid values
     """
+
     def __init__(self, **kwargs):
 
-        if kwargs.get('invalid_values', None) is None:
-            kwargs['invalid_values'] = _EMPTY
+        if kwargs.get("invalid_values", None) is None:
+            kwargs["invalid_values"] = _EMPTY
 
         super().__init__(**kwargs)
 
@@ -580,36 +554,22 @@ class Constraint_TargetAcq(SimpleConstraint):
         If specified, use the `get_exposure_type` method
         of the association rather than the utility version.
     """
+
     def __init__(self, association=None):
         if association is None:
             _get_exposure_type = get_exposure_type
         else:
             _get_exposure_type = association.get_exposure_type
 
-        super().__init__(
-            name='target_acq',
-            value='target_acquisition',
-            sources=_get_exposure_type
-        )
-
+        super().__init__(name="target_acq", value="target_acquisition", sources=_get_exposure_type)
 
 
 class Constraint_WFSC(Constraint):
     """Match on Wave Front Sensing and Control Observations"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(
-            [
-                Constraint(
-                    [
-                        DMSAttrConstraint(
-                            name='wfsc',
-                            sources=['visitype'],
-                            value='.+wfsc.+',
-                            force_unique=True
-                        )
-                    ]
-                )
-            ]
+            [Constraint([DMSAttrConstraint(name="wfsc", sources=["visitype"], value=".+wfsc.+", force_unique=True)])]
         )
 
 
@@ -618,10 +578,10 @@ class Constraint_WFSC(Constraint):
 # #########
 def format_list(alist):
     """Format a list according to DMS naming specs"""
-    return '-'.join(alist)
+    return "-".join(alist)
 
 
-def get_exposure_type(item, default='science', association=None):
+def get_exposure_type(item, default="science", association=None):
     """Determine the exposure type of a pool item
 
     Parameters
@@ -667,28 +627,28 @@ def get_exposure_type(item, default='science', association=None):
     # Retrieve pointing type. This decides the basic exposure type.
     # If the pointing is not science, we're done.
     try:
-        result = _item_attr(item, ['pntgtype'])
+        result = _item_attr(item, ["pntgtype"])
     except KeyError:
         pass
     else:
-        if result != 'science':
+        if result != "science":
             return result
 
     # We have a science exposure. Refine further.
     #
     # Base type off of exposure type.
     try:
-        exp_type = _item_attr(item, ['exp_type'])
+        exp_type = _item_attr(item, ["exp_type"])
     except KeyError:
-        raise LookupError('Exposure type cannot be determined')
+        raise LookupError("Exposure type cannot be determined")
 
     result = EXPTYPE_MAP.get(exp_type, default)
 
     if result is None:
-        raise LookupError('Cannot determine exposure type')
+        raise LookupError("Cannot determine exposure type")
 
     # If result is not science, we're done.
-    if result != 'science':
+    if result != "science":
         return result
 
     # For `science` data, compare against special modifiers
@@ -731,8 +691,4 @@ def item_getattr(item, attributes, association=None):
         invalid_values = _EMPTY
     else:
         invalid_values = association.INVALID_VALUES
-    return getattr_from_list(
-        item,
-        attributes,
-        invalid_values=invalid_values
-    )
+    return getattr_from_list(item, attributes, invalid_values=invalid_values)

--- a/romancal/associations/lib/dms_base.py
+++ b/romancal/associations/lib/dms_base.py
@@ -2,7 +2,11 @@
 
 from romancal.associations.exceptions import AssociationNotValidError
 from romancal.associations.lib.acid import ACIDMixin
-from romancal.associations.lib.constraint import AttrConstraint, Constraint, SimpleConstraint
+from romancal.associations.lib.constraint import (
+    AttrConstraint,
+    Constraint,
+    SimpleConstraint,
+)
 from romancal.associations.lib.counter import Counter
 from romancal.associations.lib.utilities import getattr_from_list
 
@@ -120,12 +124,29 @@ SPECIAL_EXPOSURE_MODIFIERS = {
 MEMBER_KEY = "expname"
 
 # Non-specified values found in DMS Association Pools
-_EMPTY = (None, "", "NULL", "Null", "null", "--", "N", "n", "F", "f", "FALSE", "false", "False", "N/A", "n/a")
+_EMPTY = (
+    None,
+    "",
+    "NULL",
+    "Null",
+    "null",
+    "--",
+    "N",
+    "n",
+    "F",
+    "f",
+    "FALSE",
+    "false",
+    "False",
+    "N/A",
+    "n/a",
+)
 
 # Degraded status information
 _DEGRADED_STATUS_OK = "No known degraded exposures in association."
 _DEGRADED_STATUS_NOTOK = (
-    "One or more members have an error associated with them.\nDetails can be found in the member.exposerr attribute."
+    "One or more members have an error associated with them.\nDetails can be found in"
+    " the member.exposerr attribute."
 )
 
 
@@ -237,7 +258,11 @@ class DMSBaseMixin(ACIDMixin):
     def from_items(self):
         """The list of items that contributed to the association."""
         try:
-            items = [member.item for product in self["products"] for member in product["members"]]
+            items = [
+                member.item
+                for product in self["products"]
+                for member in product["members"]
+            ]
         except KeyError:
             items = []
         return items
@@ -245,7 +270,11 @@ class DMSBaseMixin(ACIDMixin):
     @property
     def member_ids(self):
         """Set of all member ids in all products of this association"""
-        member_ids = {member[MEMBER_KEY] for product in self["products"] for member in product["members"]}
+        member_ids = {
+            member[MEMBER_KEY]
+            for product in self["products"]
+            for member in product["members"]
+        }
         return member_ids
 
     @property
@@ -561,7 +590,9 @@ class Constraint_TargetAcq(SimpleConstraint):
         else:
             _get_exposure_type = association.get_exposure_type
 
-        super().__init__(name="target_acq", value="target_acquisition", sources=_get_exposure_type)
+        super().__init__(
+            name="target_acq", value="target_acquisition", sources=_get_exposure_type
+        )
 
 
 class Constraint_WFSC(Constraint):
@@ -569,7 +600,18 @@ class Constraint_WFSC(Constraint):
 
     def __init__(self, *args, **kwargs):
         super().__init__(
-            [Constraint([DMSAttrConstraint(name="wfsc", sources=["visitype"], value=".+wfsc.+", force_unique=True)])]
+            [
+                Constraint(
+                    [
+                        DMSAttrConstraint(
+                            name="wfsc",
+                            sources=["visitype"],
+                            value=".+wfsc.+",
+                            force_unique=True,
+                        )
+                    ]
+                )
+            ]
         )
 
 

--- a/romancal/associations/lib/keyvalue_registry.py
+++ b/romancal/associations/lib/keyvalue_registry.py
@@ -2,12 +2,7 @@
 
 from collections import UserDict
 
-__all__ = [
-    'KeyValueRegistry',
-    'KeyValueRegistryError',
-    'KeyValueRegistryNoKeyFound',
-    'KeyValueRegistryNotSingleItemError'
-]
+__all__ = ["KeyValueRegistry", "KeyValueRegistryError", "KeyValueRegistryNoKeyFound", "KeyValueRegistryNotSingleItemError"]
 
 
 class KeyValueRegistry(UserDict):
@@ -35,7 +30,7 @@ class KeyValueRegistry(UserDict):
     def __init__(self, items=None, default=None):
         super_args = ()
         if items is not None:
-            super_args = (make_dict(items), )
+            super_args = (make_dict(items),)
         super().__init__(*super_args)
 
         self.default = None
@@ -68,16 +63,16 @@ class KeyValueRegistry(UserDict):
 class KeyValueRegistryError(Exception):
     def __init__(self, *args):
         if len(args) == 0:
-            args = (self.msg, )
+            args = (self.msg,)
         super().__init__(*args)
 
 
 class KeyValueRegistryNotSingleItemError(KeyValueRegistryError):
-    msg = 'Item cannot be a list'
+    msg = "Item cannot be a list"
 
 
 class KeyValueRegistryNoKeyFound(KeyValueRegistryError):
-    msg = 'Cannot deduce key from given value'
+    msg = "Cannot deduce key from given value"
 
 
 # *********

--- a/romancal/associations/lib/keyvalue_registry.py
+++ b/romancal/associations/lib/keyvalue_registry.py
@@ -2,7 +2,12 @@
 
 from collections import UserDict
 
-__all__ = ["KeyValueRegistry", "KeyValueRegistryError", "KeyValueRegistryNoKeyFound", "KeyValueRegistryNotSingleItemError"]
+__all__ = [
+    "KeyValueRegistry",
+    "KeyValueRegistryError",
+    "KeyValueRegistryNoKeyFound",
+    "KeyValueRegistryNotSingleItemError",
+]
 
 
 class KeyValueRegistry(UserDict):

--- a/romancal/associations/lib/keyvalue_registry.py
+++ b/romancal/associations/lib/keyvalue_registry.py
@@ -2,7 +2,6 @@
 
 from collections import UserDict
 
-
 __all__ = [
     'KeyValueRegistry',
     'KeyValueRegistryError',

--- a/romancal/associations/lib/log_config.py
+++ b/romancal/associations/lib/log_config.py
@@ -6,18 +6,14 @@ from collections import defaultdict
 from functools import partialmethod
 from logging.config import dictConfig
 
-__all__ = ['log_config']
+__all__ = ["log_config"]
 
-DMS_DEFAULT_FORMAT = (
-    '%(asctime)s'
-    ' %(levelname)s'
-    ' pid=%(process)d'
-    ' src=%(name)s.%(funcName)s'
-)
+DMS_DEFAULT_FORMAT = "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s"
 
 
-class ContextFilter():
+class ContextFilter:
     """Set Association Generator logging context"""
+
     def __init__(self):
         self.context = {}
 
@@ -32,8 +28,9 @@ class ContextFilter():
         self.context[key] = value
 
 
-class LogLevelFilter():
+class LogLevelFilter:
     """Filter on a specific level"""
+
     def __init__(self, level):
         self.__level = level
 
@@ -48,99 +45,72 @@ class DMSFormatter(logging.Formatter):
         log_parts = []
         log_parts.append(super().format(record))
         for key in record._context:
-            log_parts.append(f'{key}={record._context[key]}')
+            log_parts.append(f"{key}={record._context[key]}")
         log_parts.append(f'msg="{record.getMessage()}"')
-        log_line = ' '.join(log_parts)
+        log_line = " ".join(log_parts)
         return log_line
 
 
 # Define the common logging configuration
 # Basic logger has the following config
 base_logger = {
-    'handlers': [
-        'info',
-        'debug',
-        'default',
+    "handlers": [
+        "info",
+        "debug",
+        "default",
     ],
-    'propagate': False,
+    "propagate": False,
 }
 
 # Basic, user-centric logging
 context = ContextFilter()
 base_config = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'datefmt': '%Y%m%d%H%M',
-    'formatters': {
-        'info': {
-            'format': '%(message)s',
-            'datefmt': 'cfg://datefmt'
-        },
-        'debug': {
-            'format': '%(asctime)s:%(levelname)s:%(name)s.%(funcName)s:%(message)s',
-            'datefmt': 'cfg://datefmt'
-        }
+    "version": 1,
+    "disable_existing_loggers": False,
+    "datefmt": "%Y%m%d%H%M",
+    "formatters": {
+        "info": {"format": "%(message)s", "datefmt": "cfg://datefmt"},
+        "debug": {"format": "%(asctime)s:%(levelname)s:%(name)s.%(funcName)s:%(message)s", "datefmt": "cfg://datefmt"},
     },
-    'handlers': {
-        'info': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'info',
-            'level': logging.INFO,
-            'stream': sys.stdout,
-            'filters': ['info', 'context']
+    "handlers": {
+        "info": {
+            "class": "logging.StreamHandler",
+            "formatter": "info",
+            "level": logging.INFO,
+            "stream": sys.stdout,
+            "filters": ["info", "context"],
         },
-        'debug': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'debug',
-            'level': logging.DEBUG,
-            'stream': sys.stderr,
-            'filters': ['debug', 'context']
+        "debug": {
+            "class": "logging.StreamHandler",
+            "formatter": "debug",
+            "level": logging.DEBUG,
+            "stream": sys.stderr,
+            "filters": ["debug", "context"],
         },
-        'default': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'debug',
-            'level': logging.WARN,
-            'stream': sys.stderr,
-            'filters': ['context']
-        }
+        "default": {
+            "class": "logging.StreamHandler",
+            "formatter": "debug",
+            "level": logging.WARN,
+            "stream": sys.stderr,
+            "filters": ["context"],
+        },
     },
-    'filters': {
-        'context': {
-            '()': context
-        },
-        'info': {
-            '()': LogLevelFilter,
-            'level': logging.INFO
-        },
-        'debug': {
-            '()': LogLevelFilter,
-            'level': logging.DEBUG
-        }
+    "filters": {
+        "context": {"()": context},
+        "info": {"()": LogLevelFilter, "level": logging.INFO},
+        "debug": {"()": LogLevelFilter, "level": logging.DEBUG},
     },
-    'DMS': {
-        'datefmt': '%Y%m%d%H%M',
-        'logformat': (
-            '%(asctime)s'
-            ' %(levelname)s'
-            ' pid=%(process)d'
-            ' src=%(name)s.%(funcName)s'
-        )
-    }
+    "DMS": {
+        "datefmt": "%Y%m%d%H%M",
+        "logformat": "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s",
+    },
 }
 
 # DMS-specific configuration
 DMS_config = {
-    'formatters': {
-        'info': {
-            '()': DMSFormatter,
-            'format': 'cfg://DMS.logformat',
-            'datefmt': 'cfg://DMS.datefmt'
-        },
-        'debug': {
-            '()': DMSFormatter,
-            'format': 'cfg://DMS.logformat',
-            'datefmt': 'cfg://DMS.datefmt'
-        }
+    "formatters": {
+        "info": {"()": DMSFormatter, "format": "cfg://DMS.logformat", "datefmt": "cfg://DMS.datefmt"},
+        "debug": {"()": DMSFormatter, "format": "cfg://DMS.logformat", "datefmt": "cfg://DMS.datefmt"},
     }
 }
 
@@ -153,7 +123,7 @@ class MultilineLogger(logging.getLoggerClass()):
 
     def log(self, level, msg, *args, **kwargs):
         if self.isEnabledFor(level):
-            for line in msg.split('\n'):
+            for line in msg.split("\n"):
                 self._log(level, line, args, **kwargs)
 
     debug = partialmethod(log, logging.DEBUG)
@@ -167,11 +137,7 @@ class MultilineLogger(logging.getLoggerClass()):
 logging.setLoggerClass(MultilineLogger)
 
 
-def log_config(name=None,
-               user_name=None,
-               logger_config=None,
-               config=None,
-               merge=True):
+def log_config(name=None, user_name=None, logger_config=None, config=None, merge=True):
     """Setup logging with defaults
 
     logging.dictConfig is used with optional default
@@ -244,7 +210,7 @@ def log_config(name=None,
     global context
 
     if user_name is None:
-        user_name = 'root' if name is None else name
+        user_name = "root" if name is None else name
     if logger_config is None:
         logger_config = {}
     if config is None:
@@ -255,9 +221,7 @@ def log_config(name=None,
         use_logger.update(logger_config)
         for key in config:
             use_config[key].update(config[key])
-        use_config['loggers'] = {
-            name: use_logger
-        }
+        use_config["loggers"] = {name: use_logger}
 
     dictConfig(use_config)
     logger = logging.getLogger(name)

--- a/romancal/associations/lib/log_config.py
+++ b/romancal/associations/lib/log_config.py
@@ -8,7 +8,9 @@ from logging.config import dictConfig
 
 __all__ = ["log_config"]
 
-DMS_DEFAULT_FORMAT = "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s"
+DMS_DEFAULT_FORMAT = (
+    "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s"
+)
 
 
 class ContextFilter:
@@ -70,7 +72,10 @@ base_config = {
     "datefmt": "%Y%m%d%H%M",
     "formatters": {
         "info": {"format": "%(message)s", "datefmt": "cfg://datefmt"},
-        "debug": {"format": "%(asctime)s:%(levelname)s:%(name)s.%(funcName)s:%(message)s", "datefmt": "cfg://datefmt"},
+        "debug": {
+            "format": "%(asctime)s:%(levelname)s:%(name)s.%(funcName)s:%(message)s",
+            "datefmt": "cfg://datefmt",
+        },
     },
     "handlers": {
         "info": {
@@ -102,15 +107,25 @@ base_config = {
     },
     "DMS": {
         "datefmt": "%Y%m%d%H%M",
-        "logformat": "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s",
+        "logformat": (
+            "%(asctime)s %(levelname)s pid=%(process)d src=%(name)s.%(funcName)s"
+        ),
     },
 }
 
 # DMS-specific configuration
 DMS_config = {
     "formatters": {
-        "info": {"()": DMSFormatter, "format": "cfg://DMS.logformat", "datefmt": "cfg://DMS.datefmt"},
-        "debug": {"()": DMSFormatter, "format": "cfg://DMS.logformat", "datefmt": "cfg://DMS.datefmt"},
+        "info": {
+            "()": DMSFormatter,
+            "format": "cfg://DMS.logformat",
+            "datefmt": "cfg://DMS.datefmt",
+        },
+        "debug": {
+            "()": DMSFormatter,
+            "format": "cfg://DMS.logformat",
+            "datefmt": "cfg://DMS.datefmt",
+        },
     }
 }
 

--- a/romancal/associations/lib/log_config.py
+++ b/romancal/associations/lib/log_config.py
@@ -1,12 +1,10 @@
 """Configure Association Logging"""
 
-import sys
 import logging
-from logging.config import dictConfig
+import sys
 from collections import defaultdict
-
 from functools import partialmethod
-
+from logging.config import dictConfig
 
 __all__ = ['log_config']
 

--- a/romancal/associations/lib/member.py
+++ b/romancal/associations/lib/member.py
@@ -21,6 +21,7 @@ class Member(UserDict):
     item: obj
         The original item that created this member.
     """
+
     def __init__(self, initialdata=None, item=None):
         self.item = None
 

--- a/romancal/associations/lib/process_list.py
+++ b/romancal/associations/lib/process_list.py
@@ -3,7 +3,13 @@ from collections import deque
 from enum import Enum
 from functools import reduce
 
-__all__ = ["ListCategory", "ProcessList", "ProcessItem", "ProcessQueue", "ProcessQueueSorted"]
+__all__ = [
+    "ListCategory",
+    "ProcessList",
+    "ProcessItem",
+    "ProcessQueue",
+    "ProcessQueueSorted",
+]
 
 
 class ListCategory(Enum):
@@ -89,7 +95,13 @@ class ProcessList:
         The association rules that created the ProcessList
     """
 
-    _str_attrs = ("rules", "work_over", "only_on_match", "trigger_constraints", "trigger_rules")
+    _str_attrs = (
+        "rules",
+        "work_over",
+        "only_on_match",
+        "trigger_constraints",
+        "trigger_rules",
+    )
 
     def __init__(
         self,
@@ -104,7 +116,9 @@ class ProcessList:
         self.rules = rules
         self.work_over = work_over
         self.only_on_match = only_on_match
-        self.trigger_constraints = set(trigger_constraints) if trigger_constraints else set()
+        self.trigger_constraints = (
+            set(trigger_constraints) if trigger_constraints else set()
+        )
         self.trigger_rules = set(trigger_rules) if trigger_rules else set()
 
     @property
@@ -140,7 +154,9 @@ class ProcessList:
 
     def __str__(self):
         result = "{}(n_items: {}, {})".format(
-            self.__class__.__name__, len(self.items), {str_attr: getattr(self, str_attr) for str_attr in self._str_attrs}
+            self.__class__.__name__,
+            len(self.items),
+            {str_attr: getattr(self, str_attr) for str_attr in self._str_attrs},
         )
         return result
 
@@ -206,7 +222,10 @@ class ProcessListQueue:
                 break
 
     def __str__(self):
-        result = f"{self.__class__.__name__}: rulesets {len(self)} items {len(list(self.items()))}"
+        result = (
+            f"{self.__class__.__name__}: rulesets {len(self)} items"
+            f" {len(list(self.items()))}"
+        )
         return result
 
 
@@ -223,7 +242,9 @@ class ProcessQueueSorted:
     """
 
     def __init__(self, init=None):
-        self.queues = {list_category: ProcessListQueue() for list_category in ListCategory}
+        self.queues = {
+            list_category: ProcessListQueue() for list_category in ListCategory
+        }
 
         if init is not None:
             self.extend(init)

--- a/romancal/associations/lib/process_list.py
+++ b/romancal/associations/lib/process_list.py
@@ -3,7 +3,6 @@ from collections import deque
 from enum import Enum
 from functools import reduce
 
-
 __all__ = [
     'ListCategory',
     'ProcessList',

--- a/romancal/associations/lib/process_list.py
+++ b/romancal/associations/lib/process_list.py
@@ -3,17 +3,12 @@ from collections import deque
 from enum import Enum
 from functools import reduce
 
-__all__ = [
-    'ListCategory',
-    'ProcessList',
-    'ProcessItem',
-    'ProcessQueue',
-    'ProcessQueueSorted'
-]
+__all__ = ["ListCategory", "ProcessList", "ProcessItem", "ProcessQueue", "ProcessQueueSorted"]
 
 
 class ListCategory(Enum):
     """Categories in the list"""
+
     RULES = 0
     BOTH = 1
     EXISTING = 2
@@ -29,6 +24,7 @@ class ProcessItem:
         The object to make a `ProcessItem`.
         Objects must be equatable.
     """
+
     def __init__(self, obj):
         self.obj = obj
 
@@ -93,11 +89,17 @@ class ProcessList:
         The association rules that created the ProcessList
     """
 
-    _str_attrs = ('rules', 'work_over', 'only_on_match', 'trigger_constraints', 'trigger_rules')
+    _str_attrs = ("rules", "work_over", "only_on_match", "trigger_constraints", "trigger_rules")
 
-    def __init__(self, items=None, rules=None,
-                 work_over=ListCategory.BOTH, only_on_match=False,
-                 trigger_constraints=None, trigger_rules=None):
+    def __init__(
+        self,
+        items=None,
+        rules=None,
+        work_over=ListCategory.BOTH,
+        only_on_match=False,
+        trigger_constraints=None,
+        trigger_rules=None,
+    ):
         self.items = items
         self.rules = rules
         self.work_over = work_over
@@ -137,19 +139,15 @@ class ProcessList:
             self.only_on_match = process_list.only_on_match
 
     def __str__(self):
-        result = '{}(n_items: {}, {})'.format(
-            self.__class__.__name__,
-            len(self.items),
-            {
-                str_attr: getattr(self, str_attr)
-                for str_attr in self._str_attrs
-            }
+        result = "{}(n_items: {}, {})".format(
+            self.__class__.__name__, len(self.items), {str_attr: getattr(self, str_attr) for str_attr in self._str_attrs}
         )
         return result
 
 
 class ProcessQueue(deque):
     """Make a deque iterable and mutable"""
+
     def __iter__(self):
         while True:
             try:
@@ -166,6 +164,7 @@ class ProcessListQueue:
     init : [ProcessList[,...]] or None
         List of ProcessLists to put on the queue.
     """
+
     def __init__(self, init=None):
         self._queue = {}
         if init is not None:
@@ -207,7 +206,7 @@ class ProcessListQueue:
                 break
 
     def __str__(self):
-        result = f'{self.__class__.__name__}: rulesets {len(self)} items {len(list(self.items()))}'
+        result = f"{self.__class__.__name__}: rulesets {len(self)} items {len(list(self.items()))}"
         return result
 
 
@@ -222,11 +221,9 @@ class ProcessQueueSorted:
     init : [ProcessList[,...]]
         List of `ProcessList` to start the queue with.
     """
+
     def __init__(self, init=None):
-        self.queues = {
-            list_category: ProcessListQueue()
-            for list_category in ListCategory
-        }
+        self.queues = {list_category: ProcessListQueue() for list_category in ListCategory}
 
         if init is not None:
             self.extend(init)
@@ -251,9 +248,9 @@ class ProcessQueueSorted:
         return reduce(lambda x, y: x + len(y), self.queues.values(), 0)
 
     def __str__(self):
-        result = f'{self.__class__.__name__}:'
+        result = f"{self.__class__.__name__}:"
         for queue in self.queues:
-            result += f'\n\tQueue {queue}: {self.queues[queue]}'
+            result += f"\n\tQueue {queue}: {self.queues[queue]}"
         return result
 
 

--- a/romancal/associations/lib/product_utils.py
+++ b/romancal/associations/lib/product_utils.py
@@ -1,9 +1,9 @@
 """ Utilities for product manipulation."""
 
-from collections import defaultdict, Counter
 import copy
 import logging
 import warnings
+from collections import Counter, defaultdict
 
 from .. import config
 from .diff import compare_product_membership

--- a/romancal/associations/lib/product_utils.py
+++ b/romancal/associations/lib/product_utils.py
@@ -121,9 +121,14 @@ def prune_duplicate_products(asns):
 
     warnings.warn(f"Duplicate associations exist: {dups}", RuntimeWarning)
     if config.DEBUG:
-        warnings.warn('Duplicate associations will have "dupXXX" prepended to their names, where "XXX" is a 3-digit sequence.')
+        warnings.warn(
+            'Duplicate associations will have "dupXXX" prepended to their names, where'
+            ' "XXX" is a 3-digit sequence.'
+        )
     else:
-        warnings.warn("Duplicates will be removed, leaving only one of each.", RuntimeWarning)
+        warnings.warn(
+            "Duplicates will be removed, leaving only one of each.", RuntimeWarning
+        )
 
     pruned = copy.copy(asns)
     to_prune = defaultdict(list)

--- a/romancal/associations/lib/product_utils.py
+++ b/romancal/associations/lib/product_utils.py
@@ -33,7 +33,7 @@ def sort_by_candidate(asns):
 
     If this changes, a comparison function will need be implemented
     """
-    return sorted(asns, key=lambda asn: asn['asn_id'])
+    return sorted(asns, key=lambda asn: asn["asn_id"])
 
 
 def get_product_names(asns):
@@ -48,20 +48,11 @@ def get_product_names(asns):
     product_names, duplicates : set(str[, ...]), [str[,...]]
         2-tuple consisting of the set of product names and the list of duplicates.
     """
-    product_names = [
-        asn['products'][0]['name']
-        for asn in asns
-    ]
+    product_names = [asn["products"][0]["name"] for asn in asns]
 
-    dups = [
-        name
-        for name, count in Counter(product_names).items()
-        if count > 1
-    ]
+    dups = [name for name, count in Counter(product_names).items() if count > 1]
     if dups:
-        logger.debug(
-            'Duplicate product names: %s', dups
-        )
+        logger.debug("Duplicate product names: %s", dups)
 
     return set(product_names), dups
 
@@ -98,7 +89,7 @@ def prune_duplicate_associations(asns):
         to_prune = list()
         for asn in ordered_asns:
             try:
-                compare_product_membership(original['products'][0], asn['products'][0])
+                compare_product_membership(original["products"][0], asn["products"][0])
             except AssertionError:
                 continue
             to_prune.append(asn)
@@ -128,16 +119,16 @@ def prune_duplicate_products(asns):
     if not dups:
         return asns
 
-    warnings.warn(f'Duplicate associations exist: {dups}', RuntimeWarning)
+    warnings.warn(f"Duplicate associations exist: {dups}", RuntimeWarning)
     if config.DEBUG:
         warnings.warn('Duplicate associations will have "dupXXX" prepended to their names, where "XXX" is a 3-digit sequence.')
     else:
-        warnings.warn('Duplicates will be removed, leaving only one of each.', RuntimeWarning)
+        warnings.warn("Duplicates will be removed, leaving only one of each.", RuntimeWarning)
 
     pruned = copy.copy(asns)
     to_prune = defaultdict(list)
     for asn in asns:
-        product_name = asn['products'][0]['name']
+        product_name = asn["products"][0]["name"]
         if product_name in dups:
             to_prune[product_name].append(asn)
 
@@ -147,7 +138,7 @@ def prune_duplicate_products(asns):
         for asn in asns_to_prune[1:]:
             if config.DEBUG:
                 dup_count += 1
-                asn.asn_name = f'dup{dup_count:03d}_{asn.asn_name}'
+                asn.asn_name = f"dup{dup_count:03d}_{asn.asn_name}"
             else:
                 pruned.remove(asn)
 

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -22,7 +22,10 @@ from romancal.associations.lib.dms_base import (
 )
 from romancal.associations.lib.keyvalue_registry import KeyValueRegistryError
 from romancal.associations.lib.member import Member
-from romancal.associations.lib.product_utils import prune_duplicate_associations, prune_duplicate_products
+from romancal.associations.lib.product_utils import (
+    prune_duplicate_associations,
+    prune_duplicate_products,
+)
 from romancal.associations.lib.utilities import evaluate, is_iterable
 from romancal.associations.registry import RegistryMarker
 
@@ -94,7 +97,10 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         # Initialize validity checks
         self.validity.update(
             {
-                "has_science": {"validated": True, "check": lambda member: member["exptype"] == "science"},
+                "has_science": {
+                    "validated": True,
+                    "check": lambda member: member["exptype"] == "science",
+                },
             }
         )
 
@@ -122,7 +128,9 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         except KeyError:
             result = []
         else:
-            result = [member for member in members if member_type == member["exptype"].lower()]
+            result = [
+                member for member in members if member_type == member["exptype"].lower()
+            ]
 
         return result
 
@@ -244,9 +252,14 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
             # Pool
             if self.data["asn_pool"] == "none":
                 self.data["asn_pool"] = basename(item.meta["pool_file"])
-                parsed_name = re.search(_DMS_POOLNAME_REGEX, self.data["asn_pool"].split(".")[0])
+                parsed_name = re.search(
+                    _DMS_POOLNAME_REGEX, self.data["asn_pool"].split(".")[0]
+                )
                 if parsed_name is not None:
-                    pool_meta = {"program_id": parsed_name.group(1), "version": parsed_name.group(2)}
+                    pool_meta = {
+                        "program_id": parsed_name.group(1),
+                        "version": parsed_name.group(2),
+                    }
                     self.meta["pool_meta"] = pool_meta
 
         # Product-based updates
@@ -275,7 +288,9 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         exptype = self.get_exposure_type(item)
 
         # Determine expected member name
-        expname = Utility.rename_to_level2(item["filename"], exp_type=item["exp_type"], member_exptype=exptype)
+        expname = Utility.rename_to_level2(
+            item["filename"], exp_type=item["exp_type"], member_exptype=exptype
+        )
 
         member = Member(
             {
@@ -316,7 +331,9 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         members = self.current_product["members"]
         members.append(member)
         if member["exposerr"] not in _EMPTY:
-            logger.warning(f"Member {item['filename']} has exposure error \"{member['exposerr']}\"")
+            logger.warning(
+                f"Member {item['filename']} has exposure error \"{member['exposerr']}\""
+            )
 
         # Update meta info
         self.update_asn(item=item, member=member)
@@ -373,12 +390,16 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
 
     def __str__(self):
         result_list = []
-        result_list.append(f"{self.asn_name} with {len(self.data['products'])} products")
+        result_list.append(
+            f"{self.asn_name} with {len(self.data['products'])} products"
+        )
         result_list.append(f"Rule={self.data['asn_rule']}")
         result_list.append(self.data["constraints"])
         result_list.append("Products:")
         for product in self.data["products"]:
-            result_list.append(f"\t{product['name']} with {len(product['members'])} members")
+            result_list.append(
+                f"\t{product['name']} with {len(product['members'])} members"
+            )
         result = "\n".join(result_list)
         return result
 
@@ -425,7 +446,12 @@ class Utility:
         """
         match = re.match(_LEVEL1B_REGEX, level1b_name)
         if match is None or match.group("type") != "_uncal":
-            logger.warning(('Item FILENAME="{}" is not a Level 1b name. Cannot transform to Level 2b.').format(level1b_name))
+            logger.warning(
+                (
+                    'Item FILENAME="{}" is not a Level 1b name. Cannot transform to'
+                    " Level 2b."
+                ).format(level1b_name)
+            )
             return level1b_name
 
         if member_exptype == "background":
@@ -439,7 +465,9 @@ class Utility:
         # if is_tso:
         #    suffix += 'ints'
 
-        level2_name = "".join([match.group("path"), "_", suffix, match.group("extension")])
+        level2_name = "".join(
+            [match.group("path"), "_", suffix, match.group("extension")]
+        )
         return level2_name
 
     @staticmethod
@@ -503,7 +531,9 @@ class Utility:
 # Utilities
 # ---------
 # Define default product name filling
-format_product = FormatTemplate(key_formats={"source_id": ["s{:05d}", "s{:s}"], "expspcin": ["{:0>2s}"]})
+format_product = FormatTemplate(
+    key_formats={"source_id": ["s{:05d}", "s{:s}"], "expspcin": ["{:0>2s}"]}
+)
 
 
 def dms_product_name_noopt(asn):
@@ -646,7 +676,11 @@ class Constraint_Image_Science(DMSAttrConstraint):
     """Select on science images"""
 
     def __init__(self):
-        super().__init__(name="exp_type", sources=["exp_type"], value="|".join(IMAGE2_SCIENCE_EXP_TYPES))
+        super().__init__(
+            name="exp_type",
+            sources=["exp_type"],
+            value="|".join(IMAGE2_SCIENCE_EXP_TYPES),
+        )
 
 
 class Constraint_Single_Science(SimpleConstraint):
@@ -670,14 +704,24 @@ class Constraint_Single_Science(SimpleConstraint):
     """
 
     def __init__(self, has_science_fn, **sc_kwargs):
-        super().__init__(name="single_science", value=False, sources=lambda item: has_science_fn(), **sc_kwargs)
+        super().__init__(
+            name="single_science",
+            value=False,
+            sources=lambda item: has_science_fn(),
+            **sc_kwargs,
+        )
 
 
 class Constraint_Spectral(DMSAttrConstraint):
     """Constrain on spectral exposure types"""
 
     def __init__(self):
-        super().__init__(name="exp_type", sources=["exp_type"], value="wfi_grism|wfi_prism", force_unique=False)
+        super().__init__(
+            name="exp_type",
+            sources=["exp_type"],
+            value="wfi_grism|wfi_prism",
+            force_unique=False,
+        )
 
 
 class Constraint_Spectral_Science(Constraint):
@@ -693,10 +737,19 @@ class Constraint_Spectral_Science(Constraint):
         if exclude_exp_types is None:
             general_science = SPEC2_SCIENCE_EXP_TYPES
         else:
-            general_science = set(SPEC2_SCIENCE_EXP_TYPES).symmetric_difference(exclude_exp_types)
+            general_science = set(SPEC2_SCIENCE_EXP_TYPES).symmetric_difference(
+                exclude_exp_types
+            )
 
         super().__init__(
-            [DMSAttrConstraint(name="exp_type", sources=["exp_type"], value="|".join(general_science))], reduce=Constraint.any
+            [
+                DMSAttrConstraint(
+                    name="exp_type",
+                    sources=["exp_type"],
+                    value="|".join(general_science),
+                )
+            ],
+            reduce=Constraint.any,
         )
 
 
@@ -766,7 +819,9 @@ class AsnMixin_Science(DMS_ELPP_Base):
                 DMSAttrConstraint(
                     name="acq_obsnum",
                     sources=["obs_num"],
-                    value=lambda: "(" + "|".join(self.constraints["obs_num"].found_values) + ")",
+                    value=lambda: "("
+                    + "|".join(self.constraints["obs_num"].found_values)
+                    + ")",
                     force_unique=False,
                 )
             ],
@@ -780,7 +835,12 @@ class AsnMixin_Science(DMS_ELPP_Base):
                 Constraint_Base(),
                 DMSAttrConstraint(sources=["is_imprt"], force_undefined=True),
                 Constraint(
-                    [Constraint([self.constraints, Constraint_Obsnum()], name="rule"), constraint_acqs],
+                    [
+                        Constraint(
+                            [self.constraints, Constraint_Obsnum()], name="rule"
+                        ),
+                        constraint_acqs,
+                    ],
                     name="acq_check",
                     reduce=Constraint.any,
                 ),

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -239,7 +239,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
 
             # Program
             if self.data["program"] == "noprogram":
-                self.data["program"] = "{:0>5s}".format(item["program"])
+                self.data["program"] = f"{item['program']:0>5s}"
 
             # Pool
             if self.data["asn_pool"] == "none":
@@ -316,7 +316,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         members = self.current_product["members"]
         members.append(member)
         if member["exposerr"] not in _EMPTY:
-            logger.warning('Member {} has exposure error "{}"'.format(item["filename"], member["exposerr"]))
+            logger.warning(f"Member {item['filename']} has exposure error \"{member['exposerr']}\"")
 
         # Update meta info
         self.update_asn(item=item, member=member)
@@ -373,12 +373,12 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
 
     def __str__(self):
         result_list = []
-        result_list.append("{} with {} products".format(self.asn_name, len(self.data["products"])))
-        result_list.append("Rule={}".format(self.data["asn_rule"]))
+        result_list.append(f"{self.asn_name} with {len(self.data['products'])} products")
+        result_list.append(f"Rule={self.data['asn_rule']}")
         result_list.append(self.data["constraints"])
         result_list.append("Products:")
         for product in self.data["products"]:
-            result_list.append("\t{} with {} members".format(product["name"], len(product["members"])))
+            result_list.append(f"\t{product['name']} with {len(product['members'])} members")
         result = "\n".join(result_list)
         return result
 
@@ -524,7 +524,7 @@ def dms_product_name_noopt(asn):
 
     instrument = asn._get_instrument()
 
-    product_name = "r{}-{}_{}_{}".format(asn.data["program"], asn.acid.id, target, instrument)
+    product_name = f"r{asn.data['program']}-{asn.acid.id}_{target}_{instrument}"
     return product_name.lower()
 
 

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -1,43 +1,29 @@
 """Base classes which define the ELPP Associations"""
 
-from collections import defaultdict
 import logging
-from os.path import (
-    basename
-    )
 import re
+from collections import defaultdict
+from os.path import basename
 
-from romancal.associations import (
-    Association,
-    ProcessList,
-    libpath
-)
-from romancal.associations.registry import RegistryMarker
-from romancal.associations.lib.utilities import (
-    evaluate,
-    is_iterable
-)
-from romancal.associations.exceptions import (
-    AssociationNotValidError,
-)
+from stpipe.format_template import FormatTemplate
+
+from romancal.associations import Association, ProcessList, libpath
+from romancal.associations.exceptions import AssociationNotValidError
 from romancal.associations.lib.acid import ACID
-from romancal.associations.lib.constraint import (
-    Constraint,
-    SimpleConstraint,
-)
+from romancal.associations.lib.constraint import Constraint, SimpleConstraint
 from romancal.associations.lib.counter import Counter
 from romancal.associations.lib.dms_base import (
     _EMPTY,
+    IMAGE2_NONSCIENCE_EXP_TYPES,
+    IMAGE2_SCIENCE_EXP_TYPES,
+    SPEC2_SCIENCE_EXP_TYPES,
     DMSAttrConstraint,
     DMSBaseMixin,
-    IMAGE2_SCIENCE_EXP_TYPES,
-    IMAGE2_NONSCIENCE_EXP_TYPES,
-    SPEC2_SCIENCE_EXP_TYPES,
 )
-from stpipe.format_template import FormatTemplate
 from romancal.associations.lib.member import Member
-from romancal.associations.lib.product_utils import (
-     prune_duplicate_associations, prune_duplicate_products)
+from romancal.associations.lib.product_utils import prune_duplicate_associations, prune_duplicate_products
+from romancal.associations.lib.utilities import evaluate, is_iterable
+from romancal.associations.registry import RegistryMarker
 
 __all__ = [
     'ASN_SCHEMA',

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -20,6 +20,7 @@ from romancal.associations.lib.dms_base import (
     DMSAttrConstraint,
     DMSBaseMixin,
 )
+from romancal.associations.lib.keyvalue_registry import KeyValueRegistryError
 from romancal.associations.lib.member import Member
 from romancal.associations.lib.product_utils import prune_duplicate_associations, prune_duplicate_products
 from romancal.associations.lib.utilities import evaluate, is_iterable

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -26,42 +26,42 @@ from romancal.associations.lib.utilities import evaluate, is_iterable
 from romancal.associations.registry import RegistryMarker
 
 __all__ = [
-    'ASN_SCHEMA',
-    'AsnMixin_AuxData',
-    'AsnMixin_Science',
-    'AsnMixin_Spectrum',
-    'AsnMixin_Lv2Image',
-    'Constraint',
-    'Constraint_Base',
-    'Constraint_Expos',
-    'Constraint_Image',
-    'Constraint_Obsnum',
-    'Constraint_Optical_Path',
-    'Constraint_Spectral',
-    'Constraint_Tile',
-    'Constraint_Image_Science',
-    'Constraint_Single_Science',
-    'Constraint_Spectral_Science',
-    'Constraint_Target',
-    'DMS_ELPP_Base',
-    'DMSAttrConstraint',
-    'ProcessList',
-    'SimpleConstraint',
-    'Utility',
+    "ASN_SCHEMA",
+    "AsnMixin_AuxData",
+    "AsnMixin_Science",
+    "AsnMixin_Spectrum",
+    "AsnMixin_Lv2Image",
+    "Constraint",
+    "Constraint_Base",
+    "Constraint_Expos",
+    "Constraint_Image",
+    "Constraint_Obsnum",
+    "Constraint_Optical_Path",
+    "Constraint_Spectral",
+    "Constraint_Tile",
+    "Constraint_Image_Science",
+    "Constraint_Single_Science",
+    "Constraint_Spectral_Science",
+    "Constraint_Target",
+    "DMS_ELPP_Base",
+    "DMSAttrConstraint",
+    "ProcessList",
+    "SimpleConstraint",
+    "Utility",
 ]
 # Configure logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # The schema that these associations must adhere to.
-ASN_SCHEMA = RegistryMarker.schema(libpath('asn_schema_jw_level3.json'))
+ASN_SCHEMA = RegistryMarker.schema(libpath("asn_schema_jw_level3.json"))
 
 # DMS file name templates
-_LEVEL1B_REGEX = r'(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
-_DMS_POOLNAME_REGEX = r'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
+_LEVEL1B_REGEX = r"(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)"
+_DMS_POOLNAME_REGEX = r"jw(\d{5})_(\d{8}[Tt]\d{6})_pool"
 
 # Product name regex's
-_REGEX_ACID_VALUE = r'(o\d{3}|(c|a)\d{4})'
+_REGEX_ACID_VALUE = r"(o\d{3}|(c|a)\d{4})"
 
 # Exposures that should have received Level2b processing
 LEVEL2B_EXPTYPES = []
@@ -70,7 +70,7 @@ LEVEL2B_EXPTYPES.extend(IMAGE2_NONSCIENCE_EXP_TYPES)
 LEVEL2B_EXPTYPES.extend(SPEC2_SCIENCE_EXP_TYPES)
 
 # Association Candidates that should never make Level3 associations
-INVALID_AC_TYPES = ['background']
+INVALID_AC_TYPES = ["background"]
 
 
 class DMS_ELPP_Base(DMSBaseMixin, Association):
@@ -91,42 +91,37 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         super().__init__(*args, **kwargs)
 
         # Initialize validity checks
-        self.validity.update({
-            'has_science': {
-                'validated': True,
-                'check': lambda member: member['exptype'] == 'science'
-            },
-        })
+        self.validity.update(
+            {
+                "has_science": {"validated": True, "check": lambda member: member["exptype"] == "science"},
+            }
+        )
 
         # Other presumptions on the association
-        if 'constraints' not in self.data:
-            self.data['constraints'] = 'No constraints'
-        if 'asn_type' not in self.data:
-            self.data['asn_type'] = 'user_built'
-        if 'asn_id' not in self.data:
-            self.data['asn_id'] = 'a3001'
-        if 'target' not in self.data:
-            self.data['target'] = 'none'
-        if 'asn_pool' not in self.data:
-            self.data['asn_pool'] = 'none'
+        if "constraints" not in self.data:
+            self.data["constraints"] = "No constraints"
+        if "asn_type" not in self.data:
+            self.data["asn_type"] = "user_built"
+        if "asn_id" not in self.data:
+            self.data["asn_id"] = "a3001"
+        if "target" not in self.data:
+            self.data["target"] = "none"
+        if "asn_pool" not in self.data:
+            self.data["asn_pool"] = "none"
 
     @property
     def current_product(self):
-        return self.data['products'][-1]
+        return self.data["products"][-1]
 
     def members_by_type(self, member_type):
         """Get list of members by their exposure type"""
         member_type = member_type.lower()
         try:
-            members = self.current_product['members']
+            members = self.current_product["members"]
         except KeyError:
             result = []
         else:
-            result = [
-                member
-                for member in members
-                if member_type == member['exptype'].lower()
-            ]
+            result = [member for member in members if member_type == member["exptype"].lower()]
 
         return result
 
@@ -137,13 +132,13 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         bool
             True if it does.
         """
-        limit_reached = len(self.members_by_type('science')) >= 1
+        limit_reached = len(self.members_by_type("science")) >= 1
         return limit_reached
 
     def __eq__(self, other):
         """Compare equality of two associations"""
         if isinstance(other, DMS_ELPP_Base):
-            result = self.data['asn_type'] == other.data['asn_type']
+            result = self.data["asn_type"] == other.data["asn_type"]
             result = result and (self.member_ids == other.member_ids)
             return result
 
@@ -189,26 +184,21 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
 
         exposure = association._get_exposure()
         if exposure:
-            exposure = '-' + exposure
+            exposure = "-" + exposure
 
         subarray = association._get_subarray()
         if subarray:
-            subarray = '-' + subarray
+            subarray = "-" + subarray
 
-        product_name = (
-            'r{program}-{acid}'
-            '_{target}'
-            '_{instrument}'
-            '_{opt_elem}{subarray}'
-        )
+        product_name = "r{program}-{acid}_{target}_{instrument}_{opt_elem}{subarray}"
         product_name = product_name.format(
-            program=association.data['program'],
+            program=association.data["program"],
             acid=association.acid.id,
             target=target,
             instrument=instrument,
             opt_elem=opt_elem,
             subarray=subarray,
-            exposure=exposure
+            exposure=exposure,
         )
 
         return product_name.lower()
@@ -235,39 +225,32 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         super().update_asn(item=item, member=member)
 
         # Constraints
-        self.data['constraints'] = str(self.constraints)
+        self.data["constraints"] = str(self.constraints)
 
         # ID
-        self.data['asn_id'] = self.acid.id
+        self.data["asn_id"] = self.acid.id
 
         # Target
-        self.data['target'] = self._get_target()
+        self.data["target"] = self._get_target()
 
         # Item-based information
         if item is not None:
 
             # Program
-            if self.data['program'] == 'noprogram':
-                self.data['program'] = '{:0>5s}'.format(item['program'])
+            if self.data["program"] == "noprogram":
+                self.data["program"] = "{:0>5s}".format(item["program"])
 
             # Pool
-            if self.data['asn_pool'] == 'none':
-                self.data['asn_pool'] = basename(
-                    item.meta['pool_file']
-                )
-                parsed_name = re.search(
-                    _DMS_POOLNAME_REGEX, self.data['asn_pool'].split('.')[0]
-                )
+            if self.data["asn_pool"] == "none":
+                self.data["asn_pool"] = basename(item.meta["pool_file"])
+                parsed_name = re.search(_DMS_POOLNAME_REGEX, self.data["asn_pool"].split(".")[0])
                 if parsed_name is not None:
-                    pool_meta = {
-                        'program_id': parsed_name.group(1),
-                        'version': parsed_name.group(2)
-                    }
-                    self.meta['pool_meta'] = pool_meta
+                    pool_meta = {"program_id": parsed_name.group(1), "version": parsed_name.group(2)}
+                    self.meta["pool_meta"] = pool_meta
 
         # Product-based updates
         product = self.current_product
-        product['name'] = self.dms_product_name
+        product["name"] = self.dms_product_name
 
     def make_member(self, item):
         """Create a member from the item
@@ -283,7 +266,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
             The member
         """
         try:
-            exposerr = item['exposerr']
+            exposerr = item["exposerr"]
         except KeyError:
             exposerr = None
 
@@ -291,20 +274,16 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         exptype = self.get_exposure_type(item)
 
         # Determine expected member name
-        expname = Utility.rename_to_level2(
-            item['filename'], exp_type=item['exp_type'],
-            member_exptype=exptype
-        )
+        expname = Utility.rename_to_level2(item["filename"], exp_type=item["exp_type"], member_exptype=exptype)
 
         member = Member(
             {
-                'expname': expname,
-                'exptype': exptype,
-                'asn_candidate':item['asn_candidate'],
-                'exposerr': exposerr,
-
+                "expname": expname,
+                "exptype": exptype,
+                "asn_candidate": item["asn_candidate"],
+                "exposerr": exposerr,
             },
-            item=item
+            item=item,
         )
         return member
 
@@ -313,7 +292,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         super()._init_hook(item)
 
         # Set which sequence counter should be used.
-        self._sequence = self._sequences[self.data['asn_type']]
+        self._sequence = self._sequences[self.data["asn_type"]]
 
         # Create the product.
         self.new_product()
@@ -333,23 +312,16 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
             return
 
         self.update_validity(member)
-        members = self.current_product['members']
+        members = self.current_product["members"]
         members.append(member)
-        if member['exposerr'] not in _EMPTY:
-            logger.warning('Member {} has exposure error "{}"'.format(
-                item['filename'],
-                member['exposerr']
-            ))
+        if member["exposerr"] not in _EMPTY:
+            logger.warning('Member {} has exposure error "{}"'.format(item["filename"], member["exposerr"]))
 
         # Update meta info
         self.update_asn(item=item, member=member)
 
-    def _add_items(self,
-                   items,
-                   product_name=None,
-                   with_exptype=False,
-                   **kwargs):
-        """ Force adding items to the association
+    def _add_items(self, items, product_name=None, with_exptype=False, **kwargs):
+        """Force adding items to the association
 
         Parameters
         ----------
@@ -377,60 +349,41 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         by-passed, resulting in a potentially unusable association.
         """
         if product_name is None:
-            raise AssociationNotValidError(
-                'Product name needs to be specified'
-            )
+            raise AssociationNotValidError("Product name needs to be specified")
 
         self.new_product(product_name)
-        members = self.current_product['members']
+        members = self.current_product["members"]
         for item in items:
-            exptype = 'science'
+            exptype = "science"
             if with_exptype:
                 item, exptype = item
-            member = Member(
-                {
-                    'expname': item,
-                    'exptype': exptype
-                },
-                item=item
-            )
+            member = Member({"expname": item, "exptype": exptype}, item=item)
             self.update_validity(member)
             members.append(member)
         self.sequence = next(self._sequence)
 
     def __repr__(self):
-# flake8:  noqa: F821
+        # flake8:  noqa: F821
         try:
-            file_name, json_repr = self.ioregistry['json'].dump(self)
+            file_name, json_repr = self.ioregistry["json"].dump(self)
         except KeyValueRegistryError:
             return str(self.__class__)
         return json_repr
 
     def __str__(self):
         result_list = []
-        result_list.append(
-            '{} with {} products'.format(
-                self.asn_name,
-                len(self.data['products'])
-            )
-        )
-        result_list.append(
-            'Rule={}'.format(self.data['asn_rule'])
-        )
-        result_list.append(self.data['constraints'])
-        result_list.append('Products:')
-        for product in self.data['products']:
-            result_list.append(
-                '\t{} with {} members'.format(
-                    product['name'],
-                    len(product['members'])
-                )
-            )
-        result = '\n'.join(result_list)
+        result_list.append("{} with {} products".format(self.asn_name, len(self.data["products"])))
+        result_list.append("Rule={}".format(self.data["asn_rule"]))
+        result_list.append(self.data["constraints"])
+        result_list.append("Products:")
+        for product in self.data["products"]:
+            result_list.append("\t{} with {} members".format(product["name"], len(product["members"])))
+        result = "\n".join(result_list)
         return result
 
+
 @RegistryMarker.utility
-class Utility():
+class Utility:
     """Utility functions that understand DMS Level 3 associations"""
 
     @staticmethod
@@ -438,12 +391,10 @@ class Utility():
         """Resequence the numbering for the ELPP association types"""
         counters = defaultdict(lambda: defaultdict(Counter))
         for asn in associations:
-            asn.sequence = next(
-                counters[asn.data['asn_id']][asn.data['asn_type']]
-            )
+            asn.sequence = next(counters[asn.data["asn_id"]][asn.data["asn_type"]])
 
     @staticmethod
-    def rename_to_level2(level1b_name, exp_type=None, member_exptype='science'):
+    def rename_to_level2(level1b_name, exp_type=None, member_exptype="science"):
         """Rename a Level 1b Exposure to a Level2 name.
 
         The basic transform is changing the suffix `uncal` to
@@ -472,32 +423,22 @@ class Utility():
             The Level 2b name
         """
         match = re.match(_LEVEL1B_REGEX, level1b_name)
-        if match is None or match.group('type') != '_uncal':
-            logger.warning((
-                'Item FILENAME="{}" is not a Level 1b name. '
-                'Cannot transform to Level 2b.'
-            ).format(
-                level1b_name
-            ))
+        if match is None or match.group("type") != "_uncal":
+            logger.warning(('Item FILENAME="{}" is not a Level 1b name. Cannot transform to Level 2b.').format(level1b_name))
             return level1b_name
 
-        if member_exptype == 'background':
-            suffix = 'x1d'
+        if member_exptype == "background":
+            suffix = "x1d"
         else:
             if exp_type in LEVEL2B_EXPTYPES:
-                suffix = 'cal'
+                suffix = "cal"
             else:
-                suffix = 'rate'
+                suffix = "rate"
 
-        #if is_tso:
+        # if is_tso:
         #    suffix += 'ints'
 
-        level2_name = ''.join([
-            match.group('path'),
-            '_',
-            suffix,
-            match.group('extension')
-        ])
+        level2_name = "".join([match.group("path"), "_", suffix, match.group("extension")])
         return level2_name
 
     @staticmethod
@@ -519,14 +460,11 @@ class Utility():
         result = []
         evaled = evaluate(value)
         if is_iterable(evaled):
-            result = [
-                ACID(v)
-                for v in evaled
-            ]
+            result = [ACID(v) for v in evaled]
         return result
 
     @staticmethod
-    @RegistryMarker.callback('finalize')
+    @RegistryMarker.callback("finalize")
     def finalize(associations):
         """Check validity and duplications in an association list
 
@@ -564,13 +502,7 @@ class Utility():
 # Utilities
 # ---------
 # Define default product name filling
-format_product = FormatTemplate(
-    key_formats={
-        'source_id': ['s{:05d}', 's{:s}'],
-        'expspcin': ['{:0>2s}']
-
-    }
-)
+format_product = FormatTemplate(key_formats={"source_id": ["s{:05d}", "s{:s}"], "expspcin": ["{:0>2s}"]})
 
 
 def dms_product_name_noopt(asn):
@@ -591,12 +523,7 @@ def dms_product_name_noopt(asn):
 
     instrument = asn._get_instrument()
 
-    product_name = 'r{}-{}_{}_{}'.format(
-        asn.data['program'],
-        asn.acid.id,
-        target,
-        instrument
-    )
+    product_name = "r{}-{}_{}_{}".format(asn.data["program"], asn.acid.id, target, instrument)
     return product_name.lower()
 
 
@@ -618,15 +545,10 @@ def dms_product_name_sources(asn):
 
     opt_elem = asn._get_opt_element()
 
-    product_name_format = (
-        'r{program}-{acid}'
-        '_{source_id}'
-        '_{instrument}'
-        '_{opt_elem}'
-    )
+    product_name_format = "r{program}-{acid}_{source_id}_{instrument}_{opt_elem}"
     product_name = format_product(
         product_name_format,
-        program=asn.data['program'],
+        program=asn.data["program"],
         acid=asn.acid.id,
         instrument=instrument,
         opt_elem=opt_elem,
@@ -640,63 +562,65 @@ def dms_product_name_sources(asn):
 # -----------------
 class Constraint_Base(Constraint):
     """Select on program and instrument"""
+
     def __init__(self):
         super().__init__(
             [
                 DMSAttrConstraint(
-                    name='program',
-                    sources=['program'],
+                    name="program",
+                    sources=["program"],
                 ),
                 DMSAttrConstraint(
-                    name='instrument',
-                    sources=['instrume'],
+                    name="instrument",
+                    sources=["instrume"],
                 ),
             ],
-            name='base'
+            name="base",
         )
 
 
 class Constraint_Expos(DMSAttrConstraint):
     """Select on exposure number"""
+
     def __init__(self):
         super().__init__(
-            name='exposure_number',
-            sources=['nexpsur'],
-            #force_unique=True,
-            #required=True,
+            name="exposure_number",
+            sources=["nexpsur"],
+            # force_unique=True,
+            # required=True,
         )
 
 
 class Constraint_Tile(DMSAttrConstraint):
     """Select on exposure number"""
+
     def __init__(self):
         super().__init__(
-            name='tile',
-            sources=['tile'],
-            #force_unique=True,
-            #required=True,
+            name="tile",
+            sources=["tile"],
+            # force_unique=True,
+            # required=True,
         )
 
 
 class Constraint_Image(DMSAttrConstraint):
     """Select on exposure type"""
+
     def __init__(self):
         super().__init__(
-            name='exp_type',
-            sources=['exp_type'],
-            value=(
-                'wfi_image'
-                '|wfi_wfsc'
-            ),
+            name="exp_type",
+            sources=["exp_type"],
+            value="wfi_image|wfi_wfsc",
         )
 
 
 class Constraint_Obsnum(DMSAttrConstraint):
     """Select on OBSNUM"""
+
     def __init__(self):
         super().__init__(
-            name='obs_num',
-            sources=['obs_num'],
+            name="obs_num",
+            sources=["obs_num"],
             force_unique=False,
             required=False,
         )
@@ -704,23 +628,24 @@ class Constraint_Obsnum(DMSAttrConstraint):
 
 class Constraint_Optical_Path(Constraint):
     """Select on optical path"""
+
     def __init__(self):
-        super().__init__([
-            DMSAttrConstraint(
-                name='opt_elem',
-                sources=['opt_elem'],
-                required=False,
-            )
-        ])
+        super().__init__(
+            [
+                DMSAttrConstraint(
+                    name="opt_elem",
+                    sources=["opt_elem"],
+                    required=False,
+                )
+            ]
+        )
+
 
 class Constraint_Image_Science(DMSAttrConstraint):
     """Select on science images"""
+
     def __init__(self):
-        super().__init__(
-            name='exp_type',
-            sources=['exp_type'],
-            value='|'.join(IMAGE2_SCIENCE_EXP_TYPES)
-        )
+        super().__init__(name="exp_type", sources=["exp_type"], value="|".join(IMAGE2_SCIENCE_EXP_TYPES))
 
 
 class Constraint_Single_Science(SimpleConstraint):
@@ -744,26 +669,14 @@ class Constraint_Single_Science(SimpleConstraint):
     """
 
     def __init__(self, has_science_fn, **sc_kwargs):
-        super().__init__(
-            name='single_science',
-            value=False,
-            sources=lambda item: has_science_fn(),
-            **sc_kwargs
-        )
+        super().__init__(name="single_science", value=False, sources=lambda item: has_science_fn(), **sc_kwargs)
 
 
 class Constraint_Spectral(DMSAttrConstraint):
     """Constrain on spectral exposure types"""
+
     def __init__(self):
-        super().__init__(
-            name='exp_type',
-            sources=['exp_type'],
-            value=(
-                'wfi_grism'
-                '|wfi_prism'
-            ),
-            force_unique=False
-        )
+        super().__init__(name="exp_type", sources=["exp_type"], value="wfi_grism|wfi_prism", force_unique=False)
 
 
 class Constraint_Spectral_Science(Constraint):
@@ -779,19 +692,10 @@ class Constraint_Spectral_Science(Constraint):
         if exclude_exp_types is None:
             general_science = SPEC2_SCIENCE_EXP_TYPES
         else:
-            general_science = set(SPEC2_SCIENCE_EXP_TYPES).symmetric_difference(
-                exclude_exp_types
-            )
+            general_science = set(SPEC2_SCIENCE_EXP_TYPES).symmetric_difference(exclude_exp_types)
 
         super().__init__(
-            [
-                DMSAttrConstraint(
-                    name='exp_type',
-                    sources=['exp_type'],
-                    value='|'.join(general_science)
-                )
-            ],
-            reduce=Constraint.any
+            [DMSAttrConstraint(name="exp_type", sources=["exp_type"], value="|".join(general_science))], reduce=Constraint.any
         )
 
 
@@ -804,17 +708,18 @@ class Constraint_Target(DMSAttrConstraint):
         If specified, use the `get_exposure_type` method
         to as part of the target selection.
     """
+
     def __init__(self, association=None):
         if association is None:
             super().__init__(
-                name='target',
-                sources=['targname'],
+                name="target",
+                sources=["targname"],
             )
         else:
             super().__init__(
-                name='target',
-                sources=['targname'],
-                onlyif=lambda item: association.get_exposure_type(item) != 'background',
+                name="target",
+                sources=["targname"],
+                onlyif=lambda item: association.get_exposure_type(item) != "background",
                 force_reprocess=ProcessList.EXISTING,
                 only_on_match=True,
             )
@@ -824,9 +729,9 @@ class Constraint_Target(DMSAttrConstraint):
 # Base Mixins
 # -----------
 class AsnMixin_AuxData:
-    """Process special and non-science exposures as science.
-    """
-    def get_exposure_type(self, item, default='science'):
+    """Process special and non-science exposures as science."""
+
+    def get_exposure_type(self, item, default="science"):
         """Override to force exposure type to always be science
         Parameters
         ----------
@@ -842,11 +747,11 @@ class AsnMixin_AuxData:
         exposure_type : 'target_acquisition'
             Returns target_acquisition for mir_tacq
         """
-        NEVER_CHANGE = ['target_acquisition']
+        NEVER_CHANGE = ["target_acquisition"]
         exp_type = super().get_exposure_type(item, default=default)
         if exp_type in NEVER_CHANGE:
             return exp_type
-        return 'science'
+        return "science"
 
 
 class AsnMixin_Science(DMS_ELPP_Base):
@@ -858,42 +763,28 @@ class AsnMixin_Science(DMS_ELPP_Base):
         constraint_acqs = Constraint(
             [
                 DMSAttrConstraint(
-                    name='acq_obsnum',
-                    sources=['obs_num'],
-                    value=lambda: '('
-                    + '|'.join(self.constraints['obs_num'].found_values)
-                    + ')',
+                    name="acq_obsnum",
+                    sources=["obs_num"],
+                    value=lambda: "(" + "|".join(self.constraints["obs_num"].found_values) + ")",
                     force_unique=False,
                 )
             ],
-            name='acq_constraint',
-            work_over=ProcessList.EXISTING
+            name="acq_constraint",
+            work_over=ProcessList.EXISTING,
         )
 
         # Put all constraints together.
         self.constraints = Constraint(
             [
                 Constraint_Base(),
-                DMSAttrConstraint(
-                    sources=['is_imprt'],
-                    force_undefined=True
-                ),
+                DMSAttrConstraint(sources=["is_imprt"], force_undefined=True),
                 Constraint(
-                    [
-                        Constraint(
-                            [
-                                self.constraints,
-                                Constraint_Obsnum()
-                            ],
-                            name='rule'
-                        ),
-                        constraint_acqs
-                    ],
-                    name='acq_check',
-                    reduce=Constraint.any
+                    [Constraint([self.constraints, Constraint_Obsnum()], name="rule"), constraint_acqs],
+                    name="acq_check",
+                    reduce=Constraint.any,
                 ),
             ],
-            name='dmsbase_top'
+            name="dmsbase_top",
         )
 
         super().__init__(*args, **kwargs)
@@ -905,8 +796,9 @@ class AsnMixin_Spectrum(AsnMixin_Science):
     def _init_hook(self, item):
         """Post-check and pre-add initialization"""
 
-        self.data['asn_type'] = 'spec3'
+        self.data["asn_type"] = "spec3"
         super()._init_hook(item)
+
 
 # ---------------------------------------------
 # Mixins to define the broad category of rules.
@@ -918,4 +810,4 @@ class AsnMixin_Lv2Image:
         """Post-check and pre-add initialization"""
 
         super()._init_hook(item)
-        self.data['asn_type'] = 'image2'
+        self.data["asn_type"] = "image2"

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -2,9 +2,9 @@
 """
 import logging
 
-from romancal.associations.registry import RegistryMarker
 from romancal.associations.lib.constraint import Constraint
 from romancal.associations.lib.rules_elpp_base import *
+from romancal.associations.registry import RegistryMarker
 
 __all__ = [
     'Asn_Lv2Image',

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -32,7 +32,14 @@ class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
     def __init__(self, *args, **kwargs):
 
         # Setup constraints
-        self.constraints = Constraint([Constraint_Base(), Constraint_Target(), Constraint_Expos(), Constraint_Tile()])
+        self.constraints = Constraint(
+            [
+                Constraint_Base(),
+                Constraint_Target(),
+                Constraint_Expos(),
+                Constraint_Tile(),
+            ]
+        )
 
         # Now check and continue initialization.
         super().__init__(*args, **kwargs)

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -6,10 +6,7 @@ from romancal.associations.lib.constraint import Constraint
 from romancal.associations.lib.rules_elpp_base import *
 from romancal.associations.registry import RegistryMarker
 
-__all__ = [
-    'Asn_Lv2Image',
-    'AsnMixin_Lv2Image'
-]
+__all__ = ["Asn_Lv2Image", "AsnMixin_Lv2Image"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -21,10 +18,7 @@ logger.addHandler(logging.NullHandler())
 # Start of the User-level rules
 # --------------------------------
 @RegistryMarker.rule
-class Asn_Lv2Image(
-        AsnMixin_Lv2Image,
-        DMS_ELPP_Base
-):
+class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
     """Level2b Non-TSO Science Image Association
 
     Characteristics:
@@ -38,28 +32,21 @@ class Asn_Lv2Image(
     def __init__(self, *args, **kwargs):
 
         # Setup constraints
-        self.constraints = Constraint([
-            Constraint_Base(),
-            Constraint_Target(),
-            Constraint_Expos(),
-            Constraint_Tile()
-        ])
+        self.constraints = Constraint([Constraint_Base(), Constraint_Target(), Constraint_Expos(), Constraint_Tile()])
 
         # Now check and continue initialization.
         super().__init__(*args, **kwargs)
 
-
-
-    def get_exposure_type(self, item, default='science'):
+    def get_exposure_type(self, item, default="science"):
         """Modify exposure type depending on dither pointing index
 
         Behaves as the superclass method. However, if the constraint
         `is_current_patt_num` is True, mark the exposure type as
         `background`.
         """
-        exp_type = item['exp_type']
+        exp_type = item["exp_type"]
 
-        if exp_type == 'wfi_image':
-            exp_type == 'science'
+        if exp_type == "wfi_image":
+            exp_type == "science"
 
         return exp_type

--- a/romancal/associations/lib/tests/test_asn_from_list_lib.py
+++ b/romancal/associations/lib/tests/test_asn_from_list_lib.py
@@ -2,9 +2,10 @@
 
 import pytest
 
-from romancal.associations import (Association, load_asn)
+from romancal.associations import Association, load_asn
 from romancal.associations.asn_from_list import asn_from_list
 from romancal.associations.exceptions import AssociationNotValidError
+
 
 def test_base_association():
     """Create the simplest of associations"""

--- a/romancal/associations/lib/tests/test_asn_from_list_lib.py
+++ b/romancal/associations/lib/tests/test_asn_from_list_lib.py
@@ -47,7 +47,11 @@ def test_default_with_type():
     """ELPP association with types specified"""
     product_name = "test_product"
     items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
-    asn = asn_from_list([(item, type_) for item, type_ in items.items()], product_name=product_name, with_exptype=True)
+    asn = asn_from_list(
+        [(item, type_) for item, type_ in items.items()],
+        product_name=product_name,
+        with_exptype=True,
+    )
     assert asn["asn_rule"] == "DMS_ELPP_Base"
     assert asn["asn_type"] == "None"
     assert len(asn["products"]) == 1

--- a/romancal/associations/lib/tests/test_asn_from_list_lib.py
+++ b/romancal/associations/lib/tests/test_asn_from_list_lib.py
@@ -9,67 +9,61 @@ from romancal.associations.exceptions import AssociationNotValidError
 
 def test_base_association():
     """Create the simplest of associations"""
-    items = ['a', 'b', 'c']
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, rule=Association)
-    assert asn['asn_rule'] == 'Association'
-    assert asn['asn_type'] == 'None'
-    assert asn['members'] == items
+    assert asn["asn_rule"] == "Association"
+    assert asn["asn_type"] == "None"
+    assert asn["members"] == items
 
 
 def test_base_roundtrip():
     """Write/read created base association"""
-    items = ['a', 'b', 'c']
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, rule=Association)
     _, serialized = asn.dump()
     reloaded = load_asn(serialized, registry=None)
-    assert asn['asn_rule'] == reloaded['asn_rule']
-    assert asn['asn_type'] == reloaded['asn_type']
-    assert asn['members'] == reloaded['members']
+    assert asn["asn_rule"] == reloaded["asn_rule"]
+    assert asn["asn_type"] == reloaded["asn_type"]
+    assert asn["members"] == reloaded["members"]
+
 
 def test_default_simple():
     """Default Level3 association"""
-    product_name = 'test_product'
-    items = ['a', 'b', 'c']
+    product_name = "test_product"
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, product_name=product_name)
-    assert asn['asn_rule'] == 'DMS_ELPP_Base'
-    assert asn['asn_type'] == 'None'
-    assert len(asn['products']) == 1
-    product = asn['products'][0]
-    assert product['name'] == product_name
-    assert len(product['members']) == len(items)
-    for member in product['members']:
-        assert member['expname'] in items
-        assert member['exptype'] == 'science'
+    assert asn["asn_rule"] == "DMS_ELPP_Base"
+    assert asn["asn_type"] == "None"
+    assert len(asn["products"]) == 1
+    product = asn["products"][0]
+    assert product["name"] == product_name
+    assert len(product["members"]) == len(items)
+    for member in product["members"]:
+        assert member["expname"] in items
+        assert member["exptype"] == "science"
 
 
 def test_default_with_type():
     """ELPP association with types specified"""
-    product_name = 'test_product'
-    items = {
-        'a': 'science',
-        'b': 'target_acq',
-        'c': 'somethingelse'
-    }
-    asn = asn_from_list(
-        [(item, type_) for item, type_ in items.items()],
-        product_name=product_name,
-        with_exptype=True
-    )
-    assert asn['asn_rule'] == 'DMS_ELPP_Base'
-    assert asn['asn_type'] == 'None'
-    assert len(asn['products']) == 1
-    product = asn['products'][0]
-    assert product['name'] == product_name
-    assert len(product['members']) == len(items)
-    for member in product['members']:
-        assert member['expname'] in items
-        assert member['exptype'] == items[member['expname']]
+    product_name = "test_product"
+    items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
+    asn = asn_from_list([(item, type_) for item, type_ in items.items()], product_name=product_name, with_exptype=True)
+    assert asn["asn_rule"] == "DMS_ELPP_Base"
+    assert asn["asn_type"] == "None"
+    assert len(asn["products"]) == 1
+    product = asn["products"][0]
+    assert product["name"] == product_name
+    assert len(product["members"]) == len(items)
+    for member in product["members"]:
+        assert member["expname"] in items
+        assert member["exptype"] == items[member["expname"]]
+
 
 def test_default_fail():
     """Test default DMS_ELPP_Base fail
 
     A product name needs to be included, but is not.
     """
-    items = ['a']
+    items = ["a"]
     with pytest.raises(AssociationNotValidError):
         _ = asn_from_list(items)

--- a/romancal/associations/lib/utilities.py
+++ b/romancal/associations/lib/utilities.py
@@ -21,18 +21,18 @@ def return_on_exception(exceptions=(Exception,), default=None):
     default: obj
         The value to return when a specified exception occurs
     """
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
             except exceptions as err:
-                logger.debug(
-                    'Caught exception %s in function %s, forcing return value of %s',
-                    err, func, default
-                )
+                logger.debug("Caught exception %s in function %s, forcing return value of %s", err, func, default)
                 return default
+
         return wrapper
+
     return decorator
 
 
@@ -99,7 +99,7 @@ def getattr_from_list(adict, attributes, invalid_values=None):
             else:
                 continue
     else:
-        raise KeyError(f'Object has no attributes in {attributes}')
+        raise KeyError(f"Object has no attributes in {attributes}")
 
 
 @return_on_exception(exceptions=(KeyError,), default=None)
@@ -118,6 +118,4 @@ def getattr_from_list_nofail(*args, **kwargs):
 
 def is_iterable(obj):
     """General iterator check"""
-    return not isinstance(obj, str) and \
-        not isinstance(obj, tuple) and \
-        hasattr(obj, '__iter__')
+    return not isinstance(obj, str) and not isinstance(obj, tuple) and hasattr(obj, "__iter__")

--- a/romancal/associations/lib/utilities.py
+++ b/romancal/associations/lib/utilities.py
@@ -28,7 +28,12 @@ def return_on_exception(exceptions=(Exception,), default=None):
             try:
                 return func(*args, **kwargs)
             except exceptions as err:
-                logger.debug("Caught exception %s in function %s, forcing return value of %s", err, func, default)
+                logger.debug(
+                    "Caught exception %s in function %s, forcing return value of %s",
+                    err,
+                    func,
+                    default,
+                )
                 return default
 
         return wrapper
@@ -118,4 +123,8 @@ def getattr_from_list_nofail(*args, **kwargs):
 
 def is_iterable(obj):
     """General iterator check"""
-    return not isinstance(obj, str) and not isinstance(obj, tuple) and hasattr(obj, "__iter__")
+    return (
+        not isinstance(obj, str)
+        and not isinstance(obj, tuple)
+        and hasattr(obj, "__iter__")
+    )

--- a/romancal/associations/lib/utilities.py
+++ b/romancal/associations/lib/utilities.py
@@ -1,7 +1,7 @@
 """General Utilities"""
+import logging
 from ast import literal_eval
 from functools import wraps
-import logging
 
 from numpy.ma import masked
 

--- a/romancal/associations/load_asn.py
+++ b/romancal/associations/load_asn.py
@@ -1,7 +1,8 @@
 """Load an Association from a file or object"""
 from inspect import isclass
 
-from . import Association, AssociationRegistry
+from .association import Association
+from .registry import AssociationRegistry
 
 
 def load_asn(

--- a/romancal/associations/load_asn.py
+++ b/romancal/associations/load_asn.py
@@ -1,10 +1,7 @@
 """Load an Association from a file or object"""
 from inspect import isclass
 
-from . import (
-    Association,
-    AssociationRegistry
-)
+from . import Association, AssociationRegistry
 
 
 def load_asn(

--- a/romancal/associations/load_asn.py
+++ b/romancal/associations/load_asn.py
@@ -5,7 +5,14 @@ from .association import Association
 from .registry import AssociationRegistry
 
 
-def load_asn(serialized, format=None, first=True, validate=True, registry=AssociationRegistry, **kwargs):
+def load_asn(
+    serialized,
+    format=None,
+    first=True,
+    validate=True,
+    registry=AssociationRegistry,
+    **kwargs
+):
     """Load an Association from a file or object
 
     Parameters
@@ -56,4 +63,6 @@ def load_asn(serialized, format=None, first=True, validate=True, registry=Associ
 
     if isclass(registry):
         registry = registry()
-    return registry.load(serialized, format=format, first=first, validate=validate, **kwargs)
+    return registry.load(
+        serialized, format=format, first=first, validate=validate, **kwargs
+    )

--- a/romancal/associations/load_asn.py
+++ b/romancal/associations/load_asn.py
@@ -5,14 +5,7 @@ from .association import Association
 from .registry import AssociationRegistry
 
 
-def load_asn(
-        serialized,
-        format=None,
-        first=True,
-        validate=True,
-        registry=AssociationRegistry,
-        **kwargs
-):
+def load_asn(serialized, format=None, first=True, validate=True, registry=AssociationRegistry, **kwargs):
     """Load an Association from a file or object
 
     Parameters
@@ -63,10 +56,4 @@ def load_asn(
 
     if isclass(registry):
         registry = registry()
-    return registry.load(
-        serialized,
-        format=format,
-        first=first,
-        validate=validate,
-        **kwargs
-    )
+    return registry.load(serialized, format=format, first=first, validate=validate, **kwargs)

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -15,17 +15,17 @@ from .lib.log_config import DMS_config, log_config
 from .pool import AssociationPool
 from .registry import AssociationRegistry
 
-__all__ = ['Main']
+__all__ = ["Main"]
 
 # Configure logging
 logger = log_config(name=__package__)
 
 # Ruleset names
-DISCOVER_RULESET = 'discover'
-CANDIDATE_RULESET = 'candidate'
+DISCOVER_RULESET = "discover"
+CANDIDATE_RULESET = "candidate"
 
 
-class Main():
+class Main:
     """
     Generate Associations from an Association Pool
 
@@ -64,118 +64,100 @@ class Main():
         if args is None:
             args = sys.argv[1:]
         if isinstance(args, str):
-            args = args.split(' ')
+            args = args.split(" ")
 
-        parser = argparse.ArgumentParser(
-            description='Generate Assocation Data Products',
-            usage='asn_generate pool'
-        )
+        parser = argparse.ArgumentParser(description="Generate Assocation Data Products", usage="asn_generate pool")
         if pool is None:
-            parser.add_argument(
-                'pool', type=str, help='Association Pool'
-            )
+            parser.add_argument("pool", type=str, help="Association Pool")
         op_group = parser.add_mutually_exclusive_group()
         op_group.add_argument(
-            '-i', '--ids', nargs='+',
-            dest='asn_candidate_ids',
-            help='space-separated list of association candidate IDs to operate on.'
+            "-i",
+            "--ids",
+            nargs="+",
+            dest="asn_candidate_ids",
+            help="space-separated list of association candidate IDs to operate on.",
         )
+        op_group.add_argument("--discover", action="store_true", help="Produce discovered associations")
         op_group.add_argument(
-            '--discover',
-            action='store_true',
-            help='Produce discovered associations'
-        )
-        op_group.add_argument(
-            '--all-candidates',
-            action='store_true', dest='all_candidates',
-            help='Produce all association candidate-specific associations'
+            "--all-candidates",
+            action="store_true",
+            dest="all_candidates",
+            help="Produce all association candidate-specific associations",
         )
         parser.add_argument(
-            '-p', '--path', type=str,
-            default='.',
-            help='Folder to save the associations to. Default: "%(default)s"'
+            "-p", "--path", type=str, default=".", help='Folder to save the associations to. Default: "%(default)s"'
         )
         parser.add_argument(
-            '--save-orphans', dest='save_orphans',
-            nargs='?', const='orphaned.csv', default=False,
-            help='Save orphaned items into the specified table. Default: "%(default)s"'
+            "--save-orphans",
+            dest="save_orphans",
+            nargs="?",
+            const="orphaned.csv",
+            default=False,
+            help='Save orphaned items into the specified table. Default: "%(default)s"',
         )
         parser.add_argument(
-            '--version-id', dest='version_id',
-            nargs='?', const=True, default=None,
+            "--version-id",
+            dest="version_id",
+            nargs="?",
+            const=True,
+            default=None,
             help=(
-                'Version tag to add into association name and products.'
-                ' If not specified, no version will be used.'
-                ' If specified without a value, the current time is used.'
-                ' Otherwise, the specified string will be used.'
-            )
+                "Version tag to add into association name and products."
+                " If not specified, no version will be used."
+                " If specified without a value, the current time is used."
+                " Otherwise, the specified string will be used."
+            ),
         )
+        parser.add_argument("-r", "--rules", action="append", help="Association Rules file.")
         parser.add_argument(
-            '-r', '--rules', action='append',
-            help='Association Rules file.'
+            "--ignore-default", action="store_true", help="Do not include default rules. -r should be used if set."
         )
+        parser.add_argument("--dry-run", action="store_true", dest="dry_run", help="Execute but do not save results.")
         parser.add_argument(
-            '--ignore-default', action='store_true',
-            help='Do not include default rules. -r should be used if set.'
-        )
-        parser.add_argument(
-            '--dry-run',
-            action='store_true', dest='dry_run',
-            help='Execute but do not save results.'
-        )
-        parser.add_argument(
-            '-d', '--delimiter', type=str,
-            default='|',
-            help='''Delimiter
+            "-d",
+            "--delimiter",
+            type=str,
+            default="|",
+            help="""Delimiter
             to use if pool files are comma-separated-value
             (csv) type files. Default: "%(default)s"
-            '''
+            """,
         )
         parser.add_argument(
-            '--pool-format', type=str,
-            default='ascii',
+            "--pool-format",
+            type=str,
+            default="ascii",
             help=(
-                'Format of the pool file.'
-                ' Any format allowed by the astropy'
-                ' Unified File I/O interface is allowed.'
+                "Format of the pool file."
+                " Any format allowed by the astropy"
+                " Unified File I/O interface is allowed."
                 ' Default: "%(default)s"'
-            )
+            ),
         )
         parser.add_argument(
-            '-v', '--verbose',
-            action='store_const', dest='loglevel',
-            const=logging.INFO, default=logging.NOTSET,
-            help='Output progress and results.'
+            "-v",
+            "--verbose",
+            action="store_const",
+            dest="loglevel",
+            const=logging.INFO,
+            default=logging.NOTSET,
+            help="Output progress and results.",
         )
         parser.add_argument(
-            '-D', '--debug',
-            action='store_const', dest='loglevel',
+            "-D",
+            "--debug",
+            action="store_const",
+            dest="loglevel",
             const=logging.DEBUG,
-            help='Output detailed debugging information.'
+            help="Output detailed debugging information.",
         )
+        parser.add_argument("--DMS", action="store_true", dest="DMS_enabled", help="Running under DMS workflow conditions.")
+        parser.add_argument("--format", default="json", help='Format of the association files. Default: "%(default)s"')
+        parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}", help="Version of the generator.")
         parser.add_argument(
-            '--DMS',
-            action='store_true', dest='DMS_enabled',
-            help='Running under DMS workflow conditions.'
+            "--merge", action="store_true", help="Merge associations into single associations with multiple products"
         )
-        parser.add_argument(
-            '--format',
-            default='json',
-            help='Format of the association files. Default: "%(default)s"'
-        )
-        parser.add_argument(
-            '--version', action='version',
-            version=f'%(prog)s {__version__}',
-            help='Version of the generator.'
-        )
-        parser.add_argument(
-            '--merge', action='store_true',
-            help='Merge associations into single associations with multiple products'
-        )
-        parser.add_argument(
-            '--no-merge', action=DeprecateNoMerge,
-            help='Deprecated: Default is to not merge. See "--merge".'
-        )
+        parser.add_argument("--no-merge", action=DeprecateNoMerge, help='Deprecated: Default is to not merge. See "--merge".')
 
         parsed = parser.parse_args(args=args)
 
@@ -188,13 +170,14 @@ class Main():
         config.DEBUG = (parsed.loglevel != 0) and (parsed.loglevel <= logging.DEBUG)
 
         # Preamble
-        logger.info(f'Command-line arguments:  {args}')
-        logger.context.set('asn_candidate_ids', parsed.asn_candidate_ids)
+        logger.info(f"Command-line arguments:  {args}")
+        logger.context.set("asn_candidate_ids", parsed.asn_candidate_ids)
 
         if pool is None:
-            logger.info(f'Reading pool {parsed.pool}')
+            logger.info(f"Reading pool {parsed.pool}")
             self.pool = AssociationPool.read(
-                parsed.pool, delimiter=parsed.delimiter,
+                parsed.pool,
+                delimiter=parsed.delimiter,
                 format=parsed.pool_format,
             )
         else:
@@ -202,7 +185,7 @@ class Main():
 
         # DMS: Add further info to logging.
         try:
-            logger.context.set('program', self.pool[0]['program'])
+            logger.context.set("program", self.pool[0]["program"])
         except KeyError:
             pass
 
@@ -211,43 +194,25 @@ class Main():
         #  2) Only discovered associations that do not match
         #     candidate associations
         #  3) Both discovered and all candidate associations.
-        logger.info('Reading rules.')
-        if not parsed.discover and\
-           not parsed.all_candidates and\
-           parsed.asn_candidate_ids is None:
+        logger.info("Reading rules.")
+        if not parsed.discover and not parsed.all_candidates and parsed.asn_candidate_ids is None:
             parsed.discover = True
             parsed.all_candidates = True
         if parsed.discover or parsed.all_candidates:
-            global_constraints = constrain_on_candidates(
-                None
-            )
+            global_constraints = constrain_on_candidates(None)
         elif parsed.asn_candidate_ids is not None:
-            global_constraints = constrain_on_candidates(
-                parsed.asn_candidate_ids
-            )
+            global_constraints = constrain_on_candidates(parsed.asn_candidate_ids)
         self.rules = AssociationRegistry(
-            parsed.rules,
-            include_default=not parsed.ignore_default,
-            global_constraints=global_constraints,
-            name=CANDIDATE_RULESET
+            parsed.rules, include_default=not parsed.ignore_default, global_constraints=global_constraints, name=CANDIDATE_RULESET
         )
 
         if parsed.discover:
-            self.rules.update(
-                AssociationRegistry(
-                    parsed.rules,
-                    include_default=not parsed.ignore_default,
-                    name=DISCOVER_RULESET
-                )
-            )
+            self.rules.update(AssociationRegistry(parsed.rules, include_default=not parsed.ignore_default, name=DISCOVER_RULESET))
 
-        logger.info('Generating associations.')
-        self.associations = generate(
-            self.pool, self.rules, version_id=parsed.version_id
-        )
+        logger.info("Generating associations.")
+        self.associations = generate(self.pool, self.rules, version_id=parsed.version_id)
         if parsed.discover:
-            logger.debug(f'# asns found before discover filtering={len(self.associations)}'
-                         )
+            logger.debug(f"# asns found before discover filtering={len(self.associations)}")
 
             self.associations = filter_discovered_only(
                 self.associations,
@@ -268,11 +233,7 @@ class Main():
         logger.debug(self.__str__())
 
         if not parsed.dry_run:
-            self.save(
-                path=parsed.path,
-                format=parsed.format,
-                save_orphans=parsed.save_orphans
-            )
+            self.save(path=parsed.path, format=parsed.format, save_orphans=parsed.save_orphans)
 
     @property
     def orphaned(self):
@@ -291,17 +252,17 @@ class Main():
 
     def __str__(self):
         result = []
-        result.append((
-            'There where {:d} associations '
-            'and {:d} orphaned items found.\n'
-            'Associations found are:'
-        ).format(len(self.associations), len(self.orphaned)))
+        result.append(
+            ("There where {:d} associations and {:d} orphaned items found.\nAssociations found are:").format(
+                len(self.associations), len(self.orphaned)
+            )
+        )
         for assocs in self.associations:
             result.append(assocs.__str__())
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
-    def save(self, path='.', format='json', save_orphans=False):
+    def save(self, path=".", format="json", save_orphans=False):
         """Save the associations to disk.
 
         Parameters
@@ -317,15 +278,11 @@ class Main():
         """
         for asn in self.associations:
             (fname, serialized) = asn.dump(format=format)
-            with open(os.path.join(path, fname), 'w') as f:
+            with open(os.path.join(path, fname), "w") as f:
                 f.write(serialized)
 
         if save_orphans:
-            self.orphaned.write(
-                os.path.join(path, save_orphans),
-                format='ascii',
-                delimiter='|'
-            )
+            self.orphaned.write(os.path.join(path, save_orphans), format="ascii", delimiter="|")
 
 
 # #########
@@ -333,13 +290,12 @@ class Main():
 # #########
 class DeprecateNoMerge(argparse.Action):
     """Deprecate the `--no-merge` option"""
+
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         super().__init__(option_strings, dest, const=True, nargs=0, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        logger.warning(
-            'The "--no-merge" option is now the default and deprecated.'
-            ' Use "--merge" to force merging.')
+        logger.warning('The "--no-merge" option is now the default and deprecated. Use "--merge" to force merging.')
         setattr(namespace, self.dest, values)
 
 
@@ -353,15 +309,13 @@ def constrain_on_candidates(candidates):
         If None, then all candidates are matched.
     """
     if candidates is not None and len(candidates):
-        c_list = '|'.join(candidates)
-        values = ''.join([
-            '.+(', c_list, ').+'
-        ])
+        c_list = "|".join(candidates)
+        values = "".join([".+(", c_list, ").+"])
     else:
         values = None
     constraint = DMSAttrConstraint(
-        name='asn_candidate',
-        sources=['asn_candidate'],
+        name="asn_candidate",
+        sources=["asn_candidate"],
         value=values,
         force_unique=True,
         is_acid=True,
@@ -372,10 +326,10 @@ def constrain_on_candidates(candidates):
 
 
 def filter_discovered_only(
-        associations,
-        discover_ruleset,
-        candidate_ruleset,
-        keep_candidates=True,
+    associations,
+    discover_ruleset,
+    candidate_ruleset,
+    keep_candidates=True,
 ):
     """Return only those associations that have multiple candidates
 
@@ -406,10 +360,7 @@ def filter_discovered_only(
     and then Association.load will not return proper results.
     """
     # Split the associations along discovered/not discovered lines
-    asn_by_ruleset = {
-        candidate_ruleset: [],
-        discover_ruleset: []
-    }
+    asn_by_ruleset = {candidate_ruleset: [], discover_ruleset: []}
     for asn in associations:
         asn_by_ruleset[asn.registry.name].append(asn)
     candidate_list = asn_by_ruleset[candidate_ruleset]
@@ -433,5 +384,5 @@ def filter_discovered_only(
     return discover_list
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     Main()

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -66,7 +66,9 @@ class Main:
         if isinstance(args, str):
             args = args.split(" ")
 
-        parser = argparse.ArgumentParser(description="Generate Assocation Data Products", usage="asn_generate pool")
+        parser = argparse.ArgumentParser(
+            description="Generate Assocation Data Products", usage="asn_generate pool"
+        )
         if pool is None:
             parser.add_argument("pool", type=str, help="Association Pool")
         op_group = parser.add_mutually_exclusive_group()
@@ -77,7 +79,9 @@ class Main:
             dest="asn_candidate_ids",
             help="space-separated list of association candidate IDs to operate on.",
         )
-        op_group.add_argument("--discover", action="store_true", help="Produce discovered associations")
+        op_group.add_argument(
+            "--discover", action="store_true", help="Produce discovered associations"
+        )
         op_group.add_argument(
             "--all-candidates",
             action="store_true",
@@ -85,7 +89,11 @@ class Main:
             help="Produce all association candidate-specific associations",
         )
         parser.add_argument(
-            "-p", "--path", type=str, default=".", help='Folder to save the associations to. Default: "%(default)s"'
+            "-p",
+            "--path",
+            type=str,
+            default=".",
+            help='Folder to save the associations to. Default: "%(default)s"',
         )
         parser.add_argument(
             "--save-orphans",
@@ -108,11 +116,20 @@ class Main:
                 " Otherwise, the specified string will be used."
             ),
         )
-        parser.add_argument("-r", "--rules", action="append", help="Association Rules file.")
         parser.add_argument(
-            "--ignore-default", action="store_true", help="Do not include default rules. -r should be used if set."
+            "-r", "--rules", action="append", help="Association Rules file."
         )
-        parser.add_argument("--dry-run", action="store_true", dest="dry_run", help="Execute but do not save results.")
+        parser.add_argument(
+            "--ignore-default",
+            action="store_true",
+            help="Do not include default rules. -r should be used if set.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Execute but do not save results.",
+        )
         parser.add_argument(
             "-d",
             "--delimiter",
@@ -151,13 +168,33 @@ class Main:
             const=logging.DEBUG,
             help="Output detailed debugging information.",
         )
-        parser.add_argument("--DMS", action="store_true", dest="DMS_enabled", help="Running under DMS workflow conditions.")
-        parser.add_argument("--format", default="json", help='Format of the association files. Default: "%(default)s"')
-        parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}", help="Version of the generator.")
         parser.add_argument(
-            "--merge", action="store_true", help="Merge associations into single associations with multiple products"
+            "--DMS",
+            action="store_true",
+            dest="DMS_enabled",
+            help="Running under DMS workflow conditions.",
         )
-        parser.add_argument("--no-merge", action=DeprecateNoMerge, help='Deprecated: Default is to not merge. See "--merge".')
+        parser.add_argument(
+            "--format",
+            default="json",
+            help='Format of the association files. Default: "%(default)s"',
+        )
+        parser.add_argument(
+            "--version",
+            action="version",
+            version=f"%(prog)s {__version__}",
+            help="Version of the generator.",
+        )
+        parser.add_argument(
+            "--merge",
+            action="store_true",
+            help="Merge associations into single associations with multiple products",
+        )
+        parser.add_argument(
+            "--no-merge",
+            action=DeprecateNoMerge,
+            help='Deprecated: Default is to not merge. See "--merge".',
+        )
 
         parsed = parser.parse_args(args=args)
 
@@ -195,7 +232,11 @@ class Main:
         #     candidate associations
         #  3) Both discovered and all candidate associations.
         logger.info("Reading rules.")
-        if not parsed.discover and not parsed.all_candidates and parsed.asn_candidate_ids is None:
+        if (
+            not parsed.discover
+            and not parsed.all_candidates
+            and parsed.asn_candidate_ids is None
+        ):
             parsed.discover = True
             parsed.all_candidates = True
         if parsed.discover or parsed.all_candidates:
@@ -203,16 +244,29 @@ class Main:
         elif parsed.asn_candidate_ids is not None:
             global_constraints = constrain_on_candidates(parsed.asn_candidate_ids)
         self.rules = AssociationRegistry(
-            parsed.rules, include_default=not parsed.ignore_default, global_constraints=global_constraints, name=CANDIDATE_RULESET
+            parsed.rules,
+            include_default=not parsed.ignore_default,
+            global_constraints=global_constraints,
+            name=CANDIDATE_RULESET,
         )
 
         if parsed.discover:
-            self.rules.update(AssociationRegistry(parsed.rules, include_default=not parsed.ignore_default, name=DISCOVER_RULESET))
+            self.rules.update(
+                AssociationRegistry(
+                    parsed.rules,
+                    include_default=not parsed.ignore_default,
+                    name=DISCOVER_RULESET,
+                )
+            )
 
         logger.info("Generating associations.")
-        self.associations = generate(self.pool, self.rules, version_id=parsed.version_id)
+        self.associations = generate(
+            self.pool, self.rules, version_id=parsed.version_id
+        )
         if parsed.discover:
-            logger.debug(f"# asns found before discover filtering={len(self.associations)}")
+            logger.debug(
+                f"# asns found before discover filtering={len(self.associations)}"
+            )
 
             self.associations = filter_discovered_only(
                 self.associations,
@@ -233,7 +287,9 @@ class Main:
         logger.debug(self.__str__())
 
         if not parsed.dry_run:
-            self.save(path=parsed.path, format=parsed.format, save_orphans=parsed.save_orphans)
+            self.save(
+                path=parsed.path, format=parsed.format, save_orphans=parsed.save_orphans
+            )
 
     @property
     def orphaned(self):
@@ -253,9 +309,10 @@ class Main:
     def __str__(self):
         result = []
         result.append(
-            ("There where {:d} associations and {:d} orphaned items found.\nAssociations found are:").format(
-                len(self.associations), len(self.orphaned)
-            )
+            (
+                "There where {:d} associations and {:d} orphaned items"
+                " found.\nAssociations found are:"
+            ).format(len(self.associations), len(self.orphaned))
         )
         for assocs in self.associations:
             result.append(assocs.__str__())
@@ -282,7 +339,9 @@ class Main:
                 f.write(serialized)
 
         if save_orphans:
-            self.orphaned.write(os.path.join(path, save_orphans), format="ascii", delimiter="|")
+            self.orphaned.write(
+                os.path.join(path, save_orphans), format="ascii", delimiter="|"
+            )
 
 
 # #########
@@ -295,7 +354,10 @@ class DeprecateNoMerge(argparse.Action):
         super().__init__(option_strings, dest, const=True, nargs=0, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        logger.warning('The "--no-merge" option is now the default and deprecated. Use "--merge" to force merging.')
+        logger.warning(
+            'The "--no-merge" option is now the default and deprecated. Use "--merge"'
+            " to force merging."
+        )
         setattr(namespace, self.dest, values)
 
 

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -1,20 +1,14 @@
 """Main entry for the association generator"""
-import os
-import sys
 import argparse
 import logging
+import os
+import sys
 
 import numpy as np
 
-from romancal.associations import (
-    __version__,
-    AssociationPool,
-    AssociationRegistry,
-    generate,
-)
-from romancal.associations import config
+from romancal.associations import AssociationPool, AssociationRegistry, __version__, config, generate
 from romancal.associations.lib.dms_base import DMSAttrConstraint
-from romancal.associations.lib.log_config import (log_config, DMS_config)
+from romancal.associations.lib.log_config import DMS_config, log_config
 
 __all__ = ['Main']
 

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -6,9 +6,14 @@ import sys
 
 import numpy as np
 
-from romancal.associations import AssociationPool, AssociationRegistry, __version__, config, generate
-from romancal.associations.lib.dms_base import DMSAttrConstraint
-from romancal.associations.lib.log_config import DMS_config, log_config
+from romancal import __version__
+
+from . import config
+from .generate import generate
+from .lib.dms_base import DMSAttrConstraint
+from .lib.log_config import DMS_config, log_config
+from .pool import AssociationPool
+from .registry import AssociationRegistry
 
 __all__ = ['Main']
 

--- a/romancal/associations/pool.py
+++ b/romancal/associations/pool.py
@@ -2,12 +2,11 @@
 Association Pools
 """
 
-from pkg_resources import parse_version, get_distribution
-
 from collections import UserDict
 
 from astropy.io.ascii import convert_numpy
 from astropy.table import Table
+from pkg_resources import get_distribution, parse_version
 
 __all__ = ['AssociationPool']
 

--- a/romancal/associations/pool.py
+++ b/romancal/associations/pool.py
@@ -8,10 +8,10 @@ from astropy.io.ascii import convert_numpy
 from astropy.table import Table
 from pkg_resources import get_distribution, parse_version
 
-__all__ = ['AssociationPool']
+__all__ = ["AssociationPool"]
 
-DEFAULT_DELIMITER = '|'
-DEFAULT_FORMAT = 'ascii'
+DEFAULT_DELIMITER = "|"
+DEFAULT_FORMAT = "ascii"
 
 
 class AssociationPool(Table):
@@ -23,18 +23,13 @@ class AssociationPool(Table):
     - ASCII tables with a default delimiter of `|`
     - All values are read in as strings
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.meta['pool_file'] = self.meta.get('pool_file', 'in-memory')
+        self.meta["pool_file"] = self.meta.get("pool_file", "in-memory")
 
     @classmethod
-    def read(
-            cls,
-            filename,
-            delimiter=DEFAULT_DELIMITER,
-            format=DEFAULT_FORMAT,
-            **kwargs
-    ):
+    def read(cls, filename, delimiter=DEFAULT_DELIMITER, format=DEFAULT_FORMAT, **kwargs):
         """Read in a Pool file
 
         Parameters
@@ -53,14 +48,10 @@ class AssociationPool(Table):
         AssociationPool
             The ``AssociationPool`` representation of the file.
         """
-        table = super().read(
-            filename, delimiter=delimiter,
-            format=format,
-            converters=convert_to_str, **kwargs
-        )
+        table = super().read(filename, delimiter=delimiter, format=format, converters=convert_to_str, **kwargs)
 
         # If anything has been masked, just fill
-        table = table.filled('null')
+        table = table.filled("null")
 
         # Lowercase the column names
         # Note: Cannot do in-place because modifying the
@@ -69,7 +60,7 @@ class AssociationPool(Table):
         for c in columns:
             c.name = c.name.lower()
 
-        table.meta['pool_file'] = filename
+        table.meta["pool_file"] = filename
         return table
 
     def write(self, *args, **kwargs):
@@ -91,20 +82,17 @@ class AssociationPool(Table):
         args, kwargs : obj
             Other parameters that ``astropy.io.ascii.write`` can accept.
         """
-        delimiter = kwargs.pop('delimiter', DEFAULT_DELIMITER)
-        format = kwargs.pop('format', DEFAULT_FORMAT)
+        delimiter = kwargs.pop("delimiter", DEFAULT_DELIMITER)
+        format = kwargs.pop("format", DEFAULT_FORMAT)
         try:
-            super().write(
-                *args, delimiter=delimiter, format=format, **kwargs
-            )
+            super().write(*args, delimiter=delimiter, format=format, **kwargs)
         except TypeError:
             # Most likely caused by the actual `write` called
             # does not handle `delimiter`. `jsviewer` is one
             # such format.
             # So, try again without a delimiter.
-            super().write(
-                *args, format=format, **kwargs
-            )
+            super().write(*args, format=format, **kwargs)
+
 
 class PoolRow(UserDict):
     """A row from an AssociationPool
@@ -112,6 +100,7 @@ class PoolRow(UserDict):
     Class to create a copy of an AssociationPool row without copying
     all of the astropy.Table.Row private attributes.
     """
+
     def __init__(self, init=None):
         dict_init = dict(init)
         super().__init__(dict_init)
@@ -141,7 +130,7 @@ class _ConvertToStr(dict):
         return self.__getitem__(k)
 
 
-if parse_version(get_distribution('astropy').version) >= parse_version('5.0.dev'):
-    convert_to_str = {'*': _convert_to_str()}
+if parse_version(get_distribution("astropy").version) >= parse_version("5.0.dev"):
+    convert_to_str = {"*": _convert_to_str()}
 else:
     convert_to_str = _ConvertToStr()

--- a/romancal/associations/pool.py
+++ b/romancal/associations/pool.py
@@ -29,7 +29,9 @@ class AssociationPool(Table):
         self.meta["pool_file"] = self.meta.get("pool_file", "in-memory")
 
     @classmethod
-    def read(cls, filename, delimiter=DEFAULT_DELIMITER, format=DEFAULT_FORMAT, **kwargs):
+    def read(
+        cls, filename, delimiter=DEFAULT_DELIMITER, format=DEFAULT_FORMAT, **kwargs
+    ):
         """Read in a Pool file
 
         Parameters
@@ -48,7 +50,13 @@ class AssociationPool(Table):
         AssociationPool
             The ``AssociationPool`` representation of the file.
         """
-        table = super().read(filename, delimiter=delimiter, format=format, converters=convert_to_str, **kwargs)
+        table = super().read(
+            filename,
+            delimiter=delimiter,
+            format=format,
+            converters=convert_to_str,
+            **kwargs
+        )
 
         # If anything has been masked, just fill
         table = table.filled("null")

--- a/romancal/associations/registry.py
+++ b/romancal/associations/registry.py
@@ -8,17 +8,14 @@ from . import libpath
 from .exceptions import AssociationError, AssociationNotValidError
 from .lib.callback_registry import CallbackRegistry
 
-__all__ = [
-    'AssociationRegistry',
-    'RegistryMarker'
-]
+__all__ = ["AssociationRegistry", "RegistryMarker"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # Library files
-_ASN_RULE = 'association_rules.py'
+_ASN_RULE = "association_rules.py"
 
 
 class AssociationRegistry(dict):
@@ -61,12 +58,7 @@ class AssociationRegistry(dict):
     existing associations. See :py:func:`~romancal.associations.generate` for more information.
     """
 
-    def __init__(self,
-                 definition_files=None,
-                 include_default=True,
-                 global_constraints=None,
-                 name=None,
-                 include_bases=False):
+    def __init__(self, definition_files=None, include_default=True, global_constraints=None, name=None, include_bases=False):
         super().__init__()
 
         # Generate a UUID for this instance. Used to modify rule
@@ -84,17 +76,13 @@ class AssociationRegistry(dict):
         if include_default:
             definition_files.insert(0, libpath(_ASN_RULE))
         if len(definition_files) <= 0:
-            raise AssociationError('No rule definition files specified.')
+            raise AssociationError("No rule definition files specified.")
 
         self.schemas = []
-        self.Utility = type('Utility', (object,), {})
+        self.Utility = type("Utility", (object,), {})
         for fname in definition_files:
             module = import_from_file(fname)
-            self.populate(
-                module,
-                global_constraints=global_constraints,
-                include_bases=include_bases
-            )
+            self.populate(module, global_constraints=global_constraints, include_bases=include_bases)
 
     @property
     def rule_set(self):
@@ -173,26 +161,13 @@ class AssociationRegistry(dict):
             else:
                 return True
 
-        results = [
-            rule
-            for rule_name, rule in self.items()
-            if is_valid(rule, association)
-        ]
+        results = [rule for rule_name, rule in self.items() if is_valid(rule, association)]
 
         if len(results) == 0:
-            raise AssociationNotValidError(
-                f'Structure did not validate: "{association}"'
-            )
+            raise AssociationNotValidError(f'Structure did not validate: "{association}"')
         return results
 
-    def load(
-            self,
-            serialized,
-            format=None,
-            validate=True,
-            first=True,
-            **kwargs
-    ):
+    def load(self, serialized, format=None, validate=True, first=True, **kwargs):
         """Load a previously serialized association
 
         Parameters
@@ -225,14 +200,7 @@ class AssociationRegistry(dict):
         results = []
         for rule_name, rule in self.items():
             try:
-                results.append(
-                    rule.load(
-                        serialized,
-                        format=format,
-                        validate=validate,
-                        **kwargs
-                    )
-                )
+                results.append(rule.load(serialized, format=format, validate=validate, **kwargs))
             except (AssociationError, AttributeError) as err:
                 lasterr = err
                 continue
@@ -245,11 +213,7 @@ class AssociationRegistry(dict):
         else:
             return results
 
-    def populate(self,
-                 module,
-                 global_constraints=None,
-                 include_bases=None
-    ):
+    def populate(self, module, global_constraints=None, include_bases=None):
         """Parse out all rules and callbacks in a module and add them to the registry
 
         Parameters
@@ -261,31 +225,27 @@ class AssociationRegistry(dict):
 
             # Add rules.
             # Add rules.
-            if (include_bases and isclass(obj)) or obj._asnreg_role == 'rule':
+            if (include_bases and isclass(obj)) or obj._asnreg_role == "rule":
                 try:
                     self.add_rule(name, obj, global_constraints=global_constraints)
                 except TypeError:
-                    logger.debug(f'Could not add object {obj} as a rule due to TypeError')
+                    logger.debug(f"Could not add object {obj} as a rule due to TypeError")
                 continue
 
             # Add callbacks
-            if obj._asnreg_role == 'callback':
+            if obj._asnreg_role == "callback":
                 for event in obj._asnreg_events:
                     self.callback.add(event, obj)
                     continue
 
             # Add schema
-            if obj._asnreg_role == 'schema':
+            if obj._asnreg_role == "schema":
                 self.schemas.append(obj._asnreg_schema)
                 continue
 
             # Add utility classes
-            if obj._asnreg_role == 'utility':
-                self.Utility = type(
-                    'Utility',
-                    (obj, self.Utility),
-                    {}
-                )
+            if obj._asnreg_role == "utility":
+                self.Utility = type("Utility", (obj, self.Utility), {})
 
     def add_rule(self, name, obj, global_constraints=None):
         """Add object as rule to registry
@@ -302,7 +262,7 @@ class AssociationRegistry(dict):
             The global constraints to attach to the rule.
         """
         try:
-            rule_name = '_'.join([self.name, name])
+            rule_name = "_".join([self.name, name])
         except TypeError:
             rule_name = name
         rule = type(rule_name, (obj,), {})
@@ -317,7 +277,7 @@ class RegistryMarker:
 
     class Schema:
         def __init__(self, obj):
-            self._asnreg_role = 'schema'
+            self._asnreg_role = "schema"
             self._asnreg_schema = obj
             RegistryMarker.mark(self)
 
@@ -353,7 +313,7 @@ class RegistryMarker:
 
         """
         obj._asnreg_marked = True
-        obj._asnreg_role = getattr(obj, '_asnreg_role', None)
+        obj._asnreg_role = getattr(obj, "_asnreg_role", None)
         return obj
 
     @staticmethod
@@ -380,7 +340,7 @@ class RegistryMarker:
         - _asnreg_mark : True
               Attributed added to object and set to True
         """
-        obj._asnreg_role = 'rule'
+        obj._asnreg_role = "rule"
         RegistryMarker.mark(obj)
         return obj
 
@@ -413,6 +373,7 @@ class RegistryMarker:
         - _asnreg_mark : True
               Indicated that the object has been marked.
         """
+
         def decorator(func):
             try:
                 events = func._asnreg_events
@@ -420,9 +381,10 @@ class RegistryMarker:
                 events = list()
             events.append(event)
             RegistryMarker.mark(func)
-            func._asnreg_role = 'callback'
+            func._asnreg_role = "callback"
             func._asnreg_events = events
             return func
+
         return decorator
 
     @staticmethod
@@ -434,14 +396,14 @@ class RegistryMarker:
     @staticmethod
     def utility(class_obj):
         """Mark the class as a Utility class"""
-        class_obj._asnreg_role = 'utility'
+        class_obj._asnreg_role = "utility"
         RegistryMarker.mark(class_obj)
         return class_obj
 
     @staticmethod
     def is_marked(obj):
         """Has an objected been marked?"""
-        return hasattr(obj, '_asnreg_marked')
+        return hasattr(obj, "_asnreg_marked")
 
 
 # Utilities
@@ -459,7 +421,7 @@ def import_from_file(filename):
         The imported module
     """
     path = expandvars(expanduser(filename))
-    module_name = basename(path).split('.')[0]
+    module_name = basename(path).split(".")[0]
     spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -487,10 +449,9 @@ def get_marked(module, predicate=None, include_bases=False):
     class object : generator
         A generator that will yield all class members in the module.
     """
+
     def is_method(obj):
-        return (isfunction(obj) or
-                ismethod(obj)
-        )
+        return isfunction(obj) or ismethod(obj)
 
     for name, obj in getmembers(module, predicate):
         if isclass(obj):
@@ -499,8 +460,6 @@ def get_marked(module, predicate=None, include_bases=False):
                 yield name, obj
         elif RegistryMarker.is_marked(obj):
             if ismodule(obj):
-                yield from get_marked(
-                        obj, predicate=predicate, include_bases=include_bases
-                )
+                yield from get_marked(obj, predicate=predicate, include_bases=include_bases)
             else:
                 yield name, obj

--- a/romancal/associations/registry.py
+++ b/romancal/associations/registry.py
@@ -1,24 +1,11 @@
 """Association Registry"""
 import importlib.util
-from inspect import (
-    getmembers,
-    isclass,
-    isfunction,
-    ismethod,
-    ismodule
-)
 import logging
-from os.path import (
-    basename,
-    expanduser,
-    expandvars,
-)
+from inspect import getmembers, isclass, isfunction, ismethod, ismodule
+from os.path import basename, expanduser, expandvars
 
 from . import libpath
-from .exceptions import (
-    AssociationError,
-    AssociationNotValidError
-)
+from .exceptions import AssociationError, AssociationNotValidError
 from .lib.callback_registry import CallbackRegistry
 
 __all__ = [

--- a/romancal/associations/registry.py
+++ b/romancal/associations/registry.py
@@ -58,7 +58,14 @@ class AssociationRegistry(dict):
     existing associations. See :py:func:`~romancal.associations.generate` for more information.
     """
 
-    def __init__(self, definition_files=None, include_default=True, global_constraints=None, name=None, include_bases=False):
+    def __init__(
+        self,
+        definition_files=None,
+        include_default=True,
+        global_constraints=None,
+        name=None,
+        include_bases=False,
+    ):
         super().__init__()
 
         # Generate a UUID for this instance. Used to modify rule
@@ -82,7 +89,11 @@ class AssociationRegistry(dict):
         self.Utility = type("Utility", (object,), {})
         for fname in definition_files:
             module = import_from_file(fname)
-            self.populate(module, global_constraints=global_constraints, include_bases=include_bases)
+            self.populate(
+                module,
+                global_constraints=global_constraints,
+                include_bases=include_bases,
+            )
 
     @property
     def rule_set(self):
@@ -161,10 +172,14 @@ class AssociationRegistry(dict):
             else:
                 return True
 
-        results = [rule for rule_name, rule in self.items() if is_valid(rule, association)]
+        results = [
+            rule for rule_name, rule in self.items() if is_valid(rule, association)
+        ]
 
         if len(results) == 0:
-            raise AssociationNotValidError(f'Structure did not validate: "{association}"')
+            raise AssociationNotValidError(
+                f'Structure did not validate: "{association}"'
+            )
         return results
 
     def load(self, serialized, format=None, validate=True, first=True, **kwargs):
@@ -200,7 +215,9 @@ class AssociationRegistry(dict):
         results = []
         for rule_name, rule in self.items():
             try:
-                results.append(rule.load(serialized, format=format, validate=validate, **kwargs))
+                results.append(
+                    rule.load(serialized, format=format, validate=validate, **kwargs)
+                )
             except (AssociationError, AttributeError) as err:
                 lasterr = err
                 continue
@@ -229,7 +246,9 @@ class AssociationRegistry(dict):
                 try:
                     self.add_rule(name, obj, global_constraints=global_constraints)
                 except TypeError:
-                    logger.debug(f"Could not add object {obj} as a rule due to TypeError")
+                    logger.debug(
+                        f"Could not add object {obj} as a rule due to TypeError"
+                    )
                 continue
 
             # Add callbacks
@@ -460,6 +479,8 @@ def get_marked(module, predicate=None, include_bases=False):
                 yield name, obj
         elif RegistryMarker.is_marked(obj):
             if ismodule(obj):
-                yield from get_marked(obj, predicate=predicate, include_bases=include_bases)
+                yield from get_marked(
+                    obj, predicate=predicate, include_bases=include_bases
+                )
             else:
                 yield name, obj

--- a/romancal/associations/registry.py
+++ b/romancal/associations/registry.py
@@ -56,7 +56,7 @@ class AssociationRegistry(dict):
     In practice, this is one step in a larger loop over all items to
     be associated. This does not account for adding items to already
     existing associations. See :py:func:`~romancal.associations.generate` for more information.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -2,10 +2,9 @@
 
 import pytest
 
-from romancal.associations import (Association, AssociationRegistry, load_asn)
-from romancal.associations.asn_from_list import (Main, asn_from_list)
+from romancal.associations import Association, AssociationRegistry, load_asn
+from romancal.associations.asn_from_list import Main, asn_from_list
 from romancal.associations.exceptions import AssociationNotValidError
-
 
 
 def test_base_association():

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -9,62 +9,54 @@ from romancal.associations.exceptions import AssociationNotValidError
 
 def test_base_association():
     """Create the simplest of associations"""
-    items = ['a', 'b', 'c']
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, rule=Association)
-    assert asn['asn_rule'] == 'Association'
-    assert asn['asn_type'] == 'None'
-    assert asn['members'] == items
+    assert asn["asn_rule"] == "Association"
+    assert asn["asn_type"] == "None"
+    assert asn["members"] == items
 
 
 def test_base_roundtrip():
     """Write/read created base association"""
-    items = ['a', 'b', 'c']
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, rule=Association)
     _, serialized = asn.dump()
     reloaded = load_asn(serialized, registry=None)
-    assert asn['asn_rule'] == reloaded['asn_rule']
-    assert asn['asn_type'] == reloaded['asn_type']
-    assert asn['members'] == reloaded['members']
+    assert asn["asn_rule"] == reloaded["asn_rule"]
+    assert asn["asn_type"] == reloaded["asn_type"]
+    assert asn["members"] == reloaded["members"]
 
 
 def test_default_simple():
     """Default ELPP association"""
-    product_name = 'test_product'
-    items = ['a', 'b', 'c']
+    product_name = "test_product"
+    items = ["a", "b", "c"]
     asn = asn_from_list(items, product_name=product_name)
-    assert asn['asn_rule'] == 'DMS_ELPP_Base'
-    assert asn['asn_type'] == 'None'
-    assert len(asn['products']) == 1
-    product = asn['products'][0]
-    assert product['name'] == product_name
-    assert len(product['members']) == len(items)
-    for member in product['members']:
-        assert member['expname'] in items
-        assert member['exptype'] == 'science'
+    assert asn["asn_rule"] == "DMS_ELPP_Base"
+    assert asn["asn_type"] == "None"
+    assert len(asn["products"]) == 1
+    product = asn["products"][0]
+    assert product["name"] == product_name
+    assert len(product["members"]) == len(items)
+    for member in product["members"]:
+        assert member["expname"] in items
+        assert member["exptype"] == "science"
 
 
 def test_default_with_type():
     """ELPP association with types specified"""
-    product_name = 'test_product'
-    items = {
-        'a': 'science',
-        'b': 'target_acq',
-        'c': 'somethingelse'
-    }
-    asn = asn_from_list(
-        list(items.items()),
-        product_name=product_name,
-        with_exptype=True
-    )
-    assert asn['asn_rule'] == 'DMS_ELPP_Base'
-    assert asn['asn_type'] == 'None'
-    assert len(asn['products']) == 1
-    product = asn['products'][0]
-    assert product['name'] == product_name
-    assert len(product['members']) == len(items)
-    for member in product['members']:
-        assert member['expname'] in items
-        assert member['exptype'] == items[member['expname']]
+    product_name = "test_product"
+    items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
+    asn = asn_from_list(list(items.items()), product_name=product_name, with_exptype=True)
+    assert asn["asn_rule"] == "DMS_ELPP_Base"
+    assert asn["asn_type"] == "None"
+    assert len(asn["products"]) == 1
+    product = asn["products"][0]
+    assert product["name"] == product_name
+    assert len(product["members"]) == len(items)
+    for member in product["members"]:
+        assert member["expname"] in items
+        assert member["exptype"] == items[member["expname"]]
 
 
 def test_default_fail():
@@ -72,29 +64,21 @@ def test_default_fail():
 
     A product name needs to be included, but is not.
     """
-    items = ['a']
+    items = ["a"]
     with pytest.raises(AssociationNotValidError):
         _ = asn_from_list(items)
 
 
 def test_default_roundtrip():
     """Create/Write/Read a ELPP association"""
-    product_name = 'test_product'
-    items = {
-        'a': 'science',
-        'b': 'target_acq',
-        'c': 'somethingelse'
-    }
-    asn = asn_from_list(
-        [(item, type_) for item, type_ in items.items()],
-        product_name=product_name,
-        with_exptype=True
-    )
+    product_name = "test_product"
+    items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
+    asn = asn_from_list([(item, type_) for item, type_ in items.items()], product_name=product_name, with_exptype=True)
     _, serialized = asn.dump()
     reloaded = load_asn(serialized)
-    assert asn['asn_rule'] == reloaded['asn_rule']
-    assert asn['asn_type'] == reloaded['asn_type']
-    assert len(asn['products']) == len(reloaded['products'])
+    assert asn["asn_rule"] == reloaded["asn_rule"]
+    assert asn["asn_type"] == reloaded["asn_type"]
+    assert len(asn["products"]) == len(reloaded["products"])
 
 
 def test_cmdline_fails():
@@ -106,89 +90,72 @@ def test_cmdline_fails():
 
     # Only the association file argument
     with pytest.raises(SystemExit):
-        Main(['-o', 'test_asn.json'])
+        Main(["-o", "test_asn.json"])
 
 
-@pytest.mark.parametrize(
-    "format",
-    ['json', 'yaml']
-)
+@pytest.mark.parametrize("format", ["json", "yaml"])
 def test_cmdline_success(format, tmpdir):
     """Create ELPP associations in different formats"""
-    path = tmpdir.join('test_asn.json')
-    product_name = 'test_product'
-    inlist = ['a', 'b', 'c']
-    args = [
-        '-o', path.strpath,
-        '--product-name', product_name,
-        '--format', format
-    ]
+    path = tmpdir.join("test_asn.json")
+    product_name = "test_product"
+    inlist = ["a", "b", "c"]
+    args = ["-o", path.strpath, "--product-name", product_name, "--format", format]
     args = args + inlist
     Main(args)
     with open(path.strpath) as fp:
         asn = load_asn(fp, format=format)
-    assert len(asn['products']) == 1
-    assert asn['products'][0]['name'] == product_name
-    members = asn['products'][0]['members']
-    expnames = [
-        member['expname']
-        for member in members
-    ]
+    assert len(asn["products"]) == 1
+    assert asn["products"][0]["name"] == product_name
+    members = asn["products"][0]["members"]
+    expnames = [member["expname"] for member in members]
     assert inlist == expnames
 
 
 def test_cmdline_change_rules(tmpdir):
     """Command line change the rule"""
-    rule = 'Asn_Lv2Image'
-    path = tmpdir.join('test_asn.json')
-    inlist = ['a', 'b', 'c']
+    rule = "Asn_Lv2Image"
+    path = tmpdir.join("test_asn.json")
+    inlist = ["a", "b", "c"]
     args = [
-        '-o', path.strpath,
-        '-r', rule,
-        '--product-name', 'test',
+        "-o",
+        path.strpath,
+        "-r",
+        rule,
+        "--product-name",
+        "test",
     ]
     args = args + inlist
     Main(args)
     with open(path.strpath) as fp:
         asn = load_asn(fp, registry=AssociationRegistry(include_bases=True))
-    #assert inlist == asn['members']
-    assert inlist[0] == asn['products'][0]['members'][0]['expname']
-    assert inlist[1] == asn['products'][0]['members'][1]['expname']
-    assert inlist[2] == asn['products'][0]['members'][2]['expname']
+    # assert inlist == asn['members']
+    assert inlist[0] == asn["products"][0]["members"][0]["expname"]
+    assert inlist[1] == asn["products"][0]["members"][1]["expname"]
+    assert inlist[2] == asn["products"][0]["members"][2]["expname"]
 
 
 def test_api_list():
     """Test api call with simple list"""
-    product_name = 'test_product'
-    inlist = ['a', 'b', 'c']
+    product_name = "test_product"
+    inlist = ["a", "b", "c"]
 
     asn = asn_from_list(inlist, product_name=product_name)
-    assert len(asn['products']) == 1
-    assert asn['products'][0]['name'] == product_name
-    members = asn['products'][0]['members']
-    expnames = [
-        member['expname']
-        for member in members
-    ]
+    assert len(asn["products"]) == 1
+    assert asn["products"][0]["name"] == product_name
+    members = asn["products"][0]["members"]
+    expnames = [member["expname"] for member in members]
     assert inlist == expnames
 
 
 def test_api_with_type():
     """Test api call with type tuple"""
-    product_name = 'test_product'
-    inlist = [
-        ('a', 'science'),
-        ('b', 'psf'),
-        ('c', 'science')
-    ]
+    product_name = "test_product"
+    inlist = [("a", "science"), ("b", "psf"), ("c", "science")]
 
     asn = asn_from_list(inlist, product_name=product_name, with_exptype=True)
-    assert len(asn['products']) == 1
-    assert asn['products'][0]['name'] == product_name
-    members = asn['products'][0]['members']
-    members_dict = {
-        member['expname']: member['exptype']
-        for member in members
-    }
+    assert len(asn["products"]) == 1
+    assert asn["products"][0]["name"] == product_name
+    members = asn["products"][0]["members"]
+    members_dict = {member["expname"]: member["exptype"] for member in members}
     for name, type_ in inlist:
         assert members_dict[name] == type_

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -47,7 +47,9 @@ def test_default_with_type():
     """ELPP association with types specified"""
     product_name = "test_product"
     items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
-    asn = asn_from_list(list(items.items()), product_name=product_name, with_exptype=True)
+    asn = asn_from_list(
+        list(items.items()), product_name=product_name, with_exptype=True
+    )
     assert asn["asn_rule"] == "DMS_ELPP_Base"
     assert asn["asn_type"] == "None"
     assert len(asn["products"]) == 1
@@ -73,7 +75,11 @@ def test_default_roundtrip():
     """Create/Write/Read a ELPP association"""
     product_name = "test_product"
     items = {"a": "science", "b": "target_acq", "c": "somethingelse"}
-    asn = asn_from_list([(item, type_) for item, type_ in items.items()], product_name=product_name, with_exptype=True)
+    asn = asn_from_list(
+        [(item, type_) for item, type_ in items.items()],
+        product_name=product_name,
+        with_exptype=True,
+    )
     _, serialized = asn.dump()
     reloaded = load_asn(serialized)
     assert asn["asn_rule"] == reloaded["asn_rule"]

--- a/romancal/associations/tests/test_constraints.py
+++ b/romancal/associations/tests/test_constraints.py
@@ -1,7 +1,11 @@
 """Constraint Tests"""
 import pytest
 
-from romancal.associations.lib.constraint import Constraint, SimpleConstraint, SimpleConstraintABC
+from romancal.associations.lib.constraint import (
+    Constraint,
+    SimpleConstraint,
+    SimpleConstraintABC,
+)
 
 
 def test_sc_dup_names():
@@ -255,7 +259,10 @@ def test_copy():
     assert sc1.value == "value1"
 
 
-@pytest.mark.parametrize("klass, expected", [(SimpleConstraint, "SimpleConstraint:myname"), (Constraint, "Constraint:myname")])
+@pytest.mark.parametrize(
+    "klass, expected",
+    [(SimpleConstraint, "SimpleConstraint:myname"), (Constraint, "Constraint:myname")],
+)
 def test_id(klass, expected):
     """Test constraint ID"""
     c = klass(name="myname")

--- a/romancal/associations/tests/test_constraints.py
+++ b/romancal/associations/tests/test_constraints.py
@@ -6,29 +6,31 @@ from romancal.associations.lib.constraint import Constraint, SimpleConstraint, S
 
 def test_sc_dup_names():
     """Test that SimpleConstraint returns an empty dict"""
-    sc = SimpleConstraint(name='sc_name')
+    sc = SimpleConstraint(name="sc_name")
     dups = sc.dup_names
     assert not len(dups)
+
 
 class TestDupNames:
     """Test duplicate names in Constraint"""
 
     # Sub constraints
-    sc1 = SimpleConstraint(name='sc1')
-    sc2 = SimpleConstraint(name='sc2')
-    c1 = Constraint([sc1, sc2], name='c1')
-    c2 = Constraint([sc1, sc1], name='c2')
-    c3 = Constraint([sc1, sc2], name='sc1')
+    sc1 = SimpleConstraint(name="sc1")
+    sc2 = SimpleConstraint(name="sc2")
+    c1 = Constraint([sc1, sc2], name="c1")
+    c2 = Constraint([sc1, sc1], name="c2")
+    c3 = Constraint([sc1, sc2], name="sc1")
 
     @pytest.mark.parametrize(
-        'constraints, expected', [
+        "constraints, expected",
+        [
             ([sc1], {}),
             ([sc1, sc2], {}),
-            ([sc1, sc1], {'sc1': [sc1, sc1]}),
+            ([sc1, sc1], {"sc1": [sc1, sc1]}),
             ([c1], {}),
-            ([c2], {'sc1': [sc1, sc1]}),
-            ([c3], {'sc1': [sc1, c3]}),
-        ]
+            ([c2], {"sc1": [sc1, sc1]}),
+            ([c3], {"sc1": [sc1, c3]}),
+        ],
     )
     def test_dups(self, constraints, expected):
         c = Constraint(constraints)
@@ -40,65 +42,53 @@ class TestDupNames:
 
 def test_sc_get_all_attr():
     """Get attribute value of a simple constraint"""
-    name = 'my_sc'
-    sc = SimpleConstraint(name=name, value='my_value')
-    assert sc.get_all_attr('name') == [(sc, name)]
+    name = "my_sc"
+    sc = SimpleConstraint(name=name, value="my_value")
+    assert sc.get_all_attr("name") == [(sc, name)]
 
 
 def test_constraint_get_all_attr():
     """Get attribute value of all constraints in a constraint"""
-    names = ['sc1', 'sc2']
-    constraints = [
-        SimpleConstraint(name=name)
-        for name in names
-    ]
-    c = Constraint(constraints, name='c1')
+    names = ["sc1", "sc2"]
+    constraints = [SimpleConstraint(name=name) for name in names]
+    c = Constraint(constraints, name="c1")
 
-    expected = [
-        (constraint, constraint.name)
-        for constraint in constraints
-    ]
-    expected.append((c, 'c1'))
-    result = c.get_all_attr('name')
+    expected = [(constraint, constraint.name) for constraint in constraints]
+    expected.append((c, "c1"))
+    result = c.get_all_attr("name")
     assert set(result) == set(expected)
 
 
 def test_simpleconstraint_reprocess_match():
     """Test options for reprocessing"""
-    sc = SimpleConstraint(
-        value='my_value',
-        reprocess_on_match=True
-    )
-    match, reprocess = sc.check_and_set('my_value')
+    sc = SimpleConstraint(value="my_value", reprocess_on_match=True)
+    match, reprocess = sc.check_and_set("my_value")
     assert match
     assert len(reprocess)
 
 
 def test_simpleconstraint_reprocess_nomatch():
     """Test options for reprocessing"""
-    sc = SimpleConstraint(
-        value='my_value',
-        reprocess_on_fail=True
-    )
-    match, reprocess = sc.check_and_set('bad_value')
+    sc = SimpleConstraint(value="my_value", reprocess_on_fail=True)
+    match, reprocess = sc.check_and_set("bad_value")
     assert not match
     assert len(reprocess)
 
 
 def test_constraint_reprocess_match():
     """Test options for reprocessing"""
-    sc = SimpleConstraint(value='my_value')
+    sc = SimpleConstraint(value="my_value")
     c = Constraint([sc], reprocess_on_match=True)
-    match, reprocess = c.check_and_set('my_value')
+    match, reprocess = c.check_and_set("my_value")
     assert match
     assert len(reprocess)
 
 
 def test_constraint_reprocess_nomatch():
     """Test options for reprocessing"""
-    sc = SimpleConstraint(value='my_value')
+    sc = SimpleConstraint(value="my_value")
     c = Constraint([sc], reprocess_on_fail=True)
-    match, reprocess = c.check_and_set('bad_value')
+    match, reprocess = c.check_and_set("bad_value")
     assert not match
     assert len(reprocess)
 
@@ -119,12 +109,12 @@ def test_simpleconstraint():
     assert c.test == c.eq
 
     # Parameter initialization
-    c = SimpleConstraint(value='my_value')
-    assert c.value == 'my_value'
+    c = SimpleConstraint(value="my_value")
+    assert c.value == "my_value"
 
     # Dict initialization
-    c = SimpleConstraint({'value': 'my_value'})
-    assert c.value == 'my_value'
+    c = SimpleConstraint({"value": "my_value"})
+    assert c.value == "my_value"
 
 
 def test_simpleconstraint_checkset():
@@ -132,21 +122,21 @@ def test_simpleconstraint_checkset():
 
     # Check and set.
     c = SimpleConstraint()
-    match, reprocess = c.check_and_set('my_value')
+    match, reprocess = c.check_and_set("my_value")
     assert match
-    assert c.value == 'my_value'
+    assert c.value == "my_value"
     assert len(reprocess) == 0
 
     # Non-match
-    c = SimpleConstraint(value='my_value')
-    match, reprocess = c.check_and_set('bad_value')
+    c = SimpleConstraint(value="my_value")
+    match, reprocess = c.check_and_set("bad_value")
     assert not match
-    assert c.value == 'my_value'
+    assert c.value == "my_value"
     assert len(reprocess) == 0
 
     # Don't force unique
     c = SimpleConstraint(force_unique=False)
-    match, reprocess = c.check_and_set('my_value')
+    match, reprocess = c.check_and_set("my_value")
     assert match
     assert c.value is None
     assert len(reprocess) == 0
@@ -158,54 +148,54 @@ def test_constraint_default():
     sc1 = SimpleConstraint()
     sc2 = SimpleConstraint()
     c = Constraint([sc1, sc2])
-    match, reprocess = c.check_and_set('my_value')
+    match, reprocess = c.check_and_set("my_value")
     assert match
     for constraint in c.constraints:
-        assert constraint.value == 'my_value'
+        assert constraint.value == "my_value"
 
 
 def test_invalid_init():
     with pytest.raises(TypeError):
-        Constraint('bad init')
+        Constraint("bad init")
 
 
 def test_constraint_all():
     """Test the all operation"""
 
-    sc1 = SimpleConstraint(value='value_1')
-    sc2 = SimpleConstraint(value='value_2')
+    sc1 = SimpleConstraint(value="value_1")
+    sc2 = SimpleConstraint(value="value_2")
     c = Constraint([sc1, sc2])
-    match, reprocess = c.check_and_set('value_1')
+    match, reprocess = c.check_and_set("value_1")
     assert not match
 
 
 def test_constraint_any_basic():
     """Test the all operation"""
 
-    sc1 = SimpleConstraint(value='value_1')
-    sc2 = SimpleConstraint(value='value_2')
+    sc1 = SimpleConstraint(value="value_1")
+    sc2 = SimpleConstraint(value="value_2")
     c = Constraint([sc1, sc2], reduce=Constraint.any)
-    match, reprocess = c.check_and_set('value_1')
+    match, reprocess = c.check_and_set("value_1")
     assert match
-    match, reprocess = c.check_and_set('value_2')
+    match, reprocess = c.check_and_set("value_2")
     assert match
-    match, reprocess = c.check_and_set('value_3')
+    match, reprocess = c.check_and_set("value_3")
     assert not match
 
 
 def test_constraint_any_remember():
     """Ensure that any doesn't forget other or propositions"""
 
-    sc1 = SimpleConstraint(value='value_1')
-    sc2 = SimpleConstraint(value='value_2')
+    sc1 = SimpleConstraint(value="value_1")
+    sc2 = SimpleConstraint(value="value_2")
     c = Constraint([sc1, sc2], reduce=Constraint.any)
-    match, reprocess = c.check_and_set('value_1')
+    match, reprocess = c.check_and_set("value_1")
     assert match
-    match, reprocess = c.check_and_set('value_2')
+    match, reprocess = c.check_and_set("value_2")
     assert match
-    match, reprocess = c.check_and_set('value_1')
+    match, reprocess = c.check_and_set("value_1")
     assert match
-    match, reprocess = c.check_and_set('value_3')
+    match, reprocess = c.check_and_set("value_3")
     assert not match
 
 
@@ -222,10 +212,7 @@ def test_iteration():
         count += 1
     assert count == 2
 
-    c = Constraint([
-        Constraint([sc, sc]),
-        Constraint([sc, sc])
-    ])
+    c = Constraint([Constraint([sc, sc]), Constraint([sc, sc])])
     count = 0
     for idx in c:
         assert isinstance(idx, SimpleConstraint)
@@ -235,44 +222,42 @@ def test_iteration():
 
 def test_name_index():
     """Test for name indexing"""
-    sc1 = SimpleConstraint(name='sc1', value='value1')
-    sc2 = SimpleConstraint(name='sc2', value='value2')
+    sc1 = SimpleConstraint(name="sc1", value="value1")
+    sc2 = SimpleConstraint(name="sc2", value="value2")
     c1 = Constraint([sc1, sc2])
-    assert c1['sc1'].value
-    assert c1['sc2'].value
+    assert c1["sc1"].value
+    assert c1["sc2"].value
 
-    sc3 = SimpleConstraint(name='sc3', value='value3')
-    sc4 = SimpleConstraint(name='sc4', value='value4')
+    sc3 = SimpleConstraint(name="sc3", value="value3")
+    sc4 = SimpleConstraint(name="sc4", value="value4")
     c2 = Constraint([sc3, sc4, c1])
-    assert c2['sc1'].value
-    assert c2['sc2'].value
-    assert c2['sc3'].value
-    assert c2['sc4'].value
+    assert c2["sc1"].value
+    assert c2["sc2"].value
+    assert c2["sc3"].value
+    assert c2["sc4"].value
 
     with pytest.raises(KeyError):
-        c2['nonexistent'].value
+        c2["nonexistent"].value
 
     with pytest.raises(AttributeError):
-        c2['sc1'].nonexistent
+        c2["sc1"].nonexistent
 
 
 def test_copy():
-    sc1 = SimpleConstraint(name='sc1')
+    sc1 = SimpleConstraint(name="sc1")
     sc1_copy = sc1.copy()
     assert id(sc1) != id(sc1_copy)
-    sc1.check_and_set('value1')
-    assert sc1.value == 'value1'
+    sc1.check_and_set("value1")
+    assert sc1.value == "value1"
     assert sc1_copy.value is None
-    sc1_copy.check_and_set('value2')
-    assert sc1_copy.value == 'value2'
-    assert sc1.value == 'value1'
+    sc1_copy.check_and_set("value2")
+    assert sc1_copy.value == "value2"
+    assert sc1.value == "value1"
 
 
-@pytest.mark.parametrize('klass, expected',
-                         [(SimpleConstraint, 'SimpleConstraint:myname'),
-                          (Constraint, 'Constraint:myname')])
+@pytest.mark.parametrize("klass, expected", [(SimpleConstraint, "SimpleConstraint:myname"), (Constraint, "Constraint:myname")])
 def test_id(klass, expected):
     """Test constraint ID"""
-    c = klass(name='myname')
+    c = klass(name="myname")
 
     assert c.id == expected

--- a/romancal/associations/tests/test_constraints.py
+++ b/romancal/associations/tests/test_constraints.py
@@ -1,11 +1,7 @@
 """Constraint Tests"""
 import pytest
 
-from romancal.associations.lib.constraint import (
-    Constraint,
-    SimpleConstraint,
-    SimpleConstraintABC,
-)
+from romancal.associations.lib.constraint import Constraint, SimpleConstraint, SimpleConstraintABC
 
 
 def test_sc_dup_names():

--- a/romancal/associations/tests/test_registry.py
+++ b/romancal/associations/tests/test_registry.py
@@ -21,15 +21,16 @@ def test_registry_match(full_pool_rules):
 
 # Tests below for keyvalue_registry
 
+
 def test_dict_like():
     """Test the basic to ensure similar to a dict"""
-    data = {'a': 1, 'b': 2}
+    data = {"a": 1, "b": 2}
     kvr = KeyValueRegistry(data)
     assert data.keys() == kvr.keys()
     assert set(data.values()) == set(kvr.values())
 
-    assert kvr.get('a') == 1
-    assert kvr.get('c', 3) == 3
+    assert kvr.get("a") == 1
+    assert kvr.get("c", 3) == 3
 
     keys, values = zip(*kvr.items())
     assert set(data.keys()) == set(keys)
@@ -38,9 +39,9 @@ def test_dict_like():
     kvr_copy = kvr.copy()
     assert set(kvr_copy) == set(kvr)
 
-    assert kvr.pop('a') == 1
-    assert kvr.pop('a', 3) == 3
-    assert kvr.popitem() == ('b', 2)
+    assert kvr.pop("a") == 1
+    assert kvr.pop("a", 3) == 3
+    assert kvr.popitem() == ("b", 2)
     with pytest.raises(KeyError):
         kvr.popitem()
 
@@ -54,18 +55,18 @@ def test_dict_like():
 
 
 def test_default():
-    kvr = KeyValueRegistry(default={'a': 1})
-    assert kvr.default == 'a'
+    kvr = KeyValueRegistry(default={"a": 1})
+    assert kvr.default == "a"
     assert kvr[None] == 1
 
 
 def test_tuple():
-    data = ('a', 1)
+    data = ("a", 1)
     kvr = KeyValueRegistry(data)
-    assert kvr['a'] == 1
+    assert kvr["a"] == 1
 
     kvr = KeyValueRegistry(default=data)
-    assert kvr['a'] == 1
+    assert kvr["a"] == 1
     assert kvr[None] == 1
 
 

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -6,8 +6,8 @@ import tempfile
 import pytest
 from stdatamodels import s3_utils
 
-#from jwst.associations import (AssociationRegistry, AssociationPool)
-#from jwst.associations.tests.helpers import t_path
+# from jwst.associations import (AssociationRegistry, AssociationPool)
+# from jwst.associations.tests.helpers import t_path
 from romancal.lib.tests import helpers as lib_helpers
 
 # @pytest.fixture(scope='session')
@@ -55,7 +55,7 @@ def slow(request):
     """Setup slow fixture for tests to identify if --slow
     has been specified
     """
-    return request.config.getoption('--slow')
+    return request.config.getoption("--slow")
 
 
 @pytest.fixture(scope="module")
@@ -67,7 +67,7 @@ def jail(request, tmpdir_factory):
     temporary directory, and then have the tests access them.
     """
     old_dir = os.getcwd()
-    path = request.module.__name__.split('.')[-1]
+    path = request.module.__name__.split(".")[-1]
     if request._parent_request.fixturename is not None:
         path = path + "_" + request._parent_request.fixturename
     newpath = tmpdir_factory.mktemp(path)
@@ -78,8 +78,8 @@ def jail(request, tmpdir_factory):
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
-    terminal_reporter = config.pluginmanager.getplugin('terminalreporter')
-    config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), 'testdescription')
+    terminal_reporter = config.pluginmanager.getplugin("terminalreporter")
+    config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), "testdescription")
 
 
 class TestDescriptionPlugin:
@@ -107,7 +107,7 @@ class TestDescriptionPlugin:
             yield
         # When run as `pytest -vv`, `pytest -vvv`, etc, print the test docstring
         else:
-            self.terminal_reporter.write('\n')
+            self.terminal_reporter.write("\n")
             yield
             if self.desc:
-                self.terminal_reporter.write(f'\n{self.desc} ')
+                self.terminal_reporter.write(f"\n{self.desc} ")

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -79,7 +79,9 @@ def jail(request, tmpdir_factory):
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     terminal_reporter = config.pluginmanager.getplugin("terminalreporter")
-    config.pluginmanager.register(TestDescriptionPlugin(terminal_reporter), "testdescription")
+    config.pluginmanager.register(
+        TestDescriptionPlugin(terminal_reporter), "testdescription"
+    )
 
 
 class TestDescriptionPlugin:

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -1,15 +1,14 @@
 """Project default for pytest"""
+import inspect
 import os
 import tempfile
-import pytest
-import inspect
 
+import pytest
 from stdatamodels import s3_utils
 
 #from jwst.associations import (AssociationRegistry, AssociationPool)
 #from jwst.associations.tests.helpers import t_path
 from romancal.lib.tests import helpers as lib_helpers
-
 
 # @pytest.fixture(scope='session')
 # def full_pool_rules(request):

--- a/romancal/dark_current/__init__.py
+++ b/romancal/dark_current/__init__.py
@@ -1,3 +1,3 @@
 from .dark_current_step import DarkCurrentStep
 
-__all__ = ['DarkCurrentStep']
+__all__ = ["DarkCurrentStep"]

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -22,7 +22,7 @@ class DarkCurrentStep(RomanStep):
         dark_output = output_file(default = None) # Dark corrected model
     """
 
-    reference_file_types = ['dark']
+    reference_file_types = ["dark"]
 
     def process(self, input):
 
@@ -30,19 +30,19 @@ class DarkCurrentStep(RomanStep):
         with rdd.open(input) as input_model:
 
             # Get the name of the dark reference file to use
-            self.dark_name = self.get_reference_file(input_model, 'dark')
-            self.log.info('Using DARK reference file %s', self.dark_name)
+            self.dark_name = self.get_reference_file(input_model, "dark")
+            self.log.info("Using DARK reference file %s", self.dark_name)
 
             # Open dark model
             dark_model = rdd.open(self.dark_name)
 
             # Temporary patch to utilize stcal dark step until MA table support is fully implemented
-            if 'ngroups' not in dark_model.meta.exposure:
-                dark_model.meta.exposure['ngroups'] = dark_model.data.shape[0]
-            if 'nframes' not in dark_model.meta.exposure:
-                dark_model.meta.exposure['nframes'] = input_model.meta.exposure.nframes
-            if 'groupgap' not in dark_model.meta.exposure:
-                dark_model.meta.exposure['groupgap'] = input_model.meta.exposure.groupgap
+            if "ngroups" not in dark_model.meta.exposure:
+                dark_model.meta.exposure["ngroups"] = dark_model.data.shape[0]
+            if "nframes" not in dark_model.meta.exposure:
+                dark_model.meta.exposure["nframes"] = input_model.meta.exposure.nframes
+            if "groupgap" not in dark_model.meta.exposure:
+                dark_model.meta.exposure["groupgap"] = input_model.meta.exposure.groupgap
 
             # Reshaping data variables for stcal compatibility
             input_model.data = input_model.data[np.newaxis, :]
@@ -50,9 +50,7 @@ class DarkCurrentStep(RomanStep):
             input_model.err = input_model.err[np.newaxis, :]
 
             # Do the dark correction
-            out_data, dark_data = dark_sub.do_correction(
-                input_model, dark_model, self.dark_output
-            )
+            out_data, dark_data = dark_sub.do_correction(input_model, dark_model, self.dark_output)
 
             # Save dark data to file
             if dark_data is not None and dark_data.save:
@@ -69,9 +67,9 @@ class DarkCurrentStep(RomanStep):
 
         if self.save_results:
             try:
-                self.suffix = 'darkcurrent'
+                self.suffix = "darkcurrent"
             except AttributeError:
-                self['suffix'] = 'darkcurrent'
+                self["suffix"] = "darkcurrent"
             dark_model.close()
 
         return out_ramp
@@ -97,9 +95,9 @@ def save_dark_data_as_dark_model(dark_data, dark_model):
     out_dark.err = u.Quantity(dark_data.err, out_dark.err.unit, dtype=out_dark.err.dtype)
 
     # Temporary patch to utilize stcal dark step until MA table support is fully implemented
-    out_dark.meta.exposure['nframes'] = dark_data.exp_nframes
-    out_dark.meta.exposure['ngroups'] = dark_data.exp_ngroups
-    out_dark.meta.exposure['groupgap'] = dark_data.exp_groupgap
+    out_dark.meta.exposure["nframes"] = dark_data.exp_nframes
+    out_dark.meta.exposure["ngroups"] = dark_data.exp_ngroups
+    out_dark.meta.exposure["groupgap"] = dark_data.exp_groupgap
 
     # Create DarkRefModel and write to file
     out_dark_model = rdd.DarkRefModel(out_dark)

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -36,7 +36,8 @@ class DarkCurrentStep(RomanStep):
             # Open dark model
             dark_model = rdd.open(self.dark_name)
 
-            # Temporary patch to utilize stcal dark step until MA table support is fully implemented
+            # Temporary patch to utilize stcal dark step until MA table support
+            # is fully implemented
             if "ngroups" not in dark_model.meta.exposure:
                 dark_model.meta.exposure["ngroups"] = dark_model.data.shape[0]
             if "nframes" not in dark_model.meta.exposure:
@@ -102,7 +103,8 @@ def save_dark_data_as_dark_model(dark_data, dark_model):
         dark_data.err, out_dark.err.unit, dtype=out_dark.err.dtype
     )
 
-    # Temporary patch to utilize stcal dark step until MA table support is fully implemented
+    # Temporary patch to utilize stcal dark step until MA table support is
+    # fully implemented
     out_dark.meta.exposure["nframes"] = dark_data.exp_nframes
     out_dark.meta.exposure["ngroups"] = dark_data.exp_ngroups
     out_dark.meta.exposure["groupgap"] = dark_data.exp_groupgap

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -42,7 +42,9 @@ class DarkCurrentStep(RomanStep):
             if "nframes" not in dark_model.meta.exposure:
                 dark_model.meta.exposure["nframes"] = input_model.meta.exposure.nframes
             if "groupgap" not in dark_model.meta.exposure:
-                dark_model.meta.exposure["groupgap"] = input_model.meta.exposure.groupgap
+                dark_model.meta.exposure[
+                    "groupgap"
+                ] = input_model.meta.exposure.groupgap
 
             # Reshaping data variables for stcal compatibility
             input_model.data = input_model.data[np.newaxis, :]
@@ -50,7 +52,9 @@ class DarkCurrentStep(RomanStep):
             input_model.err = input_model.err[np.newaxis, :]
 
             # Do the dark correction
-            out_data, dark_data = dark_sub.do_correction(input_model, dark_model, self.dark_output)
+            out_data, dark_data = dark_sub.do_correction(
+                input_model, dark_model, self.dark_output
+            )
 
             # Save dark data to file
             if dark_data is not None and dark_data.save:
@@ -90,9 +94,13 @@ def save_dark_data_as_dark_model(dark_data, dark_model):
 
     # Create DarkRef object and copy dark data to it
     out_dark = maker_utils.mk_dark(shape=dark_data.data.shape)
-    out_dark.data = u.Quantity(dark_data.data, out_dark.data.unit, dtype=out_dark.data.dtype)
+    out_dark.data = u.Quantity(
+        dark_data.data, out_dark.data.unit, dtype=out_dark.data.dtype
+    )
     out_dark.dq = dark_data.groupdq
-    out_dark.err = u.Quantity(dark_data.err, out_dark.err.unit, dtype=out_dark.err.dtype)
+    out_dark.err = u.Quantity(
+        dark_data.err, out_dark.err.unit, dtype=out_dark.err.dtype
+    )
 
     # Temporary patch to utilize stcal dark step until MA table support is fully implemented
     out_dark.meta.exposure["nframes"] = dark_data.exp_nframes

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -1,14 +1,13 @@
 #! /usr/bin/env python
 
-from astropy import units as u
 import numpy as np
-
-from romancal.stpipe import RomanStep
+from astropy import units as u
 from roman_datamodels import datamodels as rdd
-from stcal.dark_current import dark_sub
 from roman_datamodels import maker_utils
 from roman_datamodels import units as ru
+from stcal.dark_current import dark_sub
 
+from romancal.stpipe import RomanStep
 
 __all__ = ["DarkCurrentStep"]
 

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -22,7 +22,10 @@ from romancal.dark_current import DarkCurrentStep
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_dark_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a DARK reffile"""
@@ -58,7 +61,10 @@ def test_dark_step_interface(instrument, exptype):
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_dark_step_subtraction(instrument, exptype):
     """Test that the values in a dark reference file are properly subtracted"""
@@ -81,7 +87,9 @@ def test_dark_step_subtraction(instrument, exptype):
     diff = ramp_model.data.value - darkref_model.data.value
 
     # test that the output data file is equal to the difference found when subtracting reffile from sci file
-    np.testing.assert_array_equal(result.data.value, diff, err_msg="dark file should be subtracted from sci file ")
+    np.testing.assert_array_equal(
+        result.data.value, diff, err_msg="dark file should be subtracted from sci file "
+    )
 
 
 @pytest.mark.parametrize(
@@ -91,7 +99,10 @@ def test_dark_step_subtraction(instrument, exptype):
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_dark_step_output_dark_file(tmpdir, instrument, exptype):
     """Test that the the step can output a proper (optional) dark file"""

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -19,11 +19,10 @@ from romancal.dark_current import DarkCurrentStep
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_dark_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a DARK reffile"""
@@ -45,7 +44,7 @@ def test_dark_step_interface(instrument, exptype):
     assert result.groupdq.shape == shape
     assert result.pixeldq.shape == shape[1:]
     assert result.err.shape == shape
-    assert result.meta.cal_step.dark == 'COMPLETE'
+    assert result.meta.cal_step.dark == "COMPLETE"
     assert result.data.dtype == np.float32
     assert result.err.dtype == np.float32
     assert result.pixeldq.dtype == np.uint32
@@ -56,11 +55,10 @@ def test_dark_step_interface(instrument, exptype):
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_dark_step_subtraction(instrument, exptype):
     """Test that the values in a dark reference file are properly subtracted"""
@@ -83,18 +81,17 @@ def test_dark_step_subtraction(instrument, exptype):
     diff = ramp_model.data.value - darkref_model.data.value
 
     # test that the output data file is equal to the difference found when subtracting reffile from sci file
-    np.testing.assert_array_equal(result.data.value, diff, err_msg='dark file should be subtracted from sci file ')
+    np.testing.assert_array_equal(result.data.value, diff, err_msg="dark file should be subtracted from sci file ")
 
 
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_dark_step_output_dark_file(tmpdir, instrument, exptype):
     """Test that the the step can output a proper (optional) dark file"""
@@ -126,8 +123,8 @@ def create_ramp_and_dark(shape, instrument, exptype):
     # Create test ramp model
     ramp = maker_utils.mk_ramp(shape)
     ramp.meta.instrument.name = instrument
-    ramp.meta.instrument.detector = 'WFI01'
-    ramp.meta.instrument.optical_element = 'F158'
+    ramp.meta.instrument.detector = "WFI01"
+    ramp.meta.instrument.optical_element = "F158"
     ramp.meta.exposure.type = exptype
     ramp.data = u.Quantity(np.ones(shape, dtype=np.float32), ru.DN, dtype=np.float32)
     ramp_model = RampModel(ramp)

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -86,7 +86,8 @@ def test_dark_step_subtraction(instrument, exptype):
     # check that the dark file is subtracted frame by frame from the science data
     diff = ramp_model.data.value - darkref_model.data.value
 
-    # test that the output data file is equal to the difference found when subtracting reffile from sci file
+    # test that the output data file is equal to the difference found when subtracting
+    # reffile from sci file
     np.testing.assert_array_equal(
         result.data.value, diff, err_msg="dark file should be subtracted from sci file "
     )

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -2,17 +2,17 @@
 Unit tests for dark current correction
 """
 
-import pytest
-import numpy as np
 import os
-from astropy import units as u
 
-from romancal.dark_current import DarkCurrentStep
-
-from roman_datamodels.datamodels import RampModel, DarkRefModel
+import numpy as np
+import pytest
 import roman_datamodels as rdm
+from astropy import units as u
 from roman_datamodels import maker_utils
 from roman_datamodels import units as ru
+from roman_datamodels.datamodels import DarkRefModel, RampModel
+
+from romancal.dark_current import DarkCurrentStep
 
 
 @pytest.mark.parametrize(

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -55,7 +55,9 @@ class DQInitStep(RomanStep):
                     input_ramp[key].update(input_model.__getattr__(key))
                 elif isinstance(input_ramp[key], np.ndarray):
                     # Cast input ndarray as RampModel dtype
-                    input_ramp[key] = input_model.__getattr__(key).astype(input_ramp[key].dtype)
+                    input_ramp[key] = input_model.__getattr__(key).astype(
+                        input_ramp[key].dtype
+                    )
                 else:
                     input_ramp[key] = input_model.__getattr__(key)
 
@@ -68,8 +70,12 @@ class DQInitStep(RomanStep):
         x_start = input_model.meta.guidestar.gw_window_xstart
         x_end = input_model.meta.guidestar.gw_window_xsize + x_start
         # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
-        init_model.pixeldq[int(x_start) : int(x_end), :] = dqflags.pixel["GW_AFFECTED_DATA"]
-        self.log.info(f"Flagging rows from: {x_start} to {x_end} as affected by guide window read")
+        init_model.pixeldq[int(x_start) : int(x_end), :] = dqflags.pixel[
+            "GW_AFFECTED_DATA"
+        ]
+        self.log.info(
+            f"Flagging rows from: {x_start} to {x_end} as affected by guide window read"
+        )
 
         # Get reference file path
         reference_file_name = self.get_reference_file(init_model, "mask")

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -1,13 +1,13 @@
 #! /usr/bin/env python
 
 import numpy as np
-
-from romancal.stpipe import RomanStep
-from romancal.dq_init import dq_initialization
-from romancal.lib import dqflags
-from roman_datamodels.datamodels import RampModel
 import roman_datamodels as rdm
 from roman_datamodels import maker_utils
+from roman_datamodels.datamodels import RampModel
+
+from romancal.dq_init import dq_initialization
+from romancal.lib import dqflags
+from romancal.stpipe import RomanStep
 
 __all__ = ["DQInitStep"]
 

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -24,7 +24,7 @@ class DQInitStep(RomanStep):
     input model.
     """
 
-    reference_file_types = ['mask']
+    reference_file_types = ["mask"]
 
     def process(self, input):
         """Perform the dq_init calibration step
@@ -68,9 +68,8 @@ class DQInitStep(RomanStep):
         x_start = input_model.meta.guidestar.gw_window_xstart
         x_end = input_model.meta.guidestar.gw_window_xsize + x_start
         # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
-        init_model.pixeldq[int(x_start):int(x_end),:] = dqflags.pixel['GW_AFFECTED_DATA']
-        self.log.info(f'Flagging rows from: {x_start} to {x_end} '
-                      'as affected by guide window read')
+        init_model.pixeldq[int(x_start) : int(x_end), :] = dqflags.pixel["GW_AFFECTED_DATA"]
+        self.log.info(f"Flagging rows from: {x_start} to {x_end} as affected by guide window read")
 
         # Get reference file path
         reference_file_name = self.get_reference_file(init_model, "mask")
@@ -80,7 +79,7 @@ class DQInitStep(RomanStep):
             # If there are mask files, perform dq step
             # Open the relevant reference files as datamodels
             reference_file_model = rdm.open(reference_file_name)
-            self.log.debug(f'Using MASK ref file: {reference_file_name}')
+            self.log.debug(f"Using MASK ref file: {reference_file_name}")
 
             # Apply the DQ step
             output_model = dq_initialization.do_dqinit(
@@ -106,11 +105,11 @@ class DQInitStep(RomanStep):
         else:
             # Skip DQ step if no mask files
             reference_file_model = None
-            self.log.warning('No MASK reference file found.')
-            self.log.warning('DQ initialization step will be skipped.')
+            self.log.warning("No MASK reference file found.")
+            self.log.warning("DQ initialization step will be skipped.")
 
             output_model = init_model
-            output_model.meta.cal_step.dq_init = 'SKIPPED'
+            output_model.meta.cal_step.dq_init = "SKIPPED"
 
         # Close the input and reference files
         input_model.close()
@@ -122,8 +121,8 @@ class DQInitStep(RomanStep):
 
         if self.save_results:
             try:
-                self.suffix = 'dqinit'
+                self.suffix = "dqinit"
             except AttributeError:
-                self['suffix'] = 'dqinit'
+                self["suffix"] = "dqinit"
 
         return output_model

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,4 +1,5 @@
 import logging
+
 import numpy as np
 
 log = logging.getLogger(__name__)

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -6,7 +6,13 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 # Guide star mode exposure types
-GUIDER_LIST = ["WFI_WIM_ACQ", "WFI_WIM_TRACK", "WFI_WSM_ACQ1", "WFI_WSM_ACQ2", "WFI_WSM_TRACK"]
+GUIDER_LIST = [
+    "WFI_WIM_ACQ",
+    "WFI_WIM_TRACK",
+    "WFI_WSM_ACQ1",
+    "WFI_WSM_ACQ2",
+    "WFI_WSM_TRACK",
+]
 
 
 def do_dqinit(input_model, mask=None):

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 # Guide star mode exposure types
-GUIDER_LIST = ['WFI_WIM_ACQ','WFI_WIM_TRACK','WFI_WSM_ACQ1','WFI_WSM_ACQ2','WFI_WSM_TRACK']
+GUIDER_LIST = ["WFI_WIM_ACQ", "WFI_WIM_TRACK", "WFI_WSM_ACQ1", "WFI_WSM_ACQ2", "WFI_WSM_TRACK"]
 
 
 def do_dqinit(input_model, mask=None):
@@ -33,7 +33,7 @@ def do_dqinit(input_model, mask=None):
 
     # Determine if mask is shapewise compatable with the input
     skip_step = False
-    if (input_model.meta.exposure.type in GUIDER_LIST):
+    if input_model.meta.exposure.type in GUIDER_LIST:
         # Check to see if the shape of the mask data array
         # is not equal to the shape of the science data
         if input_model.dq.shape != mask.dq.shape:
@@ -44,18 +44,17 @@ def do_dqinit(input_model, mask=None):
         if input_model.pixeldq.shape != mask.dq.shape:
             skip_step = True
 
-
     # Apply or skip dq correction
     if skip_step:
-        log.warning('Mask data array is not the same '
-                    'shape as the science data')
-        log.warning('Step will be skipped')
-        output_model.meta.cal_step.dq_init = 'SKIPPED'
+        log.warning("Mask data array is not the same shape as the science data")
+        log.warning("Step will be skipped")
+        output_model.meta.cal_step.dq_init = "SKIPPED"
     else:
         output_model = apply_dqinit(input_model, mask)
-        output_model.meta.cal_step.dq_init = 'COMPLETE'
+        output_model.meta.cal_step.dq_init = "COMPLETE"
 
     return output_model
+
 
 def apply_dqinit(science, mask):
     """Apply data quality mask to the dq or pixeldq arrays.
@@ -75,7 +74,7 @@ def apply_dqinit(science, mask):
     """
 
     # Set model-specific data quality in output
-    if (science.meta.exposure.type in GUIDER_LIST):
+    if science.meta.exposure.type in GUIDER_LIST:
         science.dq = np.bitwise_or(science.dq, mask.dq)
     else:
         science.pixeldq = np.bitwise_or(science.pixeldq, mask.dq)

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -57,7 +57,8 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     outfile = do_dqinit(dm_ramp, ref_data)
     dqdata = outfile["pixeldq"]
 
-    # assert that the pixels read back in match the mapping from ref data to science data
+    # assert that the pixels read back in match the mapping from ref data to
+    # science data
     assert dqdata[100, 100] == dqflags.pixel["SATURATED"]
     assert dqdata[200, 100] == dqflags.pixel["JUMP_DET"]
     assert dqdata[300, 100] == dqflags.pixel["DROPOUT"]
@@ -73,7 +74,10 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
 
 
 def test_groupdq():
-    """Check that GROUPDQ extension is added to the data and all values are initialized to zero."""
+    """
+    Check that GROUPDQ extension is added to the data and all values are
+    initialized to zero.
+    """
 
     # size of integration
     instrument = "WFI"

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -1,18 +1,17 @@
 import os
-from stdatamodels.validate import ValidationWarning
+import warnings
+
 import numpy as np
 import pytest
-import warnings
 from astropy import units as u
-
-from roman_datamodels import stnode
-from roman_datamodels.datamodels import MaskRefModel, ScienceRawModel
-from roman_datamodels import maker_utils
+from roman_datamodels import maker_utils, stnode
 from roman_datamodels import units as ru
+from roman_datamodels.datamodels import MaskRefModel, ScienceRawModel
+from stdatamodels.validate import ValidationWarning
 
-from romancal.lib import dqflags
 from romancal.dq_init import DQInitStep
 from romancal.dq_init.dq_initialization import do_dqinit
+from romancal.lib import dqflags
 
 # Set parameters for multiple runs of data
 args = "xstart, ystart, xsize, ysize, ngroups, instrument, exp_type"

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -15,12 +15,13 @@ from romancal.lib import dqflags
 
 # Set parameters for multiple runs of data
 args = "xstart, ystart, xsize, ysize, ngroups, instrument, exp_type"
-test_data = [(1, 1, 2048, 2048, 2, 'WFI', 'WFI_IMAGE')]
+test_data = [(1, 1, 2048, 2048, 2, "WFI", "WFI_IMAGE")]
 ids = ["RampModel"]
+
 
 @pytest.mark.parametrize(args, test_data, ids=ids)
 def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
-    """ Check that PIXELDQ is initialized with the information from the reference file.
+    """Check that PIXELDQ is initialized with the information from the reference file.
     test that a flagged value in the reference file flags the PIXELDQ array"""
 
     csize = (ngroups, ysize, xsize)
@@ -33,47 +34,47 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     dq = np.zeros(csize[1:], dtype=np.uint32)
 
     # edit reference file with known bad pixel values
-    dq[100, 100] = 2   # Saturated pixel
-    dq[200, 100] = 4   # Jump detected pixel
-    dq[300, 100] = 8   # Dropout
+    dq[100, 100] = 2  # Saturated pixel
+    dq[200, 100] = 4  # Jump detected pixel
+    dq[300, 100] = 8  # Dropout
     dq[400, 100] = 32  # Persistence
-    dq[500, 100] = 1   # Do_not_use
+    dq[500, 100] = 1  # Do_not_use
     dq[600, 100] = 16  # guide window affected data
-    dq[100, 200] = 3   # Saturated pixel + do not use
-    dq[200, 200] = 5   # Jump detected pixel + do not use
-    dq[300, 200] = 9   # Dropout + do not use
+    dq[100, 200] = 3  # Saturated pixel + do not use
+    dq[200, 200] = 5  # Jump detected pixel + do not use
+    dq[300, 200] = 9  # Dropout + do not use
     dq[400, 200] = 33  # Persistence + do not use
 
     # write mask model
     ref_data = maker_utils.mk_mask(csize[1:])
 
     # Copy in maskmodel elemnts
-    ref_data['dq'] = dq
+    ref_data["dq"] = dq
 
-    ref_data['meta']['instrument']['name'] = instrument
+    ref_data["meta"]["instrument"]["name"] = instrument
 
     # run do_dqinit
     outfile = do_dqinit(dm_ramp, ref_data)
-    dqdata = outfile['pixeldq']
+    dqdata = outfile["pixeldq"]
 
     # assert that the pixels read back in match the mapping from ref data to science data
-    assert (dqdata[100, 100] == dqflags.pixel['SATURATED'])
-    assert (dqdata[200, 100] == dqflags.pixel['JUMP_DET'])
-    assert (dqdata[300, 100] == dqflags.pixel['DROPOUT'])
-    assert (dqdata[400, 100] == dqflags.pixel['PERSISTENCE'])
-    assert (dqdata[500, 100] == dqflags.pixel['DO_NOT_USE'])
-    assert (dqdata[600, 100] == dqflags.pixel['GW_AFFECTED_DATA'])
-    assert (dqdata[100, 200] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
-    assert (dqdata[200, 200] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
-    assert (dqdata[300, 200] == dqflags.pixel['DROPOUT'] + dqflags.pixel['DO_NOT_USE'])
-    assert (dqdata[400, 200] == dqflags.pixel['PERSISTENCE'] + dqflags.pixel['DO_NOT_USE'])
+    assert dqdata[100, 100] == dqflags.pixel["SATURATED"]
+    assert dqdata[200, 100] == dqflags.pixel["JUMP_DET"]
+    assert dqdata[300, 100] == dqflags.pixel["DROPOUT"]
+    assert dqdata[400, 100] == dqflags.pixel["PERSISTENCE"]
+    assert dqdata[500, 100] == dqflags.pixel["DO_NOT_USE"]
+    assert dqdata[600, 100] == dqflags.pixel["GW_AFFECTED_DATA"]
+    assert dqdata[100, 200] == dqflags.pixel["SATURATED"] + dqflags.pixel["DO_NOT_USE"]
+    assert dqdata[200, 200] == dqflags.pixel["JUMP_DET"] + dqflags.pixel["DO_NOT_USE"]
+    assert dqdata[300, 200] == dqflags.pixel["DROPOUT"] + dqflags.pixel["DO_NOT_USE"]
+    assert dqdata[400, 200] == dqflags.pixel["PERSISTENCE"] + dqflags.pixel["DO_NOT_USE"]
 
 
 def test_groupdq():
     """Check that GROUPDQ extension is added to the data and all values are initialized to zero."""
 
     # size of integration
-    instrument = 'WFI'
+    instrument = "WFI"
     ngroups = 5
     xsize = 1032
     ysize = 1024
@@ -85,7 +86,7 @@ def test_groupdq():
 
     # create a MaskModel elements for the dq input mask
     ref_data = maker_utils.mk_mask(csize[1:])
-    ref_data['meta']['instrument']['name'] = instrument
+    ref_data["meta"]["instrument"]["name"] = instrument
 
     # run the correction step
     outfile = do_dqinit(dm_ramp, ref_data)
@@ -93,15 +94,16 @@ def test_groupdq():
     # check that GROUPDQ was created and initialized to zero
     groupdq = outfile.groupdq
 
-    np.testing.assert_array_equal(np.full((ngroups, ysize, xsize), 0, dtype=int),
-                                  groupdq, err_msg='groupdq not initialized to zero')
+    np.testing.assert_array_equal(
+        np.full((ngroups, ysize, xsize), 0, dtype=int), groupdq, err_msg="groupdq not initialized to zero"
+    )
 
 
 def test_err():
     """Check that a 3-D ERR array is initialized and all values are zero."""
 
     # size of integration
-    instrument = 'WFI'
+    instrument = "WFI"
     ngroups = 5
     xsize = 1032
     ysize = 1024
@@ -113,7 +115,7 @@ def test_err():
 
     # create a MaskModel elements for the dq input mask
     ref_data = maker_utils.mk_mask(csize[1:])
-    ref_data['meta']['instrument']['name'] = instrument
+    ref_data["meta"]["instrument"]["name"] = instrument
 
     # Filter out validation warnings from ref_data
     warnings.filterwarnings("ignore", category=ValidationWarning)
@@ -136,7 +138,7 @@ def test_dq_add1_groupdq():
     """
 
     # size of integration
-    instrument = 'WFI'
+    instrument = "WFI"
     ngroups = 5
     xsize = 1032
     ysize = 1024
@@ -150,38 +152,37 @@ def test_dq_add1_groupdq():
     dq = np.zeros(csize[1:], dtype=np.uint32)
 
     # write reference file with known bad pixel values
-    dq[505, 505] = 1   # Do_not_use
+    dq[505, 505] = 1  # Do_not_use
     dq[400, 500] = 3  # do_not_use and saturated pixel
 
     # write mask model
     ref_data = maker_utils.mk_mask(csize[1:])
-    ref_data['meta']['instrument']['name'] = instrument
+    ref_data["meta"]["instrument"]["name"] = instrument
 
     # Copy in maskmodel elemnts
-    ref_data['dq'] = dq
+    ref_data["dq"] = dq
 
     # set a flag in the pixel dq
-    dm_ramp.pixeldq[505, 505] = 4 # Jump detected pixel
+    dm_ramp.pixeldq[505, 505] = 4  # Jump detected pixel
 
     # run correction step
     outfile = do_dqinit(dm_ramp, ref_data)
 
     # test if pixels in pixeldq were incremented in value by 1
     # check that previous dq flag is added to mask value
-    assert (outfile.pixeldq[505, 505] == dqflags.pixel['JUMP_DET'] + dqflags.pixel['DO_NOT_USE'])
+    assert outfile.pixeldq[505, 505] == dqflags.pixel["JUMP_DET"] + dqflags.pixel["DO_NOT_USE"]
     # check two flags propagate correctly
-    assert (outfile.pixeldq[400, 500] == dqflags.pixel['SATURATED'] + dqflags.pixel['DO_NOT_USE'])
+    assert outfile.pixeldq[400, 500] == dqflags.pixel["SATURATED"] + dqflags.pixel["DO_NOT_USE"]
 
 
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_dqinit_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a DQ reffile"""
@@ -192,10 +193,10 @@ def test_dqinit_step_interface(instrument, exptype):
     # Create test science raw model
     wfi_sci_raw = maker_utils.mk_level1_science_raw(shape)
     wfi_sci_raw.meta.instrument.name = instrument
-    wfi_sci_raw.meta.instrument.detector = 'WFI01'
-    wfi_sci_raw.meta.instrument.optical_element = 'F158'
-    wfi_sci_raw.meta['guidestar']['gw_window_xstart'] = 1012
-    wfi_sci_raw.meta['guidestar']['gw_window_xsize'] = 16
+    wfi_sci_raw.meta.instrument.detector = "WFI01"
+    wfi_sci_raw.meta.instrument.optical_element = "F158"
+    wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
+    wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = u.Quantity(np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
@@ -204,13 +205,13 @@ def test_dqinit_step_interface(instrument, exptype):
     maskref = stnode.MaskRef()
     meta = {}
     maker_utils.add_ref_common(meta)
-    meta['instrument']['optical_element'] = 'F158'
-    meta['instrument']['detector'] = 'WFI01'
-    meta['reftype'] = 'MASK'
-    maskref['meta'] = meta
-    maskref['data'] = np.ones(shape[1:], dtype=np.float32)
-    maskref['dq'] = np.zeros(shape[1:], dtype=np.uint16)
-    maskref['err'] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
+    meta["instrument"]["optical_element"] = "F158"
+    meta["instrument"]["detector"] = "WFI01"
+    meta["reftype"] = "MASK"
+    maskref["meta"] = meta
+    maskref["data"] = np.ones(shape[1:], dtype=np.float32)
+    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
+    maskref["err"] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 
     # Perform Data Quality application step
@@ -219,21 +220,21 @@ def test_dqinit_step_interface(instrument, exptype):
     # Test dq_init results
     assert (result.data == wfi_sci_raw.data).all()
     assert result.pixeldq.shape == shape[1:]
-    assert result.meta.cal_step.dq_init == 'COMPLETE'
+    assert result.meta.cal_step.dq_init == "COMPLETE"
     assert result.data.dtype == np.float32
     assert result.err.dtype == np.float32
     assert result.pixeldq.dtype == np.uint32
     assert result.groupdq.dtype == np.uint8
 
+
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_dqinit_refpix(instrument, exptype):
     """Test that the basic inferface works for data requiring a DQ reffile"""
@@ -244,10 +245,10 @@ def test_dqinit_refpix(instrument, exptype):
     # Create test science raw model
     wfi_sci_raw = maker_utils.mk_level1_science_raw(shape)
     wfi_sci_raw.meta.instrument.name = instrument
-    wfi_sci_raw.meta.instrument.detector = 'WFI01'
-    wfi_sci_raw.meta.instrument.optical_element = 'F158'
-    wfi_sci_raw.meta['guidestar']['gw_window_xstart'] = 1012
-    wfi_sci_raw.meta['guidestar']['gw_window_xsize'] = 16
+    wfi_sci_raw.meta.instrument.detector = "WFI01"
+    wfi_sci_raw.meta.instrument.optical_element = "F158"
+    wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
+    wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = u.Quantity(np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
@@ -256,22 +257,21 @@ def test_dqinit_refpix(instrument, exptype):
     maskref = stnode.MaskRef()
     meta = {}
     maker_utils.add_ref_common(meta)
-    meta['instrument']['optical_element'] = 'F158'
-    meta['instrument']['detector'] = 'WFI01'
-    meta['reftype'] = 'MASK'
-    maskref['meta'] = meta
-    maskref['data'] = np.ones(shape[1:], dtype=np.float32)
-    maskref['dq'] = np.zeros(shape[1:], dtype=np.uint16)
-    maskref['err'] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
+    meta["instrument"]["optical_element"] = "F158"
+    meta["instrument"]["detector"] = "WFI01"
+    meta["reftype"] = "MASK"
+    maskref["meta"] = meta
+    maskref["data"] = np.ones(shape[1:], dtype=np.float32)
+    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
+    maskref["err"] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
-
 
     # Perform Data Quality application step
     result = DQInitStep.call(wfi_sci_raw_model, override_mask=maskref_model)
 
     # check if reference pixels are correct
     assert result.data.shape == (2, 20, 20)  # no pixels should be trimmed
-    assert result.amp33.value.shape == (2, 4096 ,128)
+    assert result.amp33.value.shape == (2, 4096, 128)
     assert result.border_ref_pix_right.shape == (2, 20, 4)
     assert result.border_ref_pix_left.shape == (2, 20, 4)
     assert result.border_ref_pix_top.shape == (2, 4, 20)

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -67,7 +67,9 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     assert dqdata[100, 200] == dqflags.pixel["SATURATED"] + dqflags.pixel["DO_NOT_USE"]
     assert dqdata[200, 200] == dqflags.pixel["JUMP_DET"] + dqflags.pixel["DO_NOT_USE"]
     assert dqdata[300, 200] == dqflags.pixel["DROPOUT"] + dqflags.pixel["DO_NOT_USE"]
-    assert dqdata[400, 200] == dqflags.pixel["PERSISTENCE"] + dqflags.pixel["DO_NOT_USE"]
+    assert (
+        dqdata[400, 200] == dqflags.pixel["PERSISTENCE"] + dqflags.pixel["DO_NOT_USE"]
+    )
 
 
 def test_groupdq():
@@ -95,7 +97,9 @@ def test_groupdq():
     groupdq = outfile.groupdq
 
     np.testing.assert_array_equal(
-        np.full((ngroups, ysize, xsize), 0, dtype=int), groupdq, err_msg="groupdq not initialized to zero"
+        np.full((ngroups, ysize, xsize), 0, dtype=int),
+        groupdq,
+        err_msg="groupdq not initialized to zero",
     )
 
 
@@ -170,9 +174,15 @@ def test_dq_add1_groupdq():
 
     # test if pixels in pixeldq were incremented in value by 1
     # check that previous dq flag is added to mask value
-    assert outfile.pixeldq[505, 505] == dqflags.pixel["JUMP_DET"] + dqflags.pixel["DO_NOT_USE"]
+    assert (
+        outfile.pixeldq[505, 505]
+        == dqflags.pixel["JUMP_DET"] + dqflags.pixel["DO_NOT_USE"]
+    )
     # check two flags propagate correctly
-    assert outfile.pixeldq[400, 500] == dqflags.pixel["SATURATED"] + dqflags.pixel["DO_NOT_USE"]
+    assert (
+        outfile.pixeldq[400, 500]
+        == dqflags.pixel["SATURATED"] + dqflags.pixel["DO_NOT_USE"]
+    )
 
 
 @pytest.mark.parametrize(
@@ -182,7 +192,10 @@ def test_dq_add1_groupdq():
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_dqinit_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a DQ reffile"""
@@ -198,7 +211,9 @@ def test_dqinit_step_interface(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    wfi_sci_raw.data = u.Quantity(
+        np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16
+    )
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Create mask model
@@ -234,7 +249,10 @@ def test_dqinit_step_interface(instrument, exptype):
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_dqinit_refpix(instrument, exptype):
     """Test that the basic inferface works for data requiring a DQ reffile"""
@@ -250,7 +268,9 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    wfi_sci_raw.data = u.Quantity(
+        np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16
+    )
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Create mask model

--- a/romancal/flatfield/__init__.py
+++ b/romancal/flatfield/__init__.py
@@ -1,3 +1,3 @@
 from .flat_field_step import FlatFieldStep
 
-__all__ = ['FlatFieldStep']
+__all__ = ["FlatFieldStep"]

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -3,6 +3,7 @@ Module for applying flat fielding
 """
 
 import logging
+
 import numpy as np
 from astropy import units as u
 from roman_datamodels import units as ru

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -13,7 +13,7 @@ from romancal.lib import dqflags
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-MICRONS_100 = 1.e-4  # 100 microns, in meters
+MICRONS_100 = 1.0e-4  # 100 microns, in meters
 
 
 def do_correction(input_model, flat=None):
@@ -51,24 +51,22 @@ def do_flat_field(output_model, flat_model):
     flat_model : Roman data model
         data model containing flat-field
     """
-    if flat_model is not None and \
-            output_model.data.shape != flat_model.data.shape:
+    if flat_model is not None and output_model.data.shape != flat_model.data.shape:
         # Check to see if flat data array is smaller than science data
-        log.warning('Flat data array is not the same '
-                    'shape as the science data')
-        log.warning('Step will be skipped')
-        output_model.meta.cal_step.flat_field = 'SKIPPED'
+        log.warning("Flat data array is not the same shape as the science data")
+        log.warning("Step will be skipped")
+        output_model.meta.cal_step.flat_field = "SKIPPED"
     elif output_model.meta.exposure.type != "WFI_IMAGE":
         # Check to see if attempt to flatten non-Image data
-        log.info('Skipping flat field for spectral exposure.')
-        output_model.meta.cal_step.flat_field = 'SKIPPED'
+        log.info("Skipping flat field for spectral exposure.")
+        output_model.meta.cal_step.flat_field = "SKIPPED"
     elif flat_model is None:
         # Check to see if attempt to flatten non-Image data
-        log.info('Skipping flat field - no flat reference file.')
-        output_model.meta.cal_step.flat_field = 'SKIPPED'
+        log.info("Skipping flat field - no flat reference file.")
+        output_model.meta.cal_step.flat_field = "SKIPPED"
     else:
         apply_flat_field(output_model, flat_model)
-        output_model.meta.cal_step.flat_field = 'COMPLETE'
+        output_model.meta.cal_step.flat_field = "COMPLETE"
 
 
 def apply_flat_field(science, flat):
@@ -95,17 +93,15 @@ def apply_flat_field(science, flat):
     # Find pixels in the flat that have a value of NaN and set
     # their DQ to NO_FLAT_FIELD
     flat_nan = np.isnan(flat_data)
-    flat_dq[flat_nan] = np.bitwise_or(flat_dq[flat_nan],
-                                      dqflags.pixel['NO_FLAT_FIELD'])
+    flat_dq[flat_nan] = np.bitwise_or(flat_dq[flat_nan], dqflags.pixel["NO_FLAT_FIELD"])
 
     # Find pixels in the flat that have a value of zero, and set
     # their DQ to NO_FLAT_FIELD
-    flat_zero = np.where(flat_data == 0.)
-    flat_dq[flat_zero] = np.bitwise_or(flat_dq[flat_zero],
-                                       dqflags.pixel['NO_FLAT_FIELD'])
+    flat_zero = np.where(flat_data == 0.0)
+    flat_dq[flat_zero] = np.bitwise_or(flat_dq[flat_zero], dqflags.pixel["NO_FLAT_FIELD"])
 
     # Find all pixels in the flat that have a DQ value of NO_FLAT_FIELD
-    flat_bad = np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD'])
+    flat_bad = np.bitwise_and(flat_dq, dqflags.pixel["NO_FLAT_FIELD"])
 
     # Reset the flat value of all bad pixels to 1.0, so that no
     # correction is made
@@ -120,14 +116,12 @@ def apply_flat_field(science, flat):
     science.var_poisson /= flat_data_squared
     science.var_rnoise /= flat_data_squared
     try:
-        science.var_flat = science.data ** 2 / flat_data_squared * flat_err ** 2
+        science.var_flat = science.data**2 / flat_data_squared * flat_err**2
     except AttributeError:
-        science['var_flat'] = np.zeros(shape=science.data.shape,
-                                       dtype=np.float32)
-        science.var_flat = science.data ** 2 / flat_data_squared * flat_err ** 2
+        science["var_flat"] = np.zeros(shape=science.data.shape, dtype=np.float32)
+        science.var_flat = science.data**2 / flat_data_squared * flat_err**2
 
-    science.err = np.sqrt(science.var_poisson +
-                          science.var_rnoise + science.var_flat)
+    science.err = np.sqrt(science.var_poisson + science.var_rnoise + science.var_flat)
 
     # Combine the science and flat DQ arrays
     science.dq = np.bitwise_or(science.dq, flat_dq)

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -98,7 +98,9 @@ def apply_flat_field(science, flat):
     # Find pixels in the flat that have a value of zero, and set
     # their DQ to NO_FLAT_FIELD
     flat_zero = np.where(flat_data == 0.0)
-    flat_dq[flat_zero] = np.bitwise_or(flat_dq[flat_zero], dqflags.pixel["NO_FLAT_FIELD"])
+    flat_dq[flat_zero] = np.bitwise_or(
+        flat_dq[flat_zero], dqflags.pixel["NO_FLAT_FIELD"]
+    )
 
     # Find all pixels in the flat that have a DQ value of NO_FLAT_FIELD
     flat_bad = np.bitwise_and(flat_dq, dqflags.pixel["NO_FLAT_FIELD"])
@@ -108,7 +110,9 @@ def apply_flat_field(science, flat):
     flat_data[np.where(flat_bad)] = 1.0
     # Now let's apply the correction to science data and error arrays.  Rely
     # on array broadcasting to handle the cubes
-    science.data = u.Quantity((science.data.value / flat_data), ru.electron / u.s, dtype=science.data.dtype)
+    science.data = u.Quantity(
+        (science.data.value / flat_data), ru.electron / u.s, dtype=science.data.dtype
+    )
 
     # Update the variances using BASELINE algorithm.  For guider data, it has
     # not gone through ramp fitting so there is no Poisson noise or readnoise

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -11,8 +11,7 @@ __all__ = ["FlatFieldStep"]
 
 
 class FlatFieldStep(RomanStep):
-    """Flat-field a science image using a flatfield reference image.
-    """
+    """Flat-field a science image using a flatfield reference image."""
 
     reference_file_types = ["flat"]
 
@@ -23,17 +22,17 @@ class FlatFieldStep(RomanStep):
         reference_file_name = self.get_reference_file(input_model, "flat")
 
         # Check for a valid reference file
-        if reference_file_name == 'N/A':
-            self.log.warning('No Flat reference file found')
-            self.log.warning('Flat Field step will be skipped')
+        if reference_file_name == "N/A":
+            self.log.warning("No Flat reference file found")
+            self.log.warning("Flat Field step will be skipped")
             reference_file_name = None
 
         if reference_file_name is not None:
             reference_file_model = rdm.open(reference_file_name)
-            self.log.debug(f'Using FLAT ref file: {reference_file_name}')
+            self.log.debug(f"Using FLAT ref file: {reference_file_name}")
         else:
             reference_file_model = None
-            self.log.debug('Using no FLAT ref file')
+            self.log.debug("Using no FLAT ref file")
 
         # Do the flat-field correction
         output_model = flat_field.do_correction(
@@ -50,8 +49,8 @@ class FlatFieldStep(RomanStep):
 
         if self.save_results:
             try:
-                self.suffix = 'flat'
+                self.suffix = "flat"
             except AttributeError:
-                self['suffix'] = 'flat'
+                self["suffix"] = "flat"
 
         return output_model

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -2,9 +2,10 @@
 Flat-field a science image
 """
 
+import roman_datamodels as rdm
+
 from ..stpipe import RomanStep
 from . import flat_field
-import roman_datamodels as rdm
 
 __all__ = ["FlatFieldStep"]
 

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -19,7 +19,9 @@ from romancal.flatfield import FlatFieldStep
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_flatfield_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
@@ -31,12 +33,22 @@ def test_flatfield_step_interface(instrument, exptype):
     wfi_image.meta.instrument.detector = "WFI01"
     wfi_image.meta.instrument.optical_element = "F158"
     wfi_image.meta.exposure.type = exptype
-    wfi_image.data = u.Quantity(np.ones(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    wfi_image.data = u.Quantity(
+        np.ones(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32
+    )
     wfi_image.dq = np.zeros(shape, dtype=np.uint32)
-    wfi_image.err = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
-    wfi_image.var_poisson = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image.var_rnoise = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image.var_flat = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image.err = u.Quantity(
+        np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32
+    )
+    wfi_image.var_poisson = u.Quantity(
+        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+    )
+    wfi_image.var_rnoise = u.Quantity(
+        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+    )
+    wfi_image.var_flat = u.Quantity(
+        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+    )
 
     wfi_image_model = ImageModel(wfi_image)
     flatref = stnode.FlatRef()
@@ -66,7 +78,9 @@ def test_flatfield_step_interface(instrument, exptype):
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_crds_temporal_match(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
@@ -88,7 +102,9 @@ def test_crds_temporal_match(instrument, exptype):
     wfi_image_model.meta.exposure.start_time = Time("2021-09-01T00:11:11.110")
     wfi_image_model.meta.exposure.end_time = Time("2021-09-01T00:33:11.110")
     ref_file_path_b = step.get_reference_file(wfi_image_model, "flat")
-    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(ref_file_path_b.rsplit("/", 1)[1:])
+    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(
+        ref_file_path_b.rsplit("/", 1)[1:]
+    )
 
 
 @pytest.mark.parametrize(
@@ -106,7 +122,9 @@ def test_crds_temporal_match(instrument, exptype):
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 # Test that spectroscopic exposure types will skip flat field step
 def test_spectroscopic_skip(instrument, exptype):

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -1,14 +1,13 @@
 import os
 
-import pytest
 import numpy as np
+import pytest
 from astropy import units as u
 from astropy.time import Time
-
-from roman_datamodels import stnode
-from roman_datamodels.datamodels import ImageModel, FlatRefModel
-from roman_datamodels import maker_utils
+from roman_datamodels import maker_utils, stnode
 from roman_datamodels import units as ru
+from roman_datamodels.datamodels import FlatRefModel, ImageModel
+
 from romancal.flatfield import FlatFieldStep
 
 

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -15,12 +15,11 @@ from romancal.flatfield import FlatFieldStep
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently \
-    available outside the internal network"
+    reason="Roman CRDS servers are not currently available outside the internal network",
 )
 def test_flatfield_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
@@ -29,62 +28,56 @@ def test_flatfield_step_interface(instrument, exptype):
 
     wfi_image = maker_utils.mk_level2_image(shape=shape)
     wfi_image.meta.instrument.name = instrument
-    wfi_image.meta.instrument.detector = 'WFI01'
-    wfi_image.meta.instrument.optical_element = 'F158'
+    wfi_image.meta.instrument.detector = "WFI01"
+    wfi_image.meta.instrument.optical_element = "F158"
     wfi_image.meta.exposure.type = exptype
-    wfi_image.data = u.Quantity(np.ones(shape, dtype=np.float32),
-                                ru.electron / u.s, dtype=np.float32)
+    wfi_image.data = u.Quantity(np.ones(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
     wfi_image.dq = np.zeros(shape, dtype=np.uint32)
-    wfi_image.err = u.Quantity(np.zeros(shape, dtype=np.float32),
-                               ru.electron / u.s, dtype=np.float32)
-    wfi_image.var_poisson = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                       ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image.var_rnoise = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                      ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image.var_flat = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                    ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image.err = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    wfi_image.var_poisson = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image.var_rnoise = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image.var_flat = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
 
     wfi_image_model = ImageModel(wfi_image)
     flatref = stnode.FlatRef()
     meta = {}
     maker_utils.add_ref_common(meta)
-    meta['instrument']['optical_element'] = 'F158'
-    meta['instrument']['detector'] = 'WFI01'
-    meta['reftype'] = 'FLAT'
-    flatref['meta'] = meta
-    flatref['data'] = np.ones(shape, dtype=np.float32)
-    flatref['dq'] = np.zeros(shape, dtype=np.uint16)
-    flatref['err'] = (np.random.random(shape) * 0.05).astype(np.float32)
+    meta["instrument"]["optical_element"] = "F158"
+    meta["instrument"]["detector"] = "WFI01"
+    meta["reftype"] = "FLAT"
+    flatref["meta"] = meta
+    flatref["data"] = np.ones(shape, dtype=np.float32)
+    flatref["dq"] = np.zeros(shape, dtype=np.uint16)
+    flatref["err"] = (np.random.random(shape) * 0.05).astype(np.float32)
     flatref_model = FlatRefModel(flatref)
 
     result = FlatFieldStep.call(wfi_image_model, override_flat=flatref_model)
 
     assert (result.data == wfi_image.data).all()
     assert result.var_flat.shape == shape
-    assert result.meta.cal_step.flat_field == 'COMPLETE'
+    assert result.meta.cal_step.flat_field == "COMPLETE"
 
 
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently \
-    available outside the internal network"
+    reason="Roman CRDS servers are not currently available outside the internal network",
 )
 def test_crds_temporal_match(instrument, exptype):
     """Test that the basic inferface works for data requiring a FLAT reffile"""
 
     wfi_image = maker_utils.mk_level2_image()
     wfi_image.meta.instrument.name = instrument
-    wfi_image.meta.instrument.detector = 'WFI01'
-    wfi_image.meta.instrument.optical_element = 'F158'
+    wfi_image.meta.instrument.detector = "WFI01"
+    wfi_image.meta.instrument.optical_element = "F158"
 
-    wfi_image.meta.exposure.start_time = Time('2020-01-02T11:11:11.110')
-    wfi_image.meta.exposure.end_time = Time('2020-01-02T11:33:11.110')
+    wfi_image.meta.exposure.start_time = Time("2020-01-02T11:11:11.110")
+    wfi_image.meta.exposure.end_time = Time("2020-01-02T11:33:11.110")
 
     wfi_image.meta.exposure.type = exptype
     wfi_image_model = ImageModel(wfi_image)
@@ -92,36 +85,41 @@ def test_crds_temporal_match(instrument, exptype):
     step = FlatFieldStep()
     ref_file_path = step.get_reference_file(wfi_image_model, "flat")
 
-    wfi_image_model.meta.exposure.start_time = Time('2021-09-01T00:11:11.110')
-    wfi_image_model.meta.exposure.end_time = Time('2021-09-01T00:33:11.110')
+    wfi_image_model.meta.exposure.start_time = Time("2021-09-01T00:11:11.110")
+    wfi_image_model.meta.exposure.end_time = Time("2021-09-01T00:33:11.110")
     ref_file_path_b = step.get_reference_file(wfi_image_model, "flat")
-    assert ("/".join(ref_file_path.rsplit("/", 1)[1:])) != \
-           ("/".join(ref_file_path_b.rsplit("/", 1)[1:]))
+    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(ref_file_path_b.rsplit("/", 1)[1:])
 
 
 @pytest.mark.parametrize(
-    "instrument", ["WFI", ]
+    "instrument",
+    [
+        "WFI",
+    ],
 )
 @pytest.mark.parametrize(
-    "exptype", ["WFI_GRISM", "WFI_PRISM", ]
+    "exptype",
+    [
+        "WFI_GRISM",
+        "WFI_PRISM",
+    ],
 )
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently \
-    available outside the internal network"
+    reason="Roman CRDS servers are not currently available outside the internal network",
 )
 # Test that spectroscopic exposure types will skip flat field step
 def test_spectroscopic_skip(instrument, exptype):
     wfi_image = maker_utils.mk_level2_image()
     wfi_image.meta.instrument.name = instrument
-    wfi_image.meta.instrument.detector = 'WFI01'
-    wfi_image.meta.instrument.optical_element = 'F158'
+    wfi_image.meta.instrument.detector = "WFI01"
+    wfi_image.meta.instrument.optical_element = "F158"
 
-    wfi_image.meta.exposure.start_time = Time('2020-02-01T00:00:00.000')
-    wfi_image.meta.exposure.end_time = Time('2020-02-01T00:00:05.000')
+    wfi_image.meta.exposure.start_time = Time("2020-02-01T00:00:00.000")
+    wfi_image.meta.exposure.end_time = Time("2020-02-01T00:00:05.000")
 
     wfi_image.meta.exposure.type = exptype
     wfi_image_model = ImageModel(wfi_image)
 
     result = FlatFieldStep.call(wfi_image_model)
-    assert result.meta.cal_step.flat_field == 'SKIPPED'
+    assert result.meta.cal_step.flat_field == "SKIPPED"

--- a/romancal/jump/__init__.py
+++ b/romancal/jump/__init__.py
@@ -1,3 +1,3 @@
 from .jump_step import JumpStep
 
-__all__ = ['JumpStep']
+__all__ = ["JumpStep"]

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -2,15 +2,16 @@
 Detect jumps in a science image
 """
 
-from roman_datamodels import datamodels as rdd
-import numpy as np
+import logging
 import time
 
-from romancal.stpipe import RomanStep
-from romancal.lib import dqflags
+import numpy as np
+from roman_datamodels import datamodels as rdd
 from stcal.jump.jump import detect_jumps
 
-import logging
+from romancal.lib import dqflags
+from romancal.stpipe import RomanStep
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -39,7 +39,7 @@ class JumpStep(RomanStep):
         use_ellipses = boolean(default=False) # Use an enclosing ellipse rather than a circle for MIRI showers
         sat_required_snowball = boolean(default=True) # Require the center of snowballs to be saturated
         expand_large_events = boolean(default=False) # must be True to trigger snowball and shower flagging
-    """
+    """  # noqa: E501
 
     reference_file_types = ["gain", "readnoise"]
 

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -41,7 +41,7 @@ class JumpStep(RomanStep):
         expand_large_events = boolean(default=False) # must be True to trigger snowball and shower flagging
     """
 
-    reference_file_types = ['gain', 'readnoise']
+    reference_file_types = ["gain", "readnoise"]
 
     def process(self, input):
 
@@ -70,12 +70,12 @@ class JumpStep(RomanStep):
             ngroups = data.shape[1]
 
             if ngroups <= 2:
-                self.log.warning('Cannot apply jump detection as NGROUPS<=2;')
-                self.log.warning('Jump step will be skipped')
+                self.log.warning("Cannot apply jump detection as NGROUPS<=2;")
+                self.log.warning("Jump step will be skipped")
 
                 result = input_model
 
-                result.meta.cal_step.jump = 'SKIPPED'
+                result.meta.cal_step.jump = "SKIPPED"
                 return result
 
             # Retrieve the parameter values
@@ -93,20 +93,18 @@ class JumpStep(RomanStep):
             sat_required_snowball = self.sat_required_snowball
             expand_large_events = self.expand_large_events
 
-            self.log.info('CR rejection threshold = %g sigma', rej_thresh)
-            if self.maximum_cores != 'none':
-                self.log.info('Maximum cores to use = %s', max_cores)
+            self.log.info("CR rejection threshold = %g sigma", rej_thresh)
+            if self.maximum_cores != "none":
+                self.log.info("Maximum cores to use = %s", max_cores)
 
             # Get the gain and readnoise reference files
-            gain_filename = self.get_reference_file(input_model, 'gain')
-            self.log.info('Using GAIN reference file: %s', gain_filename)
+            gain_filename = self.get_reference_file(input_model, "gain")
+            self.log.info("Using GAIN reference file: %s", gain_filename)
             gain_model = rdd.GainRefModel(gain_filename)
             gain_2d = gain_model.data.value
 
-            readnoise_filename = self.get_reference_file(input_model,
-                                                         'readnoise')
-            self.log.info('Using READNOISE reference file: %s',
-                          readnoise_filename)
+            readnoise_filename = self.get_reference_file(input_model, "readnoise")
+            self.log.info("Using READNOISE reference file: %s", readnoise_filename)
             readnoise_model = rdd.ReadnoiseRefModel(readnoise_filename)
             # This is to clear the WRITEABLE=False flag?
             readnoise_2d = np.copy(readnoise_model.data.value)
@@ -119,21 +117,32 @@ class JumpStep(RomanStep):
                 "DO_NOT_USE": dqflags.group["DO_NOT_USE"],
                 "SATURATED": dqflags.group["SATURATED"],
                 "JUMP_DET": dqflags.group["JUMP_DET"],
-                "NO_GAIN_VALUE": dqflags.pixel["NO_GAIN_VALUE"]
+                "NO_GAIN_VALUE": dqflags.pixel["NO_GAIN_VALUE"],
             }
 
-            gdq, pdq = detect_jumps(frames_per_group, data, gdq, pdq, err,
-                                    gain_2d, readnoise_2d, rej_thresh,
-                                    three_grp_rej_thresh, four_grp_rej_thresh,
-                                    max_cores,
-                                    max_jump_to_flag_neighbors,
-                                    min_jump_to_flag_neighbors,
-                                    flag_4_neighbors,
-                                    dqflags_d,
-                                    min_sat_area=min_sat_area, min_jump_area=min_jump_area,
-                                    expand_factor=expand_factor, use_ellipses=use_ellipses,
-                                    sat_required_snowball=sat_required_snowball,
-                                    expand_large_events=expand_large_events)
+            gdq, pdq = detect_jumps(
+                frames_per_group,
+                data,
+                gdq,
+                pdq,
+                err,
+                gain_2d,
+                readnoise_2d,
+                rej_thresh,
+                three_grp_rej_thresh,
+                four_grp_rej_thresh,
+                max_cores,
+                max_jump_to_flag_neighbors,
+                min_jump_to_flag_neighbors,
+                flag_4_neighbors,
+                dqflags_d,
+                min_sat_area=min_sat_area,
+                min_jump_area=min_jump_area,
+                expand_factor=expand_factor,
+                use_ellipses=use_ellipses,
+                sat_required_snowball=sat_required_snowball,
+                expand_large_events=expand_large_events,
+            )
 
             gdq = gdq[0, :, :, :]
             pdq = pdq[0, :, :]
@@ -142,13 +151,13 @@ class JumpStep(RomanStep):
             gain_model.close()
             readnoise_model.close()
             tstop = time.time()
-            self.log.info('The execution time in seconds: %f', tstop - tstart)
+            self.log.info("The execution time in seconds: %f", tstop - tstart)
 
-        result.meta.cal_step.jump = 'COMPLETE'
+        result.meta.cal_step.jump = "COMPLETE"
 
         if self.save_results:
             try:
-                self.suffix = 'jump'
+                self.suffix = "jump"
             except AttributeError:
-                self['suffix'] = 'jump'
+                self["suffix"] = "jump"
         return result

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -4,17 +4,15 @@
 import os
 from itertools import cycle
 
-import pytest
 import numpy as np
-from astropy.time import Time
-from astropy import units as u
-
+import pytest
 import roman_datamodels.stnode as rds
+from astropy import units as u
+from astropy.time import Time
 from roman_datamodels import datamodels as rdm
-from roman_datamodels.datamodels import GainRefModel
-from roman_datamodels.datamodels import ReadnoiseRefModel
 from roman_datamodels import maker_utils
 from roman_datamodels import units as ru
+from roman_datamodels.datamodels import GainRefModel, ReadnoiseRefModel
 
 from romancal.jump import JumpStep
 

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -16,17 +16,16 @@ from roman_datamodels.datamodels import GainRefModel, ReadnoiseRefModel
 
 from romancal.jump import JumpStep
 
-MAXIMUM_CORES = ['none', 'quarter', 'half', 'all']
+MAXIMUM_CORES = ["none", "quarter", "half", "all"]
 
 
 @pytest.fixture(scope="module")
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def generate_wfi_reffiles(tmpdir_factory):
     gainfile = str(tmpdir_factory.mktemp("ndata").join("gain.asdf"))
-    readnoisefile = str(tmpdir_factory.mktemp("ndata").join('readnoise.asdf'))
+    readnoisefile = str(tmpdir_factory.mktemp("ndata").join("readnoise.asdf"))
 
     ingain = 6
     xsize = 20
@@ -38,18 +37,18 @@ def generate_wfi_reffiles(tmpdir_factory):
     gain_ref = rds.GainRef()
     meta = {}
     maker_utils.add_ref_common(meta)
-    meta['instrument']['detector'] = 'WFI01'
-    meta['instrument']['name'] = 'WFI'
-    meta['author'] = 'John Doe'
-    meta['reftype'] = 'GAIN'
-    meta['pedigree'] = 'DUMMY'
-    meta['description'] = 'DUMMY'
-    meta['useafter'] = Time('2022-01-01T11:11:11.111')
+    meta["instrument"]["detector"] = "WFI01"
+    meta["instrument"]["name"] = "WFI"
+    meta["author"] = "John Doe"
+    meta["reftype"] = "GAIN"
+    meta["pedigree"] = "DUMMY"
+    meta["description"] = "DUMMY"
+    meta["useafter"] = Time("2022-01-01T11:11:11.111")
 
-    gain_ref['meta'] = meta
-    gain_ref['data'] = u.Quantity(np.ones(shape, dtype=np.float32) * ingain, ru.electron / ru.DN, dtype=np.float32)
-    gain_ref['dq'] = np.zeros(shape, dtype=np.uint16)
-    gain_ref['err'] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float64), ru.electron / ru.DN, dtype=np.float64)
+    gain_ref["meta"] = meta
+    gain_ref["data"] = u.Quantity(np.ones(shape, dtype=np.float32) * ingain, ru.electron / ru.DN, dtype=np.float32)
+    gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
+    gain_ref["err"] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float64), ru.electron / ru.DN, dtype=np.float64)
 
     gain_ref_model = GainRefModel(gain_ref)
     gain_ref_model.save(gainfile)
@@ -58,21 +57,21 @@ def generate_wfi_reffiles(tmpdir_factory):
     rn_ref = rds.ReadnoiseRef()
     meta = {}
     maker_utils.add_ref_common(meta)
-    meta['instrument']['detector'] = 'WFI01'
-    meta['instrument']['name'] = 'WFI'
-    meta['author'] = 'John Doe'
-    meta['reftype'] = 'READNOISE'
-    meta['pedigree'] = 'DUMMY'
-    meta['description'] = 'DUMMY'
-    meta['useafter'] = Time('2022-01-01T11:11:11.111')
-    meta['exposure'] = {}
-    meta['exposure']['type'] = 'WFI_IMAGE'
-    meta['exposure']['p_exptype'] = 'WFI_IMAGE|WFI_GRISM|WFI_PRISM|'
+    meta["instrument"]["detector"] = "WFI01"
+    meta["instrument"]["name"] = "WFI"
+    meta["author"] = "John Doe"
+    meta["reftype"] = "READNOISE"
+    meta["pedigree"] = "DUMMY"
+    meta["description"] = "DUMMY"
+    meta["useafter"] = Time("2022-01-01T11:11:11.111")
+    meta["exposure"] = {}
+    meta["exposure"]["type"] = "WFI_IMAGE"
+    meta["exposure"]["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
-    rn_ref['meta'] = meta
-    rn_ref['data'] = u.Quantity(np.ones(shape, dtype=np.float32), ru.DN, dtype=np.float32)
-    rn_ref['dq'] = np.zeros(shape, dtype=np.uint16)
-    rn_ref['err'] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float64), ru.DN, dtype=np.float64)
+    rn_ref["meta"] = meta
+    rn_ref["data"] = u.Quantity(np.ones(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    rn_ref["dq"] = np.zeros(shape, dtype=np.uint16)
+    rn_ref["err"] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float64), ru.DN, dtype=np.float64)
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)
     rn_ref_model.save(readnoisefile)
@@ -82,13 +81,10 @@ def generate_wfi_reffiles(tmpdir_factory):
 
 @pytest.fixture
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def setup_inputs():
-
-    def _setup(ngroups=10, readnoise=10, nrows=20, ncols=20,
-               nframes=1, grouptime=1.0, gain=1, deltatime=1):
+    def _setup(ngroups=10, readnoise=10, nrows=20, ncols=20, nframes=1, grouptime=1.0, gain=1, deltatime=1):
 
         err = np.ones(shape=(ngroups, nrows, ncols), dtype=np.float32)
         data = np.zeros(shape=(ngroups, nrows, ncols), dtype=np.float32)
@@ -98,22 +94,22 @@ def setup_inputs():
         csize = (ngroups, nrows, ncols)
         dm_ramp = rdm.RampModel(maker_utils.mk_ramp(csize))
 
-        dm_ramp.meta.instrument.name = 'WFI'
-        dm_ramp.meta.instrument.optical_element = 'F158'
+        dm_ramp.meta.instrument.name = "WFI"
+        dm_ramp.meta.instrument.optical_element = "F158"
 
-        dm_ramp.data = u.Quantity(data + 6., ru.DN, dtype=np.float32)
+        dm_ramp.data = u.Quantity(data + 6.0, ru.DN, dtype=np.float32)
         dm_ramp.pixeldq = pixdq
         dm_ramp.groupdq = gdq
         dm_ramp.err = u.Quantity(err, ru.DN, dtype=np.float32)
 
-        dm_ramp.meta.exposure.type = 'WFI_IMAGE'
+        dm_ramp.meta.exposure.type = "WFI_IMAGE"
         dm_ramp.meta.exposure.group_time = deltatime
         dm_ramp.meta.exposure.frame_time = deltatime
         dm_ramp.meta.exposure.ngroups = ngroups
         dm_ramp.meta.exposure.nframes = 1
         dm_ramp.meta.exposure.groupgap = 0
-        dm_ramp.meta.cal_step['dq_init'] = 'INCOMPLETE'
-        dm_ramp.meta.cal_step['jump'] = 'INCOMPLETE'
+        dm_ramp.meta.cal_step["dq_init"] = "INCOMPLETE"
+        dm_ramp.meta.cal_step["jump"] = "INCOMPLETE"
 
         return dm_ramp
 
@@ -122,8 +118,7 @@ def setup_inputs():
 
 @pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_one_CR(generate_wfi_reffiles, max_cores, setup_inputs):
     override_gain, override_readnoise = generate_wfi_reffiles
@@ -131,15 +126,13 @@ def test_one_CR(generate_wfi_reffiles, max_cores, setup_inputs):
     grouptime = 3.0
     deltaDN = 5
     ingain = 200
-    inreadnoise = 7.
+    inreadnoise = 7.0
     ngroups = 100
     CR_fraction = 3
     xsize = 20
     ysize = 20
 
-    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize,
-                          gain=ingain, readnoise=inreadnoise,
-                          deltatime=grouptime)
+    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
 
     for i in range(ngroups):
         model1.data[i, :, :] = deltaDN * i * model1.data.unit
@@ -154,25 +147,22 @@ def test_one_CR(generate_wfi_reffiles, max_cores, setup_inputs):
     # Add CRs to the SCI data
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
-        model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = \
-            model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500. * model1.data.unit
+        model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = (
+            model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500.0 * model1.data.unit
+        )
 
-    out_model = JumpStep.call(model1, override_gain=override_gain,
-                              override_readnoise=override_readnoise,
-                              maximum_cores=max_cores)
+    out_model = JumpStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores=max_cores)
 
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
 
-        assert (4 == np.max(out_model.groupdq[CR_group, CR_y_locs[i],
-                CR_x_locs[i]]))
+        assert 4 == np.max(out_model.groupdq[CR_group, CR_y_locs[i], CR_x_locs[i]])
 
 
 @pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_two_CRs(generate_wfi_reffiles, max_cores, setup_inputs):
     override_gain, override_readnoise = generate_wfi_reffiles
@@ -180,15 +170,13 @@ def test_two_CRs(generate_wfi_reffiles, max_cores, setup_inputs):
     grouptime = 3.0
     deltaDN = 5
     ingain = 6
-    inreadnoise = 7.
+    inreadnoise = 7.0
     ngroups = 100
     CR_fraction = 5
     xsize = 20
     ysize = 20
 
-    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize,
-                          gain=ingain, readnoise=inreadnoise,
-                          deltatime=grouptime)
+    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
 
     for i in range(ngroups):
         model1.data[i, :, :] = deltaDN * i * model1.data.unit
@@ -202,29 +190,26 @@ def test_two_CRs(generate_wfi_reffiles, max_cores, setup_inputs):
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
 
-        model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = \
+        model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = (
             model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500 * model1.data.unit
-        model1.data[CR_group + 8:, CR_y_locs[i], CR_x_locs[i]] = \
-            model1.data[CR_group + 8:, CR_y_locs[i], CR_x_locs[i]] + 700 * model1.data.unit
+        )
+        model1.data[CR_group + 8 :, CR_y_locs[i], CR_x_locs[i]] = (
+            model1.data[CR_group + 8 :, CR_y_locs[i], CR_x_locs[i]] + 700 * model1.data.unit
+        )
 
-    out_model = JumpStep.call(model1, override_gain=override_gain,
-                              override_readnoise=override_readnoise,
-                              maximum_cores=max_cores)
+    out_model = JumpStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores=max_cores)
 
     CR_pool = cycle(first_CR_group_locs)
     for i in range(len(CR_x_locs)):
         CR_group = next(CR_pool)
 
-        assert (4 == np.max(out_model.groupdq[CR_group, CR_y_locs[i],
-               CR_x_locs[i]]))
-        assert (4 == np.max(out_model.groupdq[CR_group + 8, CR_y_locs[i],
-               CR_x_locs[i]]))
+        assert 4 == np.max(out_model.groupdq[CR_group, CR_y_locs[i], CR_x_locs[i]])
+        assert 4 == np.max(out_model.groupdq[CR_group + 8, CR_y_locs[i], CR_x_locs[i]])
 
 
 @pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_two_group_integration(generate_wfi_reffiles, max_cores, setup_inputs):
 
@@ -235,20 +220,15 @@ def test_two_group_integration(generate_wfi_reffiles, max_cores, setup_inputs):
     ngroups = 2
     xsize = 20
     ysize = 20
-    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize,
-                          gain=ingain, readnoise=inreadnoise,
-                          deltatime=grouptime)
+    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
 
-    out_model = JumpStep.call(model1, override_gain=override_gain,
-                              override_readnoise=override_readnoise,
-                              maximum_cores=max_cores)
+    out_model = JumpStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores=max_cores)
 
-    assert out_model.meta.cal_step['jump'] == 'SKIPPED'
+    assert out_model.meta.cal_step["jump"] == "SKIPPED"
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_four_group_integration(generate_wfi_reffiles, setup_inputs):
 
@@ -259,20 +239,15 @@ def test_four_group_integration(generate_wfi_reffiles, setup_inputs):
     ngroups = 4
     xsize = 20
     ysize = 20
-    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize,
-                          gain=ingain, readnoise=inreadnoise,
-                          deltatime=grouptime)
+    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
 
-    out_model = JumpStep.call(model1, override_gain=override_gain,
-                              override_readnoise=override_readnoise,
-                              maximum_cores='none')
+    out_model = JumpStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores="none")
 
-    assert out_model.meta.cal_step['jump'] == 'COMPLETE'
+    assert out_model.meta.cal_step["jump"] == "COMPLETE"
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_three_group_integration(generate_wfi_reffiles, setup_inputs):
 
@@ -283,12 +258,8 @@ def test_three_group_integration(generate_wfi_reffiles, setup_inputs):
     ngroups = 3
     xsize = 20
     ysize = 20
-    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize,
-                          gain=ingain, readnoise=inreadnoise,
-                          deltatime=grouptime)
+    model1 = setup_inputs(ngroups=ngroups, nrows=ysize, ncols=xsize, gain=ingain, readnoise=inreadnoise, deltatime=grouptime)
 
-    out_model = JumpStep.call(model1, override_gain=override_gain,
-                              override_readnoise=override_readnoise,
-                              maximum_cores='none')
+    out_model = JumpStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores="none")
 
-    assert out_model.meta.cal_step.jump == 'COMPLETE'
+    assert out_model.meta.cal_step.jump == "COMPLETE"

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -1,6 +1,7 @@
 """General utility objects"""
 
 import numpy as np
+
 from romancal.lib import dqflags
 
 SATURATEDPIX = dqflags.pixel['SATURATED']

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -4,8 +4,9 @@ import numpy as np
 
 from romancal.lib import dqflags
 
-SATURATEDPIX = dqflags.pixel['SATURATED']
-SATURATEDGRP = dqflags.group['SATURATED']
+SATURATEDPIX = dqflags.pixel["SATURATED"]
+SATURATEDGRP = dqflags.group["SATURATED"]
+
 
 def bytes2human(n):
     """Convert bytes to human-readable format
@@ -31,14 +32,14 @@ def bytes2human(n):
     >>> bytes2human(100001221)
         '95.4M'
     """
-    symbols = ('K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+    symbols = ("K", "M", "G", "T", "P", "E", "Z", "Y")
     prefix = {}
     for i, s in enumerate(symbols):
         prefix[s] = 1 << (i + 1) * 10
     for s in reversed(symbols):
         if n >= prefix[s]:
             value = float(n) / prefix[s]
-            return f'{value:.1f}{s}'
+            return f"{value:.1f}{s}"
     return "%sB" % n
 
 

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -40,7 +40,7 @@ def bytes2human(n):
         if n >= prefix[s]:
             value = float(n) / prefix[s]
             return f"{value:.1f}{s}"
-    return "%sB" % n
+    return f"{n}B"
 
 
 def is_fully_saturated(model):

--- a/romancal/lib/dqflags.py
+++ b/romancal/lib/dqflags.py
@@ -21,46 +21,48 @@ the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 # for this file drop E241 (multiple spaces after :, for readability)
 # flake8: noqa: E241
 # Pixel-specific flags
-pixel = {'GOOD':             0,      # No bits set, all is good
-         'DO_NOT_USE':       2**0,   # Bad pixel. Do not use.
-         'SATURATED':        2**1,   # Pixel saturated during exposure
-         'JUMP_DET':         2**2,   # Jump detected during exposure
-         'DROPOUT':          2**3,   # Data lost in transmission
-         'GW_AFFECTED_DATA': 2**4,   # Data affected by the GW read window
-         'PERSISTENCE':      2**5,   # High persistence (was RESERVED_2)
-         'AD_FLOOR':         2**6,   # Below A/D floor (0 DN, was RESERVED_3)
-         'RESERVED_4':       2**7,   #
-         'UNRELIABLE_ERROR': 2**8,   # Uncertainty exceeds quoted error
-         'NON_SCIENCE':      2**9,   # Pixel not on science portion of detector
-         'DEAD':             2**10,  # Dead pixel
-         'HOT':              2**11,  # Hot pixel
-         'WARM':             2**12,  # Warm pixel
-         'LOW_QE':           2**13,  # Low quantum efficiency
-         'TELEGRAPH':        2**15,  # Telegraph pixel
-         'NONLINEAR':        2**16,  # Pixel highly nonlinear
-         'BAD_REF_PIXEL':    2**17,  # Reference pixel cannot be used
-         'NO_FLAT_FIELD':    2**18,  # Flat field cannot be measured
-         'NO_GAIN_VALUE':    2**19,  # Gain cannot be measured
-         'NO_LIN_CORR':      2**20,  # Linearity correction not available
-         'NO_SAT_CHECK':     2**21,  # Saturation check not available
-         'UNRELIABLE_BIAS':  2**22,  # Bias variance large
-         'UNRELIABLE_DARK':  2**23,  # Dark variance large
-         'UNRELIABLE_SLOPE': 2**24,  # Slope variance large (i.e., noisy pixel)
-         'UNRELIABLE_FLAT':  2**25,  # Flat variance large
-         'RESERVED_5':       2**26,  #
-         'RESERVED_6':       2**27,  #
-         'UNRELIABLE_RESET': 2**28,  # Sensitive to reset anomaly
-         'RESERVED_7':       2**29,  #
-         'OTHER_BAD_PIXEL':  2**30,  # A catch-all flag
-         'REFERENCE_PIXEL':  2**31,  # Pixel is a reference pixel
-         }
+pixel = {
+    "GOOD": 0,  # No bits set, all is good
+    "DO_NOT_USE": 2**0,  # Bad pixel. Do not use.
+    "SATURATED": 2**1,  # Pixel saturated during exposure
+    "JUMP_DET": 2**2,  # Jump detected during exposure
+    "DROPOUT": 2**3,  # Data lost in transmission
+    "GW_AFFECTED_DATA": 2**4,  # Data affected by the GW read window
+    "PERSISTENCE": 2**5,  # High persistence (was RESERVED_2)
+    "AD_FLOOR": 2**6,  # Below A/D floor (0 DN, was RESERVED_3)
+    "RESERVED_4": 2**7,  #
+    "UNRELIABLE_ERROR": 2**8,  # Uncertainty exceeds quoted error
+    "NON_SCIENCE": 2**9,  # Pixel not on science portion of detector
+    "DEAD": 2**10,  # Dead pixel
+    "HOT": 2**11,  # Hot pixel
+    "WARM": 2**12,  # Warm pixel
+    "LOW_QE": 2**13,  # Low quantum efficiency
+    "TELEGRAPH": 2**15,  # Telegraph pixel
+    "NONLINEAR": 2**16,  # Pixel highly nonlinear
+    "BAD_REF_PIXEL": 2**17,  # Reference pixel cannot be used
+    "NO_FLAT_FIELD": 2**18,  # Flat field cannot be measured
+    "NO_GAIN_VALUE": 2**19,  # Gain cannot be measured
+    "NO_LIN_CORR": 2**20,  # Linearity correction not available
+    "NO_SAT_CHECK": 2**21,  # Saturation check not available
+    "UNRELIABLE_BIAS": 2**22,  # Bias variance large
+    "UNRELIABLE_DARK": 2**23,  # Dark variance large
+    "UNRELIABLE_SLOPE": 2**24,  # Slope variance large (i.e., noisy pixel)
+    "UNRELIABLE_FLAT": 2**25,  # Flat variance large
+    "RESERVED_5": 2**26,  #
+    "RESERVED_6": 2**27,  #
+    "UNRELIABLE_RESET": 2**28,  # Sensitive to reset anomaly
+    "RESERVED_7": 2**29,  #
+    "OTHER_BAD_PIXEL": 2**30,  # A catch-all flag
+    "REFERENCE_PIXEL": 2**31,  # Pixel is a reference pixel
+}
 
 # Group-specific flags. Once groups are combined, these flags
 # are equivalent to the pixel-specific flags.
-group = {'GOOD':       pixel['GOOD'],
-         'DO_NOT_USE': pixel['DO_NOT_USE'],
-         'SATURATED':  pixel['SATURATED'],
-         'JUMP_DET':   pixel['JUMP_DET'],
-         'DROPOUT':    pixel['DROPOUT'],
-         'AD_FLOOR':   pixel['AD_FLOOR'],
-         }
+group = {
+    "GOOD": pixel["GOOD"],
+    "DO_NOT_USE": pixel["DO_NOT_USE"],
+    "SATURATED": pixel["SATURATED"],
+    "JUMP_DET": pixel["JUMP_DET"],
+    "DROPOUT": pixel["DROPOUT"],
+    "AD_FLOOR": pixel["AD_FLOOR"],
+}

--- a/romancal/lib/progress.py
+++ b/romancal/lib/progress.py
@@ -8,7 +8,7 @@ If the module is not available, then stub it out.
 """
 import logging
 
-__all__ = ['Bar']
+__all__ = ["Bar"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -17,6 +17,7 @@ logger.addHandler(logging.NullHandler())
 
 class _BarStub:
     """Stub the Bar functionality"""
+
     def __init__(self, *args, **kwargs):
         pass
 

--- a/romancal/lib/signal_slot.py
+++ b/romancal/lib/signal_slot.py
@@ -80,7 +80,9 @@ class Signal:
             try:
                 yield slot(*args, **kwargs)
             except Exception as exception:
-                logger.debug(f"Signal {self.__class__.__name_}: Slot {slot} raised {exception}")
+                logger.debug(
+                    f"Signal {self.__class__.__name_}: Slot {slot} raised {exception}"
+                )
 
     def reduce(self, *args, **kwargs):
         """Return a reduction of all the slots

--- a/romancal/lib/signal_slot.py
+++ b/romancal/lib/signal_slot.py
@@ -1,9 +1,8 @@
 """ A signal/slot implementation
 """
-from collections import namedtuple
 import inspect
 import logging
-
+from collections import namedtuple
 
 __all__ = ['Signal',
            'Signals',

--- a/romancal/lib/signal_slot.py
+++ b/romancal/lib/signal_slot.py
@@ -4,9 +4,7 @@ import inspect
 import logging
 from collections import namedtuple
 
-__all__ = ['Signal',
-           'Signals',
-           'SignalsNotAClass']
+__all__ = ["Signal", "Signals", "SignalsNotAClass"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -14,10 +12,10 @@ logger.addHandler(logging.NullHandler())
 
 """Slot data structure
 """
-Slot = namedtuple('Slot', ['func', 'single_shot'])
+Slot = namedtuple("Slot", ["func", "single_shot"])
 
 
-class Signal():
+class Signal:
     """Signal
 
     A Signal, when triggered, call the connected slots.
@@ -82,13 +80,7 @@ class Signal():
             try:
                 yield slot(*args, **kwargs)
             except Exception as exception:
-                logger.debug(
-                    'Signal {}: Slot {} raised {}'.format(
-                        self.__class__.__name_,
-                        slot,
-                        exception
-                    )
-                )
+                logger.debug(f"Signal {self.__class__.__name_}: Slot {slot} raised {exception}")
 
     def reduce(self, *args, **kwargs):
         """Return a reduction of all the slots
@@ -125,7 +117,7 @@ class Signal():
             result = slot(*args, **kwargs)
             args = result
             if not isinstance(args, tuple):
-                args = (args, )
+                args = (args,)
         return result
 
     @property
@@ -164,18 +156,11 @@ class Signal():
         single_shot: bool
             If True, the function/method is removed after being called.
         """
-        slot = Slot(
-            func=func,
-            single_shot=single_shot
-        )
+        slot = Slot(func=func, single_shot=single_shot)
         self._slots.append(slot)
 
     def disconnect(self, func):
-        self._slots = [
-            slot
-            for slot in self._slots
-            if slot.func != func
-        ]
+        self._slots = [slot for slot in self._slots if slot.func != func]
 
     def clear(self, single_shot=False):
         """Clear slots
@@ -186,19 +171,11 @@ class Signal():
             If True, only remove single shot
             slots.
         """
-        logger.debug(
-            'Signal {}: Clearing slots'.format(
-                self.__class__.__name__
-            )
-        )
+        logger.debug(f"Signal {self.__class__.__name__}: Clearing slots")
         if not single_shot:
             self._slots.clear()
         else:
-            self._slots = [
-                slot
-                for slot in self._slots
-                if not slot.single_shot
-            ]
+            self._slots = [slot for slot in self._slots if not slot.single_shot]
 
     @property
     def slots(self):
@@ -214,18 +191,14 @@ class Signal():
                 yield slot.func
         finally:
             # Clean out single shots
-            self._slots = [
-                slot
-                for slot in self._slots
-                if not slot.single_shot
-            ]
+            self._slots = [slot for slot in self._slots if not slot.single_shot]
             self.reset_enabled()
 
 
 class SignalsErrorBase(Exception):
-    '''Base Signals Error'''
+    """Base Signals Error"""
 
-    default_message = ''
+    default_message = ""
 
     def __init__(self, *args):
         if len(args):
@@ -235,12 +208,13 @@ class SignalsErrorBase(Exception):
 
 
 class SignalsNotAClass(SignalsErrorBase):
-    '''Must add a Signal Class'''
-    default_message = 'Signal must be a class.'
+    """Must add a Signal Class"""
+
+    default_message = "Signal must be a class."
 
 
 class Signals(dict):
-    '''Manage the signals.'''
+    """Manage the signals."""
 
     def __setitem__(self, key, value):
         if key not in self:
@@ -252,7 +226,7 @@ class Signals(dict):
         for signal in self:
             if signal.__name__ == key:
                 return self[signal]
-        raise KeyError(f'{key}')
+        raise KeyError(f"{key}")
 
     def add(self, signal_class, *args, **kwargs):
         if inspect.isclass(signal_class):

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -122,7 +122,9 @@ def replace_suffix(name, new_suffix):
 # #####################################
 # Functions to generate `KNOW_SUFFIXES`
 # #####################################
-def combine_suffixes(to_add=(_calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,)):
+def combine_suffixes(
+    to_add=(_calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,)
+):
     """Combine the suffix lists into a single list
 
     Parameters
@@ -181,7 +183,9 @@ def find_suffixes():
 KNOW_SUFFIXES = combine_suffixes()
 
 # Regex for removal
-REMOVE_SUFFIX_REGEX = re.compile("^(?P<root>.+?)((?P<separator>_|-)(" + "|".join(KNOW_SUFFIXES) + "))?$")
+REMOVE_SUFFIX_REGEX = re.compile(
+    "^(?P<root>.+?)((?P<separator>_|-)(" + "|".join(KNOW_SUFFIXES) + "))?$"
+)
 
 
 # ############################################
@@ -191,10 +195,15 @@ REMOVE_SUFFIX_REGEX = re.compile("^(?P<root>.+?)((?P<separator>_|-)(" + "|".join
 if __name__ == "__main__":
     print("Searching code base for calibration suffixes...")
     calculated_suffixes = find_suffixes()
-    found_suffixes = combine_suffixes(to_add=(calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,))
+    found_suffixes = combine_suffixes(
+        to_add=(calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,)
+    )
     print(
         "Known list has {known_len} suffixes. Found {new_len} suffixes.".format(
             known_len=len(KNOW_SUFFIXES), new_len=len(found_suffixes)
         )
     )
-    print(f"Suffixes that have changed are {set(found_suffixes).symmetric_difference(KNOW_SUFFIXES)}")
+    print(
+        "Suffixes that have changed are"
+        f" {set(found_suffixes).symmetric_difference(KNOW_SUFFIXES)}"
+    )

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -24,7 +24,7 @@ import itertools
 import logging
 import re
 
-__all__ = ['remove_suffix']
+__all__ = ["remove_suffix"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -34,53 +34,55 @@ logger.addHandler(logging.NullHandler())
 # have to exist. Used by `find_suffixes` to
 # add to the result it produces.
 SUFFIXES_TO_ADD = [
-    'ca', 'crf',
-    'cal',
-    'dark',
-    'flat',
-    'median',
-    'phot',
-    'photom',
-    'ramp', 'rate',
-    'uncal',
-    'assignwcs',
-    'dq_init',
-    'dqinit',
-    'assign_wcs',
-    'linearity',
-    'jump',
-    'rampfit',
-    'saturation',
-    'dark_current',
-    'darkcurrent'
+    "ca",
+    "crf",
+    "cal",
+    "dark",
+    "flat",
+    "median",
+    "phot",
+    "photom",
+    "ramp",
+    "rate",
+    "uncal",
+    "assignwcs",
+    "dq_init",
+    "dqinit",
+    "assign_wcs",
+    "linearity",
+    "jump",
+    "rampfit",
+    "saturation",
+    "dark_current",
+    "darkcurrent",
 ]
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ['pipeline', 'step']
+SUFFIXES_TO_DISCARD = ["pipeline", "step"]
 
 
 # Calculated suffixes.
 _calculated_suffixes = {
-    'saturationstep',
-    'darkcurrentstep',
-    'jumpstep',
-    'rampfit',
-    'dark_current',
-    'assignwcsstep',
-    'flatfieldstep',
-    'step',
-    'dqinitstep',
-    'assign_wcs',
-    'linearity',
-    'rampfitstep',
-    'photomstep',
-    'pipeline',
-    'dq_init',
-    'linearitystep',
-    'dark_current',
-    'jump',
-    'tweakregstep'
+    "saturationstep",
+    "darkcurrentstep",
+    "jumpstep",
+    "rampfit",
+    "dark_current",
+    "assignwcsstep",
+    "flatfieldstep",
+    "step",
+    "dqinitstep",
+    "assign_wcs",
+    "linearity",
+    "rampfitstep",
+    "photomstep",
+    "pipeline",
+    "dq_init",
+    "linearitystep",
+    "dark_current",
+    "jump",
+    "tweakregstep",
 }
 
 
@@ -92,12 +94,12 @@ def remove_suffix(name):
     separator = None
     match = REMOVE_SUFFIX_REGEX.match(name)
     try:
-        name = match.group('root')
-        separator = match.group('separator')
+        name = match.group("root")
+        separator = match.group("separator")
     except AttributeError:
         pass
     if separator is None:
-        separator = '_'
+        separator = "_"
     return name, separator
 
 
@@ -120,10 +122,7 @@ def replace_suffix(name, new_suffix):
 # #####################################
 # Functions to generate `KNOW_SUFFIXES`
 # #####################################
-def combine_suffixes(
-        to_add=(_calculated_suffixes, SUFFIXES_TO_ADD),
-        to_remove=(SUFFIXES_TO_DISCARD,)
-):
+def combine_suffixes(to_add=(_calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,)):
     """Combine the suffix lists into a single list
 
     Parameters
@@ -166,10 +165,7 @@ def find_suffixes():
     # First traverse the code base and find all
     # `Step` classes. The default suffix is the
     # class name.
-    suffixes = {
-        klass_name.lower()
-        for klass_name, klass in all_steps().items()
-    }
+    suffixes = {klass_name.lower() for klass_name, klass in all_steps().items()}
 
     # That's all folks
     return list(suffixes)
@@ -185,32 +181,20 @@ def find_suffixes():
 KNOW_SUFFIXES = combine_suffixes()
 
 # Regex for removal
-REMOVE_SUFFIX_REGEX = re.compile(
-    '^(?P<root>.+?)((?P<separator>_|-)(' +
-    '|'.join(KNOW_SUFFIXES) + '))?$'
-)
+REMOVE_SUFFIX_REGEX = re.compile("^(?P<root>.+?)((?P<separator>_|-)(" + "|".join(KNOW_SUFFIXES) + "))?$")
 
 
 # ############################################
 # Main
 # Find and report differences from known list.
 # ############################################
-if __name__ == '__main__':
-    print('Searching code base for calibration suffixes...')
+if __name__ == "__main__":
+    print("Searching code base for calibration suffixes...")
     calculated_suffixes = find_suffixes()
-    found_suffixes = combine_suffixes(
-        to_add=(calculated_suffixes, SUFFIXES_TO_ADD),
-        to_remove=(SUFFIXES_TO_DISCARD, )
-    )
+    found_suffixes = combine_suffixes(to_add=(calculated_suffixes, SUFFIXES_TO_ADD), to_remove=(SUFFIXES_TO_DISCARD,))
     print(
-        'Known list has {known_len} suffixes.'
-        ' Found {new_len} suffixes.'.format(
-            known_len=len(KNOW_SUFFIXES),
-            new_len=len(found_suffixes)
+        "Known list has {known_len} suffixes. Found {new_len} suffixes.".format(
+            known_len=len(KNOW_SUFFIXES), new_len=len(found_suffixes)
         )
     )
-    print(
-        'Suffixes that have changed are {}'.format(
-            set(found_suffixes).symmetric_difference(KNOW_SUFFIXES)
-        )
-    )
+    print(f"Suffixes that have changed are {set(found_suffixes).symmetric_difference(KNOW_SUFFIXES)}")

--- a/romancal/lib/tests/helpers.py
+++ b/romancal/lib/tests/helpers.py
@@ -1,7 +1,6 @@
-import os
 import glob
 import io
-
+import os
 
 S3_BUCKET_NAME = "test-s3-data"
 

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -4,14 +4,11 @@ import pytest
 
 from romancal.lib.basic_utils import bytes2human
 
-test_data = [(1000, '1000B'),
-             (1024, '1.0K'),
-             (1024*10, '10.0K'),
-             (100001221, '95.4M')]
+test_data = [(1000, "1000B"), (1024, "1.0K"), (1024 * 10, "10.0K"), (100001221, "95.4M")]
 
 
 @pytest.mark.parametrize("input_data, result", test_data)
 def test_bytes2human(input_data, result):
-    """ test the basic conversion """
+    """test the basic conversion"""
 
     assert bytes2human(input_data) == result

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -4,7 +4,12 @@ import pytest
 
 from romancal.lib.basic_utils import bytes2human
 
-test_data = [(1000, "1000B"), (1024, "1.0K"), (1024 * 10, "10.0K"), (100001221, "95.4M")]
+test_data = [
+    (1000, "1000B"),
+    (1024, "1.0K"),
+    (1024 * 10, "10.0K"),
+    (100001221, "95.4M"),
+]
 
 
 @pytest.mark.parametrize("input_data, result", test_data)

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -4,7 +4,6 @@ import pytest
 
 from romancal.lib.basic_utils import bytes2human
 
-
 test_data = [(1000, '1000B'),
              (1024, '1.0K'),
              (1024*10, '10.0K'),

--- a/romancal/lib/tests/test_suffix.py
+++ b/romancal/lib/tests/test_suffix.py
@@ -8,12 +8,9 @@ from romancal.lib import suffix as s
 from romancal.lib.basic_utils import LoggingContext
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def enable_logging():
-    with LoggingContext(
-            logging.getLogger(s.__name__),
-            handler=logging.StreamHandler()
-    ):
+    with LoggingContext(logging.getLogger(s.__name__), handler=logging.StreamHandler()):
         yield
 
 
@@ -21,33 +18,23 @@ def test_suffix_existence(enable_logging):
     """Generate current suffix list and compare"""
 
     calculated_suffixes = s.find_suffixes()
-    found_suffixes = s.combine_suffixes(
-        to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD),
-        to_remove=(s.SUFFIXES_TO_DISCARD, )
-    )
+    found_suffixes = s.combine_suffixes(to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD), to_remove=(s.SUFFIXES_TO_DISCARD,))
     diff = set(found_suffixes).symmetric_difference(s.KNOW_SUFFIXES)
-    assert not diff, f'Suffixes unaccounted for:\n{diff}'
+    assert not diff, f"Suffixes unaccounted for:\n{diff}"
 
 
-@pytest.mark.parametrize(
-    'suffix',
-    s.KNOW_SUFFIXES
-)
+@pytest.mark.parametrize("suffix", s.KNOW_SUFFIXES)
 def test_suffix_removal(suffix, enable_logging):
     """Test suffix removal"""
-    basename = 'file'
-    full_fpath = basename + '_' + suffix
+    basename = "file"
+    full_fpath = basename + "_" + suffix
     removed_path, separator = s.remove_suffix(full_fpath)
     assert removed_path == basename
-    assert separator == '_'
+    assert separator == "_"
 
 
-@pytest.mark.parametrize(
-    'suffix',
-    s.KNOW_SUFFIXES
-)
-def test_suffix_replacement(suffix, enable_logging, base='file',
-                            new='junk', sep='_'):
+@pytest.mark.parametrize("suffix", s.KNOW_SUFFIXES)
+def test_suffix_replacement(suffix, enable_logging, base="file", new="junk", sep="_"):
     """Test suffix replacement"""
     full_path = base + sep + suffix
     replaced = s.replace_suffix(full_path, new)

--- a/romancal/lib/tests/test_suffix.py
+++ b/romancal/lib/tests/test_suffix.py
@@ -1,10 +1,11 @@
 """Test suffix replacement"""
 
 import logging
+
 import pytest
 
-from romancal.lib.basic_utils import LoggingContext
 from romancal.lib import suffix as s
+from romancal.lib.basic_utils import LoggingContext
 
 
 @pytest.fixture(scope='module')

--- a/romancal/lib/tests/test_suffix.py
+++ b/romancal/lib/tests/test_suffix.py
@@ -18,7 +18,10 @@ def test_suffix_existence(enable_logging):
     """Generate current suffix list and compare"""
 
     calculated_suffixes = s.find_suffixes()
-    found_suffixes = s.combine_suffixes(to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD), to_remove=(s.SUFFIXES_TO_DISCARD,))
+    found_suffixes = s.combine_suffixes(
+        to_add=(calculated_suffixes, s.SUFFIXES_TO_ADD),
+        to_remove=(s.SUFFIXES_TO_DISCARD,),
+    )
     diff = set(found_suffixes).symmetric_difference(s.KNOW_SUFFIXES)
     assert not diff, f"Suffixes unaccounted for:\n{diff}"
 

--- a/romancal/linearity/__init__.py
+++ b/romancal/linearity/__init__.py
@@ -1,3 +1,3 @@
 from .linearity_step import LinearityStep
 
-__all__ = ['LinearityStep']
+__all__ = ["LinearityStep"]

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -58,9 +58,13 @@ class LinearityStep(RomanStep):
             # Call linearity correction function in stcal
             # The third return value is the procesed zero frame which
             # Roman does not use.
-            new_data, new_pdq, _ = linearity_correction(output_model.data.value, gdq, pdq, lin_coeffs, lin_dq, dqflags.pixel)
+            new_data, new_pdq, _ = linearity_correction(
+                output_model.data.value, gdq, pdq, lin_coeffs, lin_dq, dqflags.pixel
+            )
 
-            output_model.data = u.Quantity(new_data[0, :, :, :], ru.DN, dtype=new_data.dtype)
+            output_model.data = u.Quantity(
+                new_data[0, :, :, :], ru.DN, dtype=new_data.dtype
+            )
             output_model.pixeldq = new_pdq
 
             # Close the reference file and update the step status

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -2,15 +2,15 @@
 Apply linearity correction to a science image
 """
 
-from roman_datamodels import datamodels as rdd
-import roman_datamodels as rdm
 import numpy as np
-
-from romancal.stpipe import RomanStep
-from romancal.lib import dqflags
-from stcal.linearity.linearity import linearity_correction
+import roman_datamodels as rdm
 from astropy import units as u
+from roman_datamodels import datamodels as rdd
 from roman_datamodels import units as ru
+from stcal.linearity.linearity import linearity_correction
+
+from romancal.lib import dqflags
+from romancal.stpipe import RomanStep
 
 __all__ = ["LinearityStep"]
 

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -21,7 +21,7 @@ class LinearityStep(RomanStep):
     detector response, using the "classic" polynomial method.
     """
 
-    reference_file_types = ['linearity']
+    reference_file_types = ["linearity"]
 
     def process(self, input):
 
@@ -29,15 +29,15 @@ class LinearityStep(RomanStep):
         with rdm.open(input) as input_model:
 
             # Get the name of the linearity reference file to use
-            self.lin_name = self.get_reference_file(input_model, 'linearity')
-            self.log.info('Using Linearity reference file %s', self.lin_name)
+            self.lin_name = self.get_reference_file(input_model, "linearity")
+            self.log.info("Using Linearity reference file %s", self.lin_name)
 
             # Check for a valid reference file
-            if self.lin_name == 'N/A':
-                self.log.warning('No Linearity reference file found')
-                self.log.warning('Linearity step will be skipped')
+            if self.lin_name == "N/A":
+                self.log.warning("No Linearity reference file found")
+                self.log.warning("Linearity step will be skipped")
                 result = input_model.copy()
-                result.meta.cal_step['linearity'] = 'SKIPPED'
+                result.meta.cal_step["linearity"] = "SKIPPED"
 
                 return result
 
@@ -47,8 +47,8 @@ class LinearityStep(RomanStep):
             lin_coeffs = lin_model.coeffs.copy()
             lin_dq = lin_model.dq  # 2D pixeldq from linearity model
 
-            gdq = input_model.groupdq   # groupdq array of input model
-            pdq = input_model.pixeldq   # pixeldq array of input model
+            gdq = input_model.groupdq  # groupdq array of input model
+            pdq = input_model.pixeldq  # pixeldq array of input model
 
             gdq = gdq[np.newaxis, :]
 
@@ -58,20 +58,18 @@ class LinearityStep(RomanStep):
             # Call linearity correction function in stcal
             # The third return value is the procesed zero frame which
             # Roman does not use.
-            new_data, new_pdq, _ = linearity_correction(output_model.data.value,
-                                                     gdq, pdq, lin_coeffs,
-                                                     lin_dq, dqflags.pixel)
+            new_data, new_pdq, _ = linearity_correction(output_model.data.value, gdq, pdq, lin_coeffs, lin_dq, dqflags.pixel)
 
             output_model.data = u.Quantity(new_data[0, :, :, :], ru.DN, dtype=new_data.dtype)
             output_model.pixeldq = new_pdq
 
             # Close the reference file and update the step status
             lin_model.close()
-            output_model.meta.cal_step['linearity'] = 'COMPLETE'
+            output_model.meta.cal_step["linearity"] = "COMPLETE"
 
         if self.save_results:
             try:
-                self.suffix = 'linearity'
+                self.suffix = "linearity"
             except AttributeError:
-                self['suffix'] = 'linearity'
+                self["suffix"] = "linearity"
         return output_model

--- a/romancal/photom/__init__.py
+++ b/romancal/photom/__init__.py
@@ -1,3 +1,3 @@
 from .photom_step import PhotomStep
 
-__all__ = ['PhotomStep']
+__all__ = ["PhotomStep"]

--- a/romancal/photom/photom.py
+++ b/romancal/photom/photom.py
@@ -29,7 +29,9 @@ def photom_io(input_model, photom_metadata):
     # Store the conversion factor in the meta data
     log.info(f"photmjsr value: {conversion:.6g}")
     input_model.meta.photometry.conversion_megajanskys = conversion
-    input_model.meta.photometry.conversion_microjanskys = conversion.to(u.microjansky / u.arcsecond**2)
+    input_model.meta.photometry.conversion_microjanskys = conversion.to(
+        u.microjansky / u.arcsecond**2
+    )
 
     # Get the scalar conversion uncertainty factor
     uncertainty_conv = photom_metadata["uncertainty"]
@@ -37,7 +39,9 @@ def photom_io(input_model, photom_metadata):
     # Store the uncertainty conversion factor in the meta data
     log.info(f"uncertainty value: {uncertainty_conv:.6g}")
     input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
-    input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(u.microjansky / u.arcsecond**2)
+    input_model.meta.photometry.conversion_microjanskys_uncertainty = (
+        uncertainty_conv.to(u.microjansky / u.arcsecond**2)
+    )
 
     # Return updated input model
     return input_model
@@ -93,9 +97,14 @@ def apply_photom(input_model, photom):
     """
     # Obtain photom parameters for the selected optical element
     try:
-        photom_parameters = photom.phot_table[input_model.meta.instrument.optical_element.upper()]
+        photom_parameters = photom.phot_table[
+            input_model.meta.instrument.optical_element.upper()
+        ]
     except KeyError:
-        warnings.warn(f"No matching photom parameters for {input_model.meta.instrument.optical_element}")
+        warnings.warn(
+            "No matching photom parameters for"
+            f" {input_model.meta.instrument.optical_element}"
+        )
         return input_model
 
     # Copy pixel area information to output datamodel

--- a/romancal/photom/photom.py
+++ b/romancal/photom/photom.py
@@ -24,22 +24,20 @@ def photom_io(input_model, photom_metadata):
 
     """
     # Get the scalar conversion factor.
-    conversion = photom_metadata['photmjsr']  # unit is MJy / sr
+    conversion = photom_metadata["photmjsr"]  # unit is MJy / sr
 
     # Store the conversion factor in the meta data
-    log.info(f'photmjsr value: {conversion:.6g}')
+    log.info(f"photmjsr value: {conversion:.6g}")
     input_model.meta.photometry.conversion_megajanskys = conversion
-    input_model.meta.photometry.conversion_microjanskys = conversion.to(
-        u.microjansky / u.arcsecond ** 2)
+    input_model.meta.photometry.conversion_microjanskys = conversion.to(u.microjansky / u.arcsecond**2)
 
     # Get the scalar conversion uncertainty factor
-    uncertainty_conv = photom_metadata['uncertainty']
+    uncertainty_conv = photom_metadata["uncertainty"]
 
     # Store the uncertainty conversion factor in the meta data
-    log.info(f'uncertainty value: {uncertainty_conv:.6g}')
+    log.info(f"uncertainty value: {uncertainty_conv:.6g}")
     input_model.meta.photometry.conversion_megajanskys_uncertainty = uncertainty_conv
-    input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(
-        u.microjansky / u.arcsecond ** 2)
+    input_model.meta.photometry.conversion_microjanskys_uncertainty = uncertainty_conv.to(u.microjansky / u.arcsecond**2)
 
     # Return updated input model
     return input_model
@@ -64,7 +62,7 @@ def save_area_info(input_model, photom_parameters):
     area_a2 = photom_parameters["pixelareasr"].to(u.arcsecond**2)
 
     # Copy the pixel area values to the input model
-    log.debug(f'pixelarea_steradians = {area_ster}, pixelarea_arcsecsq = {area_a2}')
+    log.debug(f"pixelarea_steradians = {area_ster}, pixelarea_arcsecsq = {area_a2}")
     input_model.meta.photometry.pixelarea_arcsecsq = area_a2
     input_model.meta.photometry.pixelarea_steradians = area_ster
 
@@ -97,8 +95,7 @@ def apply_photom(input_model, photom):
     try:
         photom_parameters = photom.phot_table[input_model.meta.instrument.optical_element.upper()]
     except KeyError:
-        warnings.warn(f'No matching photom parameters for '
-                      f'{input_model.meta.instrument.optical_element}')
+        warnings.warn(f"No matching photom parameters for {input_model.meta.instrument.optical_element}")
         return input_model
 
     # Copy pixel area information to output datamodel

--- a/romancal/photom/photom.py
+++ b/romancal/photom/photom.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+
 from astropy import units as u
 
 log = logging.getLogger(__name__)

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 
-from romancal.stpipe import RomanStep
-from romancal.photom import photom
 import roman_datamodels as rdm
+
+from romancal.photom import photom
+from romancal.stpipe import RomanStep
 
 __all__ = ["PhotomStep"]
 

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -14,7 +14,7 @@ class PhotomStep(RomanStep):
         reference files and attaching to the input science data model
     """
 
-    reference_file_types = ['photom']
+    reference_file_types = ["photom"]
 
     def process(self, input):
         """Perform the photometric calibration step
@@ -40,18 +40,16 @@ class PhotomStep(RomanStep):
             if reffile is not None:
                 # If there is a reference file, perform photom application
                 photom_model = rdm.open(reffile)
-                self.log.debug(f'Using PHOTOM ref file: {reffile}')
+                self.log.debug(f"Using PHOTOM ref file: {reffile}")
 
                 # Do the correction
                 if input_model.meta.exposure.type == "WFI_IMAGE":
-                    output_model = photom.apply_photom(input_model,
-                                                       photom_model)
-                    output_model.meta.cal_step.photom = 'COMPLETE'
+                    output_model = photom.apply_photom(input_model, photom_model)
+                    output_model.meta.cal_step.photom = "COMPLETE"
                 else:
-                    self.log.warning('No photometric corrections for '
-                                     'spectral data')
-                    self.log.warning('Photom step will be skipped')
-                    input_model.meta.cal_step.photom = 'SKIPPED'
+                    self.log.warning("No photometric corrections for spectral data")
+                    self.log.warning("Photom step will be skipped")
+                    input_model.meta.cal_step.photom = "SKIPPED"
                     input_model.meta.photometry.pixelarea_arcsecsq = None
                     input_model.meta.photometry.pixelarea_steradians = None
                     input_model.meta.photometry.conversion_megajanskys = None
@@ -66,9 +64,9 @@ class PhotomStep(RomanStep):
 
             else:
                 # Skip Photom step if no photom file
-                self.log.warning('No PHOTOM reference file found')
-                self.log.warning('Photom step will be skipped')
-                input_model.meta.cal_step.photom = 'SKIPPED'
+                self.log.warning("No PHOTOM reference file found")
+                self.log.warning("Photom step will be skipped")
+                input_model.meta.cal_step.photom = "SKIPPED"
                 output_model = input_model
 
         # Close the input and reference files
@@ -80,8 +78,8 @@ class PhotomStep(RomanStep):
 
         if self.save_results:
             try:
-                self.suffix = 'photom'
+                self.suffix = "photom"
             except AttributeError:
-                self['suffix'] = 'photom'
+                self["suffix"] = "photom"
 
         return output_model

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -54,8 +54,12 @@ class PhotomStep(RomanStep):
                     input_model.meta.photometry.pixelarea_steradians = None
                     input_model.meta.photometry.conversion_megajanskys = None
                     input_model.meta.photometry.conversion_microjanskys = None
-                    input_model.meta.photometry.conversion_megajanskys_uncertainty = None
-                    input_model.meta.photometry.conversion_microjanskys_uncertainty = None
+                    input_model.meta.photometry.conversion_megajanskys_uncertainty = (
+                        None
+                    )
+                    input_model.meta.photometry.conversion_microjanskys_uncertainty = (
+                        None
+                    )
                     try:
                         photom_model.close()
                     except AttributeError:

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -280,7 +280,9 @@ def test_photom_step_interface(instrument, exptype):
     ),
 )
 def test_photom_step_interface_spectroscopic(instrument, exptype):
-    """Test apply_photom properly populates photometric keywords for spectroscopic data"""
+    """
+    Test apply_photom properly populates photometric keywords for spectroscopic data
+    """
 
     # Create a small area for the file
     shape = (20, 20)

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -29,25 +29,23 @@ def create_photom_wfi_image(min_r=3.1, delta=0.1):
     """
 
     # Keyword and eleents list for phot_table construction
-    optical_element = ["F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213",
-                       "GRISM", "PRISM", "DARK"]
+    optical_element = ["F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213", "GRISM", "PRISM", "DARK"]
     none_type_elements = ["GRISM", "PRISM", "DARK"]
     keyword = ["photmjsr", "uncertainty", "pixelareasr"]
     nrows = len(optical_element)
 
     # Create sample photometry keyword values
-    photmjsr = np.linspace(min_r, min_r + (nrows - 1.) * delta, nrows) * u.megajansky / u.steradian
-    uncertainty = np.linspace(min_r/20.0, min_r/20.0 + (nrows - 1.) * delta/20.0, nrows) * \
-                  u.megajansky / u.steradian
+    photmjsr = np.linspace(min_r, min_r + (nrows - 1.0) * delta, nrows) * u.megajansky / u.steradian
+    uncertainty = np.linspace(min_r / 20.0, min_r / 20.0 + (nrows - 1.0) * delta / 20.0, nrows) * u.megajansky / u.steradian
 
     # Create sample area keyword values
-    area_ster = 2.31307642258977E-14 * u.steradian
+    area_ster = 2.31307642258977e-14 * u.steradian
     pixelareasr = np.ones(nrows, dtype=np.float32) * area_ster
 
     # Bundle values into a list
     values = list(zip(photmjsr, uncertainty, pixelareasr))
 
-    #Create dictionary containing all values
+    # Create dictionary containing all values
     reftab = {}
     for element_idx, element in enumerate(optical_element):
         key_dict = {}
@@ -64,7 +62,7 @@ def create_photom_wfi_image(min_r=3.1, delta=0.1):
     photom_model = maker_utils.mk_wfi_img_photom()
 
     # Copy values above into defautl datamodel
-    photom_model.phot_table=reftab
+    photom_model.phot_table = reftab
 
     return photom_model
 
@@ -87,8 +85,7 @@ def test_no_photom_match():
     # Set bad values which would be overwritten by apply_photom
     input_model.meta.photometry.pixelarea_steradians = -1.0 * u.sr
     input_model.meta.photometry.conversion_megajanskys = -1.0 * u.megajansky / u.steradian
-    input_model.meta.photometry.conversion_microjanskys_uncertainty = \
-        -1.0 * u.microjansky / u.arcsecond ** 2
+    input_model.meta.photometry.conversion_microjanskys_uncertainty = -1.0 * u.microjansky / u.arcsecond**2
 
     with warnings.catch_warnings(record=True) as caught:
         # Look for now non existent F146 optical element
@@ -99,10 +96,8 @@ def test_no_photom_match():
 
         # Assert that photom elements are not updated
         assert output_model.meta.photometry.pixelarea_steradians == -1.0 * u.sr
-        assert output_model.meta.photometry.conversion_megajanskys == \
-               -1.0 * u.megajansky / u.steradian
-        assert output_model.meta.photometry.conversion_microjanskys_uncertainty == \
-               -1.0 * u.microjansky / u.arcsecond ** 2
+        assert output_model.meta.photometry.conversion_megajanskys == -1.0 * u.megajansky / u.steradian
+        assert output_model.meta.photometry.conversion_microjanskys_uncertainty == -1.0 * u.microjansky / u.arcsecond**2
 
 
 def test_apply_photom1():
@@ -121,42 +116,34 @@ def test_apply_photom1():
     output_model = photom.apply_photom(input_model, photom_model)
 
     # Set reference photometry
-    area_ster = 2.31307642258977E-14 * u.steradian
+    area_ster = 2.31307642258977e-14 * u.steradian
     area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
 
     # Tests for pixel areas
-    assert (np.isclose(output_model.meta.photometry.pixelarea_steradians.value,
-                        area_ster.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.pixelarea_steradians.value, area_ster.value, atol=1.0e-7)
     assert output_model.meta.photometry.pixelarea_steradians.unit == area_ster.unit
-    assert (np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value,
-                        area_a2.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value, area_a2.value, atol=1.0e-7)
     assert output_model.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit
 
     # Set reference photometry
     phot_ster = 3.5 * u.megajansky / u.steradian
-    phot_a2 = phot_ster.to(u.microjansky / u.arcsecond ** 2)
+    phot_a2 = phot_ster.to(u.microjansky / u.arcsecond**2)
 
     # Tests for photometry
-    assert (np.isclose(output_model.meta.photometry.conversion_megajanskys.value,
-                       phot_ster.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.conversion_megajanskys.value, phot_ster.value, atol=1.0e-7)
     assert output_model.meta.photometry.conversion_megajanskys.unit == phot_ster.unit
-    assert (np.isclose(output_model.meta.photometry.conversion_microjanskys.value,
-                       phot_a2.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.conversion_microjanskys.value, phot_a2.value, atol=1.0e-7)
     assert output_model.meta.photometry.conversion_microjanskys.unit == phot_a2.unit
 
     # Set reference photometric uncertainty
     muphot_ster = 0.175 * u.megajansky / u.steradian
-    muphot_a2 = muphot_ster.to(u.microjansky / u.arcsecond ** 2)
+    muphot_a2 = muphot_ster.to(u.microjansky / u.arcsecond**2)
 
     # Tests for photometric uncertainty
-    assert (np.isclose(output_model.meta.photometry.conversion_megajanskys_uncertainty.value,
-                       muphot_ster.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.conversion_megajanskys_uncertainty.value, muphot_ster.value, atol=1.0e-7)
     assert output_model.meta.photometry.conversion_megajanskys_uncertainty.unit == muphot_ster.unit
-    assert (np.isclose(output_model.meta.photometry.conversion_microjanskys_uncertainty.value,
-                       muphot_a2.value, atol=1.e-7))
+    assert np.isclose(output_model.meta.photometry.conversion_microjanskys_uncertainty.value, muphot_a2.value, atol=1.0e-7)
     assert output_model.meta.photometry.conversion_microjanskys_uncertainty.unit == muphot_a2.unit
-
-
 
 
 def test_apply_photom2():
@@ -177,18 +164,17 @@ def test_apply_photom2():
     iy = shape[0] // 2
 
     # Test that the data has not changed
-    assert (np.allclose(output_model.data[iy, ix], input_model.data[iy, ix], rtol=1.e-7))
+    assert np.allclose(output_model.data[iy, ix], input_model.data[iy, ix], rtol=1.0e-7)
 
 
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_IMAGE"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_photom_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a photom reffile"""
@@ -210,20 +196,19 @@ def test_photom_step_interface(instrument, exptype):
     assert (result.data == wfi_image.data).all()
     assert result.data.shape == shape
     if exptype == "WFI_IMAGE":
-        assert result.meta.cal_step.photom == 'COMPLETE'
+        assert result.meta.cal_step.photom == "COMPLETE"
     else:
-        assert result.meta.cal_step.photom == 'SKIPPED'
+        assert result.meta.cal_step.photom == "SKIPPED"
 
 
 @pytest.mark.parametrize(
     "instrument, exptype",
     [
         ("WFI", "WFI_PRISM"),
-    ]
+    ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_photom_step_interface_spectroscopic(instrument, exptype):
     """Test apply_photom properly populates photometric keywords for spectroscopic data"""
@@ -239,14 +224,12 @@ def test_photom_step_interface_spectroscopic(instrument, exptype):
     wfi_image.meta.instrument.optical_element = "PRISM"
 
     # Set photometric values for spectroscopic data
-    wfi_image.meta.photometry.pixelarea_steradians = 2.31307642258977E-14 * u.steradian
+    wfi_image.meta.photometry.pixelarea_steradians = 2.31307642258977e-14 * u.steradian
     wfi_image.meta.photometry.pixelarea_arcsecsq = 0.000984102303070964 * u.arcsecond * u.arcsecond
     wfi_image.meta.photometry.conversion_megajanskys = -99999 * u.megajansky / u.steradian
-    wfi_image.meta.photometry.conversion_megajanskys_uncertainty = -99999 * u.megajansky / \
-                                                                   u.steradian
-    wfi_image.meta.photometry.conversion_microjanskys = -99999 * u.microjansky / u.arcsecond ** 2
-    wfi_image.meta.photometry.conversion_microjanskys_uncertainty = -99999 * u.microjansky / \
-                                                                    u.arcsecond ** 2
+    wfi_image.meta.photometry.conversion_megajanskys_uncertainty = -99999 * u.megajansky / u.steradian
+    wfi_image.meta.photometry.conversion_microjanskys = -99999 * u.microjansky / u.arcsecond**2
+    wfi_image.meta.photometry.conversion_microjanskys_uncertainty = -99999 * u.microjansky / u.arcsecond**2
 
     # Create input model
     wfi_image_model = ImageModel(wfi_image)
@@ -259,7 +242,7 @@ def test_photom_step_interface_spectroscopic(instrument, exptype):
     result = PhotomStep.call(wfi_image_model, override_photom=photom_model)
 
     # Test that the data has not changed
-    assert (np.allclose(result.data, wfi_image_model.data, rtol=1.e-7))
+    assert np.allclose(result.data, wfi_image_model.data, rtol=1.0e-7)
 
     # Test that keywords are properly overwritten
     assert result.meta.photometry.conversion_megajanskys is None

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -1,12 +1,13 @@
 import os
-import pytest
-import numpy as np
 import warnings
-from astropy import units as u
 
-from romancal.photom import photom, PhotomStep
-from roman_datamodels.datamodels import ImageModel, WfiImgPhotomRefModel
+import numpy as np
+import pytest
+from astropy import units as u
 from roman_datamodels import maker_utils
+from roman_datamodels.datamodels import ImageModel, WfiImgPhotomRefModel
+
+from romancal.photom import PhotomStep, photom
 
 
 def create_photom_wfi_image(min_r=3.1, delta=0.1):

--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -29,14 +29,34 @@ def create_photom_wfi_image(min_r=3.1, delta=0.1):
     """
 
     # Keyword and eleents list for phot_table construction
-    optical_element = ["F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213", "GRISM", "PRISM", "DARK"]
+    optical_element = [
+        "F062",
+        "F087",
+        "F106",
+        "F129",
+        "F146",
+        "F158",
+        "F184",
+        "F213",
+        "GRISM",
+        "PRISM",
+        "DARK",
+    ]
     none_type_elements = ["GRISM", "PRISM", "DARK"]
     keyword = ["photmjsr", "uncertainty", "pixelareasr"]
     nrows = len(optical_element)
 
     # Create sample photometry keyword values
-    photmjsr = np.linspace(min_r, min_r + (nrows - 1.0) * delta, nrows) * u.megajansky / u.steradian
-    uncertainty = np.linspace(min_r / 20.0, min_r / 20.0 + (nrows - 1.0) * delta / 20.0, nrows) * u.megajansky / u.steradian
+    photmjsr = (
+        np.linspace(min_r, min_r + (nrows - 1.0) * delta, nrows)
+        * u.megajansky
+        / u.steradian
+    )
+    uncertainty = (
+        np.linspace(min_r / 20.0, min_r / 20.0 + (nrows - 1.0) * delta / 20.0, nrows)
+        * u.megajansky
+        / u.steradian
+    )
 
     # Create sample area keyword values
     area_ster = 2.31307642258977e-14 * u.steradian
@@ -84,20 +104,33 @@ def test_no_photom_match():
 
     # Set bad values which would be overwritten by apply_photom
     input_model.meta.photometry.pixelarea_steradians = -1.0 * u.sr
-    input_model.meta.photometry.conversion_megajanskys = -1.0 * u.megajansky / u.steradian
-    input_model.meta.photometry.conversion_microjanskys_uncertainty = -1.0 * u.microjansky / u.arcsecond**2
+    input_model.meta.photometry.conversion_megajanskys = (
+        -1.0 * u.megajansky / u.steradian
+    )
+    input_model.meta.photometry.conversion_microjanskys_uncertainty = (
+        -1.0 * u.microjansky / u.arcsecond**2
+    )
 
     with warnings.catch_warnings(record=True) as caught:
         # Look for now non existent F146 optical element
         output_model = photom.apply_photom(input_model, photom_model)
 
         # Assert warning key matches that of the input file
-        assert str(caught[0].message).split()[-1] == input_model.meta.instrument.optical_element
+        assert (
+            str(caught[0].message).split()[-1]
+            == input_model.meta.instrument.optical_element
+        )
 
         # Assert that photom elements are not updated
         assert output_model.meta.photometry.pixelarea_steradians == -1.0 * u.sr
-        assert output_model.meta.photometry.conversion_megajanskys == -1.0 * u.megajansky / u.steradian
-        assert output_model.meta.photometry.conversion_microjanskys_uncertainty == -1.0 * u.microjansky / u.arcsecond**2
+        assert (
+            output_model.meta.photometry.conversion_megajanskys
+            == -1.0 * u.megajansky / u.steradian
+        )
+        assert (
+            output_model.meta.photometry.conversion_microjanskys_uncertainty
+            == -1.0 * u.microjansky / u.arcsecond**2
+        )
 
 
 def test_apply_photom1():
@@ -120,9 +153,17 @@ def test_apply_photom1():
     area_a2 = 0.000984102303070964 * u.arcsecond * u.arcsecond
 
     # Tests for pixel areas
-    assert np.isclose(output_model.meta.photometry.pixelarea_steradians.value, area_ster.value, atol=1.0e-7)
+    assert np.isclose(
+        output_model.meta.photometry.pixelarea_steradians.value,
+        area_ster.value,
+        atol=1.0e-7,
+    )
     assert output_model.meta.photometry.pixelarea_steradians.unit == area_ster.unit
-    assert np.isclose(output_model.meta.photometry.pixelarea_arcsecsq.value, area_a2.value, atol=1.0e-7)
+    assert np.isclose(
+        output_model.meta.photometry.pixelarea_arcsecsq.value,
+        area_a2.value,
+        atol=1.0e-7,
+    )
     assert output_model.meta.photometry.pixelarea_arcsecsq.unit == area_a2.unit
 
     # Set reference photometry
@@ -130,9 +171,17 @@ def test_apply_photom1():
     phot_a2 = phot_ster.to(u.microjansky / u.arcsecond**2)
 
     # Tests for photometry
-    assert np.isclose(output_model.meta.photometry.conversion_megajanskys.value, phot_ster.value, atol=1.0e-7)
+    assert np.isclose(
+        output_model.meta.photometry.conversion_megajanskys.value,
+        phot_ster.value,
+        atol=1.0e-7,
+    )
     assert output_model.meta.photometry.conversion_megajanskys.unit == phot_ster.unit
-    assert np.isclose(output_model.meta.photometry.conversion_microjanskys.value, phot_a2.value, atol=1.0e-7)
+    assert np.isclose(
+        output_model.meta.photometry.conversion_microjanskys.value,
+        phot_a2.value,
+        atol=1.0e-7,
+    )
     assert output_model.meta.photometry.conversion_microjanskys.unit == phot_a2.unit
 
     # Set reference photometric uncertainty
@@ -140,10 +189,24 @@ def test_apply_photom1():
     muphot_a2 = muphot_ster.to(u.microjansky / u.arcsecond**2)
 
     # Tests for photometric uncertainty
-    assert np.isclose(output_model.meta.photometry.conversion_megajanskys_uncertainty.value, muphot_ster.value, atol=1.0e-7)
-    assert output_model.meta.photometry.conversion_megajanskys_uncertainty.unit == muphot_ster.unit
-    assert np.isclose(output_model.meta.photometry.conversion_microjanskys_uncertainty.value, muphot_a2.value, atol=1.0e-7)
-    assert output_model.meta.photometry.conversion_microjanskys_uncertainty.unit == muphot_a2.unit
+    assert np.isclose(
+        output_model.meta.photometry.conversion_megajanskys_uncertainty.value,
+        muphot_ster.value,
+        atol=1.0e-7,
+    )
+    assert (
+        output_model.meta.photometry.conversion_megajanskys_uncertainty.unit
+        == muphot_ster.unit
+    )
+    assert np.isclose(
+        output_model.meta.photometry.conversion_microjanskys_uncertainty.value,
+        muphot_a2.value,
+        atol=1.0e-7,
+    )
+    assert (
+        output_model.meta.photometry.conversion_microjanskys_uncertainty.unit
+        == muphot_a2.unit
+    )
 
 
 def test_apply_photom2():
@@ -174,7 +237,10 @@ def test_apply_photom2():
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_photom_step_interface(instrument, exptype):
     """Test that the basic inferface works for data requiring a photom reffile"""
@@ -208,7 +274,10 @@ def test_photom_step_interface(instrument, exptype):
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 def test_photom_step_interface_spectroscopic(instrument, exptype):
     """Test apply_photom properly populates photometric keywords for spectroscopic data"""
@@ -225,11 +294,21 @@ def test_photom_step_interface_spectroscopic(instrument, exptype):
 
     # Set photometric values for spectroscopic data
     wfi_image.meta.photometry.pixelarea_steradians = 2.31307642258977e-14 * u.steradian
-    wfi_image.meta.photometry.pixelarea_arcsecsq = 0.000984102303070964 * u.arcsecond * u.arcsecond
-    wfi_image.meta.photometry.conversion_megajanskys = -99999 * u.megajansky / u.steradian
-    wfi_image.meta.photometry.conversion_megajanskys_uncertainty = -99999 * u.megajansky / u.steradian
-    wfi_image.meta.photometry.conversion_microjanskys = -99999 * u.microjansky / u.arcsecond**2
-    wfi_image.meta.photometry.conversion_microjanskys_uncertainty = -99999 * u.microjansky / u.arcsecond**2
+    wfi_image.meta.photometry.pixelarea_arcsecsq = (
+        0.000984102303070964 * u.arcsecond * u.arcsecond
+    )
+    wfi_image.meta.photometry.conversion_megajanskys = (
+        -99999 * u.megajansky / u.steradian
+    )
+    wfi_image.meta.photometry.conversion_megajanskys_uncertainty = (
+        -99999 * u.megajansky / u.steradian
+    )
+    wfi_image.meta.photometry.conversion_microjanskys = (
+        -99999 * u.microjansky / u.arcsecond**2
+    )
+    wfi_image.meta.photometry.conversion_microjanskys_uncertainty = (
+        -99999 * u.microjansky / u.arcsecond**2
+    )
 
     # Create input model
     wfi_image_model = ImageModel(wfi_image)

--- a/romancal/pipeline/__init__.py
+++ b/romancal/pipeline/__init__.py
@@ -4,4 +4,4 @@ made available by this package.
 """
 from .exposure_pipeline import ExposurePipeline
 
-__all__ = ['ExposurePipeline']
+__all__ = ["ExposurePipeline"]

--- a/romancal/pipeline/__init__.py
+++ b/romancal/pipeline/__init__.py
@@ -4,5 +4,4 @@ made available by this package.
 """
 from .exposure_pipeline import ExposurePipeline
 
-
 __all__ = ['ExposurePipeline']

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python
-from os.path import basename
 import logging
+from os.path import basename
 
 import numpy as np
 from roman_datamodels import datamodels as rdd
-from ..stpipe import RomanPipeline
-from romancal.lib.basic_utils import is_fully_saturated
-from romancal.lib import dqflags
 
 # step imports
 from romancal.assign_wcs import AssignWcsStep
+from romancal.dark_current import DarkCurrentStep
 from romancal.dq_init import dq_init_step
 from romancal.flatfield import FlatFieldStep
 from romancal.jump import jump_step
-from romancal.dark_current import DarkCurrentStep
+from romancal.lib import dqflags
+from romancal.lib.basic_utils import is_fully_saturated
 from romancal.linearity import LinearityStep
 from romancal.photom import PhotomStep
 from romancal.ramp_fitting import ramp_fit_step
 from romancal.saturation import SaturationStep
+
+from ..stpipe import RomanPipeline
 
 __all__ = ['ExposurePipeline']
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -20,12 +20,11 @@ from romancal.saturation import SaturationStep
 
 from ..stpipe import RomanPipeline
 
-__all__ = ['ExposurePipeline']
+__all__ = ["ExposurePipeline"]
 
 # Define logging
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
-
 
 
 class ExposurePipeline(RomanPipeline):
@@ -44,23 +43,24 @@ class ExposurePipeline(RomanPipeline):
     """
 
     # Define aliases to steps
-    step_defs = {'dq_init': dq_init_step.DQInitStep,
-                 'saturation': SaturationStep,
-                 'linearity': LinearityStep,
-                 'dark_current': DarkCurrentStep,
-                 'jump': jump_step.JumpStep,
-                 'rampfit': ramp_fit_step.RampFitStep,
-                 'assign_wcs': AssignWcsStep,
-                 'flatfield': FlatFieldStep,
-                 'photom': PhotomStep,
-                 }
+    step_defs = {
+        "dq_init": dq_init_step.DQInitStep,
+        "saturation": SaturationStep,
+        "linearity": LinearityStep,
+        "dark_current": DarkCurrentStep,
+        "jump": jump_step.JumpStep,
+        "rampfit": ramp_fit_step.RampFitStep,
+        "assign_wcs": AssignWcsStep,
+        "flatfield": FlatFieldStep,
+        "photom": PhotomStep,
+    }
 
     # start the actual processing
     def process(self, input):
 
-        """ Process the Roman WFI data """
+        """Process the Roman WFI data"""
 
-        log.info('Starting Roman exposure calibration pipeline ...')
+        log.info("Starting Roman exposure calibration pipeline ...")
         if isinstance(input, str):
             input_filename = basename(input)
         else:
@@ -69,9 +69,9 @@ class ExposurePipeline(RomanPipeline):
         # open the input file
         input = rdd.open(input)
 
-        log.debug('Exposure Processing a WFI exposure')
+        log.debug("Exposure Processing a WFI exposure")
 
-        self.dq_init.suffix = 'dq_init'
+        self.dq_init.suffix = "dq_init"
         result = self.dq_init(input)
         if input_filename:
             result.meta.filename = input_filename
@@ -79,7 +79,7 @@ class ExposurePipeline(RomanPipeline):
 
         # Test for fully saturated data
         if is_fully_saturated(result):
-            log.info('All pixels are saturated. Returning a zeroed-out image.')
+            log.info("All pixels are saturated. Returning a zeroed-out image.")
 
             # Return zeroed-out image file (stopping pipeline)
             return self.create_fully_saturated_zeroed_image(result)
@@ -93,64 +93,61 @@ class ExposurePipeline(RomanPipeline):
         if "groupdq" in result.keys():
             if is_fully_saturated(result):
                 # Set all subsequent steps to skipped
-                for step_str in ['assign_wcs', 'flat_field', 'photom']:
-                    result.meta.cal_step[step_str] = 'SKIPPED'
+                for step_str in ["assign_wcs", "flat_field", "photom"]:
+                    result.meta.cal_step[step_str] = "SKIPPED"
 
                 # Set suffix for proper output naming
-                self.suffix = 'cal'
+                self.suffix = "cal"
 
                 # Return fully saturated image file (stopping pipeline)
                 return result
 
         result = self.assign_wcs(result)
-        if result.meta.exposure.type == 'WFI_IMAGE':
+        if result.meta.exposure.type == "WFI_IMAGE":
             result = self.flatfield(result)
         else:
-            log.info('Flat Field step is being SKIPPED')
-            result.meta.cal_step.flat_field = 'SKIPPED'
+            log.info("Flat Field step is being SKIPPED")
+            result.meta.cal_step.flat_field = "SKIPPED"
         result = self.photom(result)
 
         # setup output_file for saving
         self.setup_output(result)
-        log.info('Roman exposure calibration pipeline ending...')
+        log.info("Roman exposure calibration pipeline ending...")
 
         return result
 
     def setup_output(self, input):
-        """ Determine the proper file name suffix to use later """
-        if input.meta.cal_step.ramp_fit == 'COMPLETE':
-            self.suffix = 'cal'
-            input.meta.filename = input.meta.filename.replace(
-                'uncal', self.suffix)
-            input['output_file'] = input.meta.filename
+        """Determine the proper file name suffix to use later"""
+        if input.meta.cal_step.ramp_fit == "COMPLETE":
+            self.suffix = "cal"
+            input.meta.filename = input.meta.filename.replace("uncal", self.suffix)
+            input["output_file"] = input.meta.filename
             self.output_file = input.meta.filename
         else:
-            self.suffix = 'ramp'
+            self.suffix = "ramp"
 
     def create_fully_saturated_zeroed_image(self, input_model):
         """
         Create zeroed-out image file
         """
         # The set order is: data, dq, var_poisson, var_rnoise, err
-        fully_saturated_model = ramp_fit_step.create_image_model(input_model,
-                                              (np.zeros(input_model.data.shape[1:],
-                                                        dtype=input_model.data.dtype),
-                                               input_model.pixeldq | input_model.groupdq[0] |
-                                                                     dqflags.group['SATURATED'],
-                                               np.zeros(input_model.err.shape[1:],
-                                                        dtype=input_model.err.dtype),
-                                               np.zeros(input_model.err.shape[1:],
-                                                        dtype=input_model.err.dtype),
-                                               np.zeros(input_model.err.shape[1:],
-                                                        dtype=input_model.err.dtype)))
+        fully_saturated_model = ramp_fit_step.create_image_model(
+            input_model,
+            (
+                np.zeros(input_model.data.shape[1:], dtype=input_model.data.dtype),
+                input_model.pixeldq | input_model.groupdq[0] | dqflags.group["SATURATED"],
+                np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
+                np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
+                np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
+            ),
+        )
 
         # Set all subsequent steps to skipped
-        for step_str in ['linearity', 'dark', 'jump', 'ramp_fit', 'assign_wcs',
-                         'flat_field', 'photom']:
-            fully_saturated_model.meta.cal_step[step_str] = 'SKIPPED'
+        for step_str in ["linearity", "dark", "jump", "ramp_fit", "assign_wcs", "flat_field", "photom"]:
+            fully_saturated_model.meta.cal_step[step_str] = "SKIPPED"
 
         # Set suffix for proper output naming
-        self.suffix = 'cal'
+        self.suffix = "cal"
 
         # Return zeroed-out image file
         return fully_saturated_model

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -135,7 +135,9 @@ class ExposurePipeline(RomanPipeline):
             input_model,
             (
                 np.zeros(input_model.data.shape[1:], dtype=input_model.data.dtype),
-                input_model.pixeldq | input_model.groupdq[0] | dqflags.group["SATURATED"],
+                input_model.pixeldq
+                | input_model.groupdq[0]
+                | dqflags.group["SATURATED"],
                 np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
                 np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
                 np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype),
@@ -143,7 +145,15 @@ class ExposurePipeline(RomanPipeline):
         )
 
         # Set all subsequent steps to skipped
-        for step_str in ["linearity", "dark", "jump", "ramp_fit", "assign_wcs", "flat_field", "photom"]:
+        for step_str in [
+            "linearity",
+            "dark",
+            "jump",
+            "ramp_fit",
+            "assign_wcs",
+            "flat_field",
+            "photom",
+        ]:
             fully_saturated_model.meta.cal_step[step_str] = "SKIPPED"
 
         # Set suffix for proper output naming

--- a/romancal/ramp_fitting/__init__.py
+++ b/romancal/ramp_fitting/__init__.py
@@ -1,3 +1,3 @@
 from .ramp_fit_step import RampFitStep
 
-__all__ = ['RampFitStep']
+__all__ = ["RampFitStep"]

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -1,17 +1,17 @@
 #! /usr/bin/env python
 #
 import logging
+
 import numpy as np
 from astropy import units as u
-
-from romancal.stpipe import RomanStep
-from romancal.lib import dqflags
 from roman_datamodels import datamodels as rdd
-from roman_datamodels import stnode as rds
 from roman_datamodels import maker_utils
+from roman_datamodels import stnode as rds
 from roman_datamodels import units as ru
-
 from stcal.ramp_fitting import ramp_fit
+
+from romancal.lib import dqflags
+from romancal.stpipe import RomanStep
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -157,8 +157,8 @@ class RampFitStep(RomanStep):
             log.info("Using GAIN reference file: %s", gain_filename)
             gain_model = rdd.open(gain_filename, mode="rw")
 
-            log.info("Using algorithm = %s" % self.algorithm)
-            log.info("Using weighting = %s" % self.weighting)
+            log.info(f"Using algorithm = {self.algorithm}")
+            log.info(f"Using weighting = {self.weighting}")
 
             buffsize = ramp_fit.BUFSIZE
             image_info, integ_info, opt_info, gls_opt_model = ramp_fit.ramp_fit(

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -36,24 +36,24 @@ def create_optional_results_model(input_model, opt_info):
     opt_model : `~roman_datamodels.datamodels.RampFitOutputModel`
         The optional ``RampFitOutputModel`` to be returned from the ramp fit step.
     """
-    (slope, sigslope, var_poisson, var_rnoise,
-        yint, sigyint, pedestal, weights, crmag) = opt_info
+    (slope, sigslope, var_poisson, var_rnoise, yint, sigyint, pedestal, weights, crmag) = opt_info
     meta = {}
     meta.update(input_model.meta)
     crmag.shape = crmag.shape[1:]
     crmag.dtype = np.float32
 
-    inst = {'meta': meta,
-            'slope': u.Quantity(np.squeeze(slope), ru.electron / u.s, dtype=slope.dtype),
-            'sigslope': u.Quantity(np.squeeze(sigslope), ru.electron / u.s, dtype=sigslope.dtype),
-            'var_poisson': u.Quantity(np.squeeze(var_poisson), ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
-            'var_rnoise': u.Quantity(np.squeeze(var_rnoise), ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
-            'yint': u.Quantity(np.squeeze(yint), ru.electron, dtype=yint.dtype),
-            'sigyint': u.Quantity(np.squeeze(sigyint), ru.electron, dtype=sigyint.dtype),
-            'pedestal': u.Quantity(np.squeeze(pedestal), ru.electron, dtype=pedestal.dtype),
-            'weights': np.squeeze(weights),
-            'crmag': u.Quantity(crmag, ru.electron, dtype=pedestal.dtype),
-            }
+    inst = {
+        "meta": meta,
+        "slope": u.Quantity(np.squeeze(slope), ru.electron / u.s, dtype=slope.dtype),
+        "sigslope": u.Quantity(np.squeeze(sigslope), ru.electron / u.s, dtype=sigslope.dtype),
+        "var_poisson": u.Quantity(np.squeeze(var_poisson), ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
+        "var_rnoise": u.Quantity(np.squeeze(var_rnoise), ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
+        "yint": u.Quantity(np.squeeze(yint), ru.electron, dtype=yint.dtype),
+        "sigyint": u.Quantity(np.squeeze(sigyint), ru.electron, dtype=sigyint.dtype),
+        "pedestal": u.Quantity(np.squeeze(pedestal), ru.electron, dtype=pedestal.dtype),
+        "weights": np.squeeze(weights),
+        "crmag": u.Quantity(crmag, ru.electron, dtype=pedestal.dtype),
+    }
 
     out_node = rds.RampFitOutput(inst)
     opt_model = rdd.RampFitOutputModel(out_node)
@@ -91,25 +91,26 @@ def create_image_model(input_model, image_info):
     # ... and add all keys from input
     meta = {}
     meta.update(input_model.meta)
-    meta['cal_step']['ramp_fit'] = 'INCOMPLETE'
-    meta['photometry'] = maker_utils.mk_photometry()
-    inst = {'meta': meta,
-            'data': u.Quantity(data, ru.electron / u.s, dtype=data.dtype),
-            'dq': dq,
-            'var_poisson': u.Quantity(var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
-            'var_rnoise': u.Quantity(var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
-            'err': u.Quantity(err, ru.electron / u.s, dtype=err.dtype),
-            'amp33': input_model.amp33,
-            'border_ref_pix_left': input_model.border_ref_pix_left,
-            'border_ref_pix_right': input_model.border_ref_pix_right,
-            'border_ref_pix_top': input_model.border_ref_pix_top,
-            'border_ref_pix_bottom': input_model.border_ref_pix_bottom,
-            'dq_border_ref_pix_left': input_model.dq_border_ref_pix_left,
-            'dq_border_ref_pix_right': input_model.dq_border_ref_pix_right,
-            'dq_border_ref_pix_top': input_model.dq_border_ref_pix_top,
-            'dq_border_ref_pix_bottom': input_model.dq_border_ref_pix_bottom,
-            'cal_logs': rds.CalLogs(),
-            }
+    meta["cal_step"]["ramp_fit"] = "INCOMPLETE"
+    meta["photometry"] = maker_utils.mk_photometry()
+    inst = {
+        "meta": meta,
+        "data": u.Quantity(data, ru.electron / u.s, dtype=data.dtype),
+        "dq": dq,
+        "var_poisson": u.Quantity(var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
+        "var_rnoise": u.Quantity(var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
+        "err": u.Quantity(err, ru.electron / u.s, dtype=err.dtype),
+        "amp33": input_model.amp33,
+        "border_ref_pix_left": input_model.border_ref_pix_left,
+        "border_ref_pix_right": input_model.border_ref_pix_right,
+        "border_ref_pix_top": input_model.border_ref_pix_top,
+        "border_ref_pix_bottom": input_model.border_ref_pix_bottom,
+        "dq_border_ref_pix_left": input_model.dq_border_ref_pix_left,
+        "dq_border_ref_pix_right": input_model.dq_border_ref_pix_right,
+        "dq_border_ref_pix_top": input_model.dq_border_ref_pix_top,
+        "dq_border_ref_pix_bottom": input_model.dq_border_ref_pix_bottom,
+        "cal_logs": rds.CalLogs(),
+    }
     out_node = rds.WfiImage(inst)
     im = rdd.ImageModel(out_node)
 
@@ -120,7 +121,6 @@ def create_image_model(input_model, image_info):
     im.err = im.err[4:-4, 4:-4]
     im.var_poisson = im.var_poisson[4:-4, 4:-4]
     im.var_rnoise = im.var_rnoise[4:-4, 4:-4]
-
 
     return im
 
@@ -137,62 +137,69 @@ class RampFitStep(RomanStep):
         maximum_cores = option('none','quarter','half','all',default='none') # max number of processes to create
         save_opt = boolean(default=False) # Save optional output
     """
-    algorithm = 'ols'      # Only algorithm allowed
+    algorithm = "ols"  # Only algorithm allowed
 
-    weighting = 'optimal'  # Only weighting allowed
+    weighting = "optimal"  # Only weighting allowed
 
-    reference_file_types = ['readnoise', 'gain']
+    reference_file_types = ["readnoise", "gain"]
 
     def process(self, input):
-        with rdd.open(input, mode='rw') as input_model:
+        with rdd.open(input, mode="rw") as input_model:
             max_cores = self.maximum_cores
-            readnoise_filename = self.get_reference_file(input_model, 'readnoise')
-            gain_filename = self.get_reference_file(input_model, 'gain')
+            readnoise_filename = self.get_reference_file(input_model, "readnoise")
+            gain_filename = self.get_reference_file(input_model, "gain")
             input_model.data = input_model.data[np.newaxis, :]
             input_model.groupdq = input_model.groupdq[np.newaxis, :]
             input_model.err = input_model.err[np.newaxis, :]
 
-            log.info('Using READNOISE reference file: %s', readnoise_filename)
-            readnoise_model = rdd.open(readnoise_filename, mode='rw')
-            log.info('Using GAIN reference file: %s', gain_filename)
-            gain_model = rdd.open(gain_filename, mode='rw')
+            log.info("Using READNOISE reference file: %s", readnoise_filename)
+            readnoise_model = rdd.open(readnoise_filename, mode="rw")
+            log.info("Using GAIN reference file: %s", gain_filename)
+            gain_model = rdd.open(gain_filename, mode="rw")
 
-            log.info('Using algorithm = %s' % self.algorithm)
-            log.info('Using weighting = %s' % self.weighting)
+            log.info("Using algorithm = %s" % self.algorithm)
+            log.info("Using weighting = %s" % self.weighting)
 
             buffsize = ramp_fit.BUFSIZE
             image_info, integ_info, opt_info, gls_opt_model = ramp_fit.ramp_fit(
-                input_model, buffsize, self.save_opt,
-                readnoise_model.data.value, gain_model.data.value, self.algorithm,
-                self.weighting, max_cores, dqflags.pixel)
+                input_model,
+                buffsize,
+                self.save_opt,
+                readnoise_model.data.value,
+                gain_model.data.value,
+                self.algorithm,
+                self.weighting,
+                max_cores,
+                dqflags.pixel,
+            )
             readnoise_model.close()
             gain_model.close()
-
 
         # Save the OLS optional fit product, if it exists
         if opt_info is not None:
             opt_model = create_optional_results_model(input_model, opt_info)
-            self.save_model(opt_model, 'fitopt', output_file=self.opt_name)
-
+            self.save_model(opt_model, "fitopt", output_file=self.opt_name)
 
         # All pixels saturated, therefore returning an image file with zero data
         if image_info is None:
-            log.info('All pixels are saturated. Returning a zeroed-out image.')
+            log.info("All pixels are saturated. Returning a zeroed-out image.")
 
             # Image info order is: data, dq, var_poisson, var_rnoise, err
-            image_info = (np.zeros(input_model.data.shape[2:], dtype=input_model.data.dtype),
-                          input_model.pixeldq | input_model.groupdq[0][0] | dqflags.group['SATURATED'],
-                          np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
-                          np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
-                          np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype))
+            image_info = (
+                np.zeros(input_model.data.shape[2:], dtype=input_model.data.dtype),
+                input_model.pixeldq | input_model.groupdq[0][0] | dqflags.group["SATURATED"],
+                np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
+                np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
+                np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
+            )
 
         out_model = create_image_model(input_model, image_info)
-        out_model.meta.cal_step.ramp_fit = 'COMPLETE'
+        out_model.meta.cal_step.ramp_fit = "COMPLETE"
 
         if self.save_results:
             try:
-                self.suffix = 'rampfit'
+                self.suffix = "rampfit"
             except AttributeError:
-                self['suffix'] = 'rampfit'
+                self["suffix"] = "rampfit"
 
         return out_model

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -36,7 +36,17 @@ def create_optional_results_model(input_model, opt_info):
     opt_model : `~roman_datamodels.datamodels.RampFitOutputModel`
         The optional ``RampFitOutputModel`` to be returned from the ramp fit step.
     """
-    (slope, sigslope, var_poisson, var_rnoise, yint, sigyint, pedestal, weights, crmag) = opt_info
+    (
+        slope,
+        sigslope,
+        var_poisson,
+        var_rnoise,
+        yint,
+        sigyint,
+        pedestal,
+        weights,
+        crmag,
+    ) = opt_info
     meta = {}
     meta.update(input_model.meta)
     crmag.shape = crmag.shape[1:]
@@ -45,9 +55,17 @@ def create_optional_results_model(input_model, opt_info):
     inst = {
         "meta": meta,
         "slope": u.Quantity(np.squeeze(slope), ru.electron / u.s, dtype=slope.dtype),
-        "sigslope": u.Quantity(np.squeeze(sigslope), ru.electron / u.s, dtype=sigslope.dtype),
-        "var_poisson": u.Quantity(np.squeeze(var_poisson), ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
-        "var_rnoise": u.Quantity(np.squeeze(var_rnoise), ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
+        "sigslope": u.Quantity(
+            np.squeeze(sigslope), ru.electron / u.s, dtype=sigslope.dtype
+        ),
+        "var_poisson": u.Quantity(
+            np.squeeze(var_poisson),
+            ru.electron**2 / u.s**2,
+            dtype=var_poisson.dtype,
+        ),
+        "var_rnoise": u.Quantity(
+            np.squeeze(var_rnoise), ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+        ),
         "yint": u.Quantity(np.squeeze(yint), ru.electron, dtype=yint.dtype),
         "sigyint": u.Quantity(np.squeeze(sigyint), ru.electron, dtype=sigyint.dtype),
         "pedestal": u.Quantity(np.squeeze(pedestal), ru.electron, dtype=pedestal.dtype),
@@ -83,8 +101,12 @@ def create_image_model(input_model, image_info):
     data, dq, var_poisson, var_rnoise, err = image_info
 
     data = u.Quantity(data, ru.electron / u.s, dtype=data.dtype)
-    var_poisson = u.Quantity(var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype)
-    var_rnoise = u.Quantity(var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype)
+    var_poisson = u.Quantity(
+        var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype
+    )
+    var_rnoise = u.Quantity(
+        var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+    )
     err = u.Quantity(err, ru.electron / u.s, dtype=err.dtype)
 
     # Create output datamodel
@@ -97,8 +119,12 @@ def create_image_model(input_model, image_info):
         "meta": meta,
         "data": u.Quantity(data, ru.electron / u.s, dtype=data.dtype),
         "dq": dq,
-        "var_poisson": u.Quantity(var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype),
-        "var_rnoise": u.Quantity(var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype),
+        "var_poisson": u.Quantity(
+            var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype
+        ),
+        "var_rnoise": u.Quantity(
+            var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+        ),
         "err": u.Quantity(err, ru.electron / u.s, dtype=err.dtype),
         "amp33": input_model.amp33,
         "border_ref_pix_left": input_model.border_ref_pix_left,
@@ -187,7 +213,9 @@ class RampFitStep(RomanStep):
             # Image info order is: data, dq, var_poisson, var_rnoise, err
             image_info = (
                 np.zeros(input_model.data.shape[2:], dtype=input_model.data.dtype),
-                input_model.pixeldq | input_model.groupdq[0][0] | dqflags.group["SATURATED"],
+                input_model.pixeldq
+                | input_model.groupdq[0][0]
+                | dqflags.group["SATURATED"],
                 np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
                 np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),
                 np.zeros(input_model.err.shape[2:], dtype=input_model.err.dtype),

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -162,7 +162,7 @@ class RampFitStep(RomanStep):
         opt_name = string(default='')
         maximum_cores = option('none','quarter','half','all',default='none') # max number of processes to create
         save_opt = boolean(default=False) # Save optional output
-    """
+    """  # noqa: E501
     algorithm = "ols"  # Only algorithm allowed
 
     weighting = "optimal"  # Only weighting allowed

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -1,16 +1,15 @@
-import pytest
-import numpy as np
 import os
-from astropy.time import Time
-from astropy import units as u
 
-from roman_datamodels.datamodels import RampModel, GainRefModel, ReadnoiseRefModel, ImageModel
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.time import Time
 from roman_datamodels import maker_utils
 from roman_datamodels import units as ru
+from roman_datamodels.datamodels import GainRefModel, ImageModel, RampModel, ReadnoiseRefModel
 
-from romancal.ramp_fitting import RampFitStep
 from romancal.lib import dqflags
-
+from romancal.ramp_fitting import RampFitStep
 
 MAXIMUM_CORES = ['none', 'quarter', 'half', 'all']
 

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -11,17 +11,18 @@ from roman_datamodels.datamodels import GainRefModel, ImageModel, RampModel, Rea
 from romancal.lib import dqflags
 from romancal.ramp_fitting import RampFitStep
 
-MAXIMUM_CORES = ['none', 'quarter', 'half', 'all']
+MAXIMUM_CORES = ["none", "quarter", "half", "all"]
 
-DO_NOT_USE = dqflags.group['DO_NOT_USE']
-JUMP_DET = dqflags.group['JUMP_DET']
-SATURATED = dqflags.group['SATURATED']
+DO_NOT_USE = dqflags.group["DO_NOT_USE"]
+JUMP_DET = dqflags.group["JUMP_DET"]
+SATURATED = dqflags.group["SATURATED"]
 
 dqflags = {
     "DO_NOT_USE": 1,
     "SATURATED": 2,
     "JUMP_DET": 4,
 }
+
 
 def generate_ramp_model(shape, deltatime=1):
     data = u.Quantity((np.random.random(shape) * 0.5).astype(np.float32), ru.DN, dtype=np.float32)
@@ -45,47 +46,47 @@ def generate_ramp_model(shape, deltatime=1):
     return ramp_model
 
 
-def generate_wfi_reffiles(shape, ingain = 6):
+def generate_wfi_reffiles(shape, ingain=6):
     # Create temporary gain reference file
     gain_ref = maker_utils.mk_gain(shape)
 
-    gain_ref['meta']['instrument']['detector'] = 'WFI01'
-    gain_ref['meta']['instrument']['name'] = 'WFI'
-    gain_ref['meta']['reftype'] = 'GAIN'
-    gain_ref['meta']['useafter'] = Time('2022-01-01T11:11:11.111')
+    gain_ref["meta"]["instrument"]["detector"] = "WFI01"
+    gain_ref["meta"]["instrument"]["name"] = "WFI"
+    gain_ref["meta"]["reftype"] = "GAIN"
+    gain_ref["meta"]["useafter"] = Time("2022-01-01T11:11:11.111")
 
-    gain_ref['data'] = u.Quantity((np.random.random(shape) * 0.5).astype(np.float32) * ingain,
-                                  ru.electron / ru.DN, dtype=np.float32)
-    gain_ref['dq'] = np.zeros(shape, dtype=np.uint16)
-    gain_ref['err'] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float32),
-                                 ru.electron / ru.DN, dtype=np.float32)
+    gain_ref["data"] = u.Quantity(
+        (np.random.random(shape) * 0.5).astype(np.float32) * ingain, ru.electron / ru.DN, dtype=np.float32
+    )
+    gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
+    gain_ref["err"] = u.Quantity((np.random.random(shape) * 0.05).astype(np.float32), ru.electron / ru.DN, dtype=np.float32)
 
     gain_ref_model = GainRefModel(gain_ref)
 
     # Create temporary readnoise reference file
     rn_ref = maker_utils.mk_readnoise(shape)
-    rn_ref['meta']['instrument']['detector'] = 'WFI01'
-    rn_ref['meta']['instrument']['name'] = 'WFI'
-    rn_ref['meta']['reftype'] = 'READNOISE'
-    rn_ref['meta']['useafter'] = Time('2022-01-01T11:11:11.111')
+    rn_ref["meta"]["instrument"]["detector"] = "WFI01"
+    rn_ref["meta"]["instrument"]["name"] = "WFI"
+    rn_ref["meta"]["reftype"] = "READNOISE"
+    rn_ref["meta"]["useafter"] = Time("2022-01-01T11:11:11.111")
 
-    rn_ref['meta']['exposure']['type'] = 'WFI_IMAGE'
-    rn_ref['meta']['exposure']['frame_time'] = 666
+    rn_ref["meta"]["exposure"]["type"] = "WFI_IMAGE"
+    rn_ref["meta"]["exposure"]["frame_time"] = 666
 
-    rn_ref['data'] = u.Quantity((np.random.random(shape) * 0.01).astype(np.float32), ru.DN, dtype=np.float32)
+    rn_ref["data"] = u.Quantity((np.random.random(shape) * 0.01).astype(np.float32), ru.DN, dtype=np.float32)
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)
 
     # return gainfile, readnoisefile
     return gain_ref_model, rn_ref_model
 
+
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 @pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
 def test_one_group_small_buffer_fit_ols(max_cores):
-    ingain = 1.
+    ingain = 1.0
     deltatime = 1
     ngroups = 1
     xsize = 20
@@ -96,24 +97,23 @@ def test_one_group_small_buffer_fit_ols(max_cores):
 
     model1 = generate_ramp_model(shape, deltatime)
 
-    model1.data[0, 15, 10] = 10.0 * model1.data.unit # add single CR
+    model1.data[0, 15, 10] = 10.0 * model1.data.unit  # add single CR
 
-    out_model = \
-        RampFitStep.call(model1, override_gain=override_gain,
-                         override_readnoise=override_readnoise,
-                         maximum_cores=max_cores)
+    out_model = RampFitStep.call(
+        model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores=max_cores
+    )
 
     data = out_model.data.value
 
     # Index changes due to trimming of reference pixels
     np.testing.assert_allclose(data[11, 6], 10.0, 1e-6)
 
+
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 def test_multicore_ramp_fit_match():
-    ingain = 1.
+    ingain = 1.0
     deltatime = 1
     ngroups = 4
     xsize = 20
@@ -124,15 +124,11 @@ def test_multicore_ramp_fit_match():
 
     model1 = generate_ramp_model(shape, deltatime)
 
-    out_model = \
-        RampFitStep.call(model1, override_gain=override_gain,
-                         override_readnoise=override_readnoise,
-                         maximum_cores="none")
+    out_model = RampFitStep.call(model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores="none")
 
-    all_out_model = \
-        RampFitStep.call(model1, override_gain=override_gain,
-                         override_readnoise=override_readnoise,
-                         maximum_cores="all")
+    all_out_model = RampFitStep.call(
+        model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores="all"
+    )
 
     # Original ramp parameters
     np.testing.assert_allclose(out_model.data, all_out_model.data, 1e-6)
@@ -153,12 +149,11 @@ def test_multicore_ramp_fit_match():
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network"
+    os.environ.get("CI") == "true", reason="Roman CRDS servers are not currently available outside the internal network"
 )
 @pytest.mark.parametrize("max_cores", MAXIMUM_CORES)
 def test_saturated_ramp_fit(max_cores):
-    ingain = 1.
+    ingain = 1.0
     deltatime = 1
     ngroups = 4
     xsize = 20
@@ -173,10 +168,9 @@ def test_saturated_ramp_fit(max_cores):
     model1.groupdq = model1.groupdq | SATURATED
 
     # Run ramp fit step
-    out_model = \
-        RampFitStep.call(model1, override_gain=override_gain,
-                         override_readnoise=override_readnoise,
-                         maximum_cores=max_cores)
+    out_model = RampFitStep.call(
+        model1, override_gain=override_gain, override_readnoise=override_readnoise, maximum_cores=max_cores
+    )
 
     # Test data and error arrays are zeroed out
     np.testing.assert_array_equal(out_model.data.value, 0)
@@ -189,24 +183,17 @@ def test_saturated_ramp_fit(max_cores):
 
     # Test that original ramp parameters preserved
     np.testing.assert_allclose(out_model.amp33, model1.amp33, 1e-6)
-    np.testing.assert_allclose(out_model.border_ref_pix_left, model1.border_ref_pix_left,
-                               1e-6)
-    np.testing.assert_allclose(out_model.border_ref_pix_right, model1.border_ref_pix_right,
-                               1e-6)
+    np.testing.assert_allclose(out_model.border_ref_pix_left, model1.border_ref_pix_left, 1e-6)
+    np.testing.assert_allclose(out_model.border_ref_pix_right, model1.border_ref_pix_right, 1e-6)
     np.testing.assert_allclose(out_model.border_ref_pix_top, model1.border_ref_pix_top, 1e-6)
-    np.testing.assert_allclose(out_model.border_ref_pix_bottom, model1.border_ref_pix_bottom,
-                               1e-6)
-    np.testing.assert_allclose(out_model.dq_border_ref_pix_left,
-                               model1.dq_border_ref_pix_left, 1e-6)
-    np.testing.assert_allclose(out_model.dq_border_ref_pix_right,
-                               model1.dq_border_ref_pix_right, 1e-6)
-    np.testing.assert_allclose(out_model.dq_border_ref_pix_top, model1.dq_border_ref_pix_top,
-                               1e-6)
-    np.testing.assert_allclose(out_model.dq_border_ref_pix_bottom,
-                               model1.dq_border_ref_pix_bottom, 1e-6)
+    np.testing.assert_allclose(out_model.border_ref_pix_bottom, model1.border_ref_pix_bottom, 1e-6)
+    np.testing.assert_allclose(out_model.dq_border_ref_pix_left, model1.dq_border_ref_pix_left, 1e-6)
+    np.testing.assert_allclose(out_model.dq_border_ref_pix_right, model1.dq_border_ref_pix_right, 1e-6)
+    np.testing.assert_allclose(out_model.dq_border_ref_pix_top, model1.dq_border_ref_pix_top, 1e-6)
+    np.testing.assert_allclose(out_model.dq_border_ref_pix_bottom, model1.dq_border_ref_pix_bottom, 1e-6)
 
     # Test that an Image model was returned.
     assert type(out_model) == ImageModel
 
     # Test that the ramp fit step was labeled complete
-    assert out_model.meta.cal_step.ramp_fit == 'COMPLETE'
+    assert out_model.meta.cal_step.ramp_fit == "COMPLETE"

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -1,18 +1,20 @@
-from datetime import datetime
 import copy
+import getpass
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 
-import getpass
 import pytest
-from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from astropy.table import Table
+from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from numpy.testing import assert_allclose, assert_equal
-#from astropy.io.fits import conf
 
 from romancal.regtest.regtestdata import RegtestData
 from romancal.regtest.sdp_pools_source import SDPPoolsSource
+
+#from astropy.io.fits import conf
+
 
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -110,9 +110,13 @@ def generate_artifactory_json(request, artifactory_repos):
             rtdata.to_asdf(path_asdf)
 
             # Generate an OKify JSON file
-            pattern = os.path.join(rtdata.remote_results_path, os.path.basename(rtdata.output))
+            pattern = os.path.join(
+                rtdata.remote_results_path, os.path.basename(rtdata.output)
+            )
             okify_schema_pattern.append(pattern)
-            okify_schema = generate_upload_schema(okify_schema_pattern, f"{os.path.dirname(rtdata.truth_remote)}/")
+            okify_schema = generate_upload_schema(
+                okify_schema_pattern, f"{os.path.dirname(rtdata.truth_remote)}/"
+            )
 
             jsonfile = os.path.join(cwd, f"{request.node.name}_okify.json")
             with open(jsonfile, "w") as fd:
@@ -122,7 +126,9 @@ def generate_artifactory_json(request, artifactory_repos):
             upload_schema_pattern.append(rtdata.output)
             upload_schema_pattern.append(os.path.abspath(jsonfile))
             upload_schema_pattern.append(path_asdf)
-            upload_schema = generate_upload_schema(upload_schema_pattern, rtdata.remote_results_path)
+            upload_schema = generate_upload_schema(
+                upload_schema_pattern, rtdata.remote_results_path
+            )
 
             jsonfile = os.path.join(cwd, f"{request.node.name}_results.json")
             with open(jsonfile, "w") as fd:
@@ -170,7 +176,9 @@ def generate_upload_schema(pattern, target, recursive=False):
     else:
         # Populate schema for this test's data
         upload_schema = copy.deepcopy(UPLOAD_SCHEMA)
-        upload_schema["files"][0].update({"pattern": pattern, "target": target, "recursive": recursive})
+        upload_schema["files"][0].update(
+            {"pattern": pattern, "target": target, "recursive": recursive}
+        )
     return upload_schema
 
 
@@ -245,7 +253,9 @@ def diff_astropy_tables():
 
                 if truth[col_name].dtype.kind == "f":
                     try:
-                        assert_allclose(result[col_name], truth[col_name], rtol=rtol, atol=atol)
+                        assert_allclose(
+                            result[col_name], truth[col_name], rtol=rtol, atol=atol
+                        )
                     except AssertionError as err:
                         diffs.append(
                             "\n----------------------------------\n"
@@ -274,7 +284,10 @@ def diff_astropy_tables():
 # Add option to specify a single pool name
 def pytest_addoption(parser):
     parser.addoption(
-        "--sdp-pool", metavar="sdp_pool", default=None, help="SDP test pool to run. Specify the name only, not extension or path"
+        "--sdp-pool",
+        metavar="sdp_pool",
+        default=None,
+        help="SDP test pool to run. Specify the name only, not extension or path",
     )
     parser.addoption(
         "--standard-pool",

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -13,8 +13,7 @@ from numpy.testing import assert_allclose, assert_equal
 from romancal.regtest.regtestdata import RegtestData
 from romancal.regtest.sdp_pools_source import SDPPoolsSource
 
-#from astropy.io.fits import conf
-
+# from astropy.io.fits import conf
 
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
@@ -27,8 +26,8 @@ TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
 def artifactory_repos(pytestconfig):
     """Provides Artifactory inputs_root and results_root"""
     try:
-        inputs_root = pytestconfig.getini('inputs_root')[0]
-        results_root = pytestconfig.getini('results_root')[0]
+        inputs_root = pytestconfig.getini("inputs_root")[0]
+        results_root = pytestconfig.getini("results_root")[0]
     except IndexError:
         inputs_root = "roman-pipeline"
         results_root = "roman-pipeline-results"
@@ -50,8 +49,7 @@ def pytest_runtest_makereport(item, call):
 
 
 def postmortem(request, fixturename):
-    """Retrieve a fixture object if a test failed, else return None
-    """
+    """Retrieve a fixture object if a test failed, else return None"""
     try:
         if request.node.report_setup.passed:
             try:
@@ -66,7 +64,7 @@ def postmortem(request, fixturename):
         return None
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def generate_artifactory_json(request, artifactory_repos):
     """Pytest fixture that leaves behind JSON upload and okify specfiles
     if the rtdata or rtdata_module fixtures are used in either a test or a
@@ -77,11 +75,11 @@ def generate_artifactory_json(request, artifactory_repos):
 
     def artifactory_result_path():
         # Generate the Artifactory result path
-        whoami = getpass.getuser() or 'nobody'
-        user_tag = f'NOT_CI_{whoami}'
-        build_tag = os.environ.get('BUILD_TAG', user_tag)
-        build_matrix_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', '0')
-        subdir = f'{TODAYS_DATE}_{build_tag}_{build_matrix_suffix}'
+        whoami = getpass.getuser() or "nobody"
+        user_tag = f"NOT_CI_{whoami}"
+        build_tag = os.environ.get("BUILD_TAG", user_tag)
+        build_matrix_suffix = os.environ.get("BUILD_MATRIX_SUFFIX", "0")
+        subdir = f"{TODAYS_DATE}_{build_tag}_{build_matrix_suffix}"
         testname = request.node.originalname or request.node.name
 
         return os.path.join(results_root, subdir, testname) + os.sep
@@ -91,14 +89,14 @@ def generate_artifactory_json(request, artifactory_repos):
     upload_schema_pattern = []
     okify_schema_pattern = []
 
-    rtdata = postmortem(request, 'rtdata') or postmortem(request, 'rtdata_module')
+    rtdata = postmortem(request, "rtdata") or postmortem(request, "rtdata_module")
     if rtdata:
         try:
             # The _jail fixture from ci_watson sets tmp_path
-            cwd = str(request.node.funcargs['tmp_path'])
+            cwd = str(request.node.funcargs["tmp_path"])
         except KeyError:
             # The jail fixture (module-scoped) returns the path
-            cwd = str(request.node.funcargs['jail'])
+            cwd = str(request.node.funcargs["jail"])
         rtdata.remote_results_path = artifactory_result_path()
         rtdata.test_name = request.node.name
         # Dump the failed test traceback into rtdata
@@ -112,25 +110,22 @@ def generate_artifactory_json(request, artifactory_repos):
             rtdata.to_asdf(path_asdf)
 
             # Generate an OKify JSON file
-            pattern = os.path.join(rtdata.remote_results_path,
-                os.path.basename(rtdata.output))
+            pattern = os.path.join(rtdata.remote_results_path, os.path.basename(rtdata.output))
             okify_schema_pattern.append(pattern)
-            okify_schema = generate_upload_schema(okify_schema_pattern,
-                f"{os.path.dirname(rtdata.truth_remote)}/")
+            okify_schema = generate_upload_schema(okify_schema_pattern, f"{os.path.dirname(rtdata.truth_remote)}/")
 
             jsonfile = os.path.join(cwd, f"{request.node.name}_okify.json")
-            with open(jsonfile, 'w') as fd:
+            with open(jsonfile, "w") as fd:
                 json.dump(okify_schema, fd, indent=2)
 
             # Generate an upload JSON file, including the OKify, asdf file
             upload_schema_pattern.append(rtdata.output)
             upload_schema_pattern.append(os.path.abspath(jsonfile))
             upload_schema_pattern.append(path_asdf)
-            upload_schema = generate_upload_schema(upload_schema_pattern,
-                rtdata.remote_results_path)
+            upload_schema = generate_upload_schema(upload_schema_pattern, rtdata.remote_results_path)
 
             jsonfile = os.path.join(cwd, f"{request.node.name}_results.json")
-            with open(jsonfile, 'w') as fd:
+            with open(jsonfile, "w") as fd:
                 json.dump(upload_schema, fd, indent=2)
 
 
@@ -170,45 +165,43 @@ def generate_upload_schema(pattern, target, recursive=False):
 
         for p in pattern:
             temp_schema = copy.deepcopy(UPLOAD_SCHEMA["files"][0])
-            temp_schema.update({"pattern": p, "target": target,
-                                "recursive": recursive})
+            temp_schema.update({"pattern": p, "target": target, "recursive": recursive})
             upload_schema["files"].append(temp_schema)
     else:
         # Populate schema for this test's data
         upload_schema = copy.deepcopy(UPLOAD_SCHEMA)
-        upload_schema["files"][0].update({"pattern": pattern, "target": target,
-                                          "recursive": recursive})
+        upload_schema["files"][0].update({"pattern": pattern, "target": target, "recursive": recursive})
     return upload_schema
 
 
 def _rtdata_fixture_implementation(artifactory_repos, envopt, request):
     """Provides the RemoteResource class"""
     inputs_root, results_root = artifactory_repos
-    rtdata = RegtestData(env=envopt, inputs_root=inputs_root,
-        results_root=results_root)
+    rtdata = RegtestData(env=envopt, inputs_root=inputs_root, results_root=results_root)
 
     yield rtdata
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def rtdata(artifactory_repos, envopt, request, _jail):
     yield from _rtdata_fixture_implementation(artifactory_repos, envopt, request)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def rtdata_module(artifactory_repos, envopt, request, jail):
     yield from _rtdata_fixture_implementation(artifactory_repos, envopt, request)
 
 
 @pytest.fixture
 def ignore_asdf_paths():
-    ignore_attr = ["meta.[date, filename]",
-                   "asdf_library",
-                   "history",
-                   "cal_logs",
-                   ]
+    ignore_attr = [
+        "meta.[date, filename]",
+        "asdf_library",
+        "history",
+        "cal_logs",
+    ]
 
-    return {'ignore': ignore_attr}
+    return {"ignore": ignore_attr}
 
 
 @pytest.fixture
@@ -239,7 +232,7 @@ def diff_astropy_tables():
 
         # Disable meta comparison for now, until we're able to specify
         # individual entries for comparison
-        #if result.meta != truth.meta:
+        # if result.meta != truth.meta:
         #    diffs.append("Metadata does not match")
 
         for col_name in truth.colnames:
@@ -252,10 +245,10 @@ def diff_astropy_tables():
 
                 if truth[col_name].dtype.kind == "f":
                     try:
-                        assert_allclose(result[col_name], truth[col_name],
-                            rtol=rtol, atol=atol)
+                        assert_allclose(result[col_name], truth[col_name], rtol=rtol, atol=atol)
                     except AssertionError as err:
-                        diffs.append("\n----------------------------------\n"
+                        diffs.append(
+                            "\n----------------------------------\n"
                             + f"Column '{col_name}' values do not "
                             + f"match (within tolerances) \n{err}"
                         )
@@ -277,37 +270,39 @@ def diff_astropy_tables():
 
     return _diff_astropy_tables
 
+
 # Add option to specify a single pool name
 def pytest_addoption(parser):
     parser.addoption(
-        '--sdp-pool', metavar='sdp_pool', default=None,
-        help='SDP test pool to run. Specify the name only, not extension or path'
+        "--sdp-pool", metavar="sdp_pool", default=None, help="SDP test pool to run. Specify the name only, not extension or path"
     )
     parser.addoption(
-        '--standard-pool', metavar='standard_pool', default=None,
-        help='Standard test pool to run. Specify the name only, not extension or path'
+        "--standard-pool",
+        metavar="standard_pool",
+        default=None,
+        help="Standard test pool to run. Specify the name only, not extension or path",
     )
 
 
 @pytest.fixture
 def sdp_pool(request):
     """Retrieve a specific SDP pool to test"""
-    return request.config.getoption('--sdp-pool')
+    return request.config.getoption("--sdp-pool")
 
 
 @pytest.fixture
 def standard_pool(request):
     """Retrieve a specific standard pool to test"""
-    return request.config.getoption('--standard-pool')
+    return request.config.getoption("--standard-pool")
 
 
 def pytest_generate_tests(metafunc):
     """Prefetch and parametrize a set of test pools"""
-    if 'pool_path' in metafunc.fixturenames:
+    if "pool_path" in metafunc.fixturenames:
         try:
-            SDPPoolsSource.inputs_root = metafunc.config.getini('inputs_root')[0]
-            SDPPoolsSource.results_root = metafunc.config.getini('results_root')[0]
-            SDPPoolsSource.env = metafunc.config.getoption('env')
+            SDPPoolsSource.inputs_root = metafunc.config.getini("inputs_root")[0]
+            SDPPoolsSource.results_root = metafunc.config.getini("results_root")[0]
+            SDPPoolsSource.env = metafunc.config.getoption("env")
         except IndexError:
             SDPPoolsSource.inputs_root = "roman-pipeline"
             SDPPoolsSource.results_root = "roman-pipeline-results"
@@ -320,9 +315,6 @@ def pytest_generate_tests(metafunc):
         except Exception:
             pool_paths = []
 
-        ids = [
-            Path(pool_path).stem
-            for pool_path in pool_paths
-        ]
+        ids = [Path(pool_path).stem for pool_path in pool_paths]
 
-        metafunc.parametrize('pool_path', pool_paths, ids=ids)
+        metafunc.parametrize("pool_path", pool_paths, ids=ids)

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -1,22 +1,17 @@
+import os
+import os.path as op
+import pprint
+import shutil
+import sys
 from difflib import unified_diff
 from glob import glob as _sys_glob
 from io import StringIO
-import os
-import os.path as op
 from pathlib import Path
-import pprint
-import requests
-import shutil
-import sys
 
 import asdf
+import requests
 from asdf.commands.diff import diff as asdf_diff
-from ci_watson.artifactory_helpers import (
-    check_url,
-    get_bigdata_root,
-    get_bigdata,
-    BigdataError,
-)
+from ci_watson.artifactory_helpers import BigdataError, check_url, get_bigdata, get_bigdata_root
 
 # from romancal.lib.suffix import replace_suffix
 from romancal.stpipe import RomanStep

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -11,7 +11,12 @@ from pathlib import Path
 import asdf
 import requests
 from asdf.commands.diff import diff as asdf_diff
-from ci_watson.artifactory_helpers import BigdataError, check_url, get_bigdata, get_bigdata_root
+from ci_watson.artifactory_helpers import (
+    BigdataError,
+    check_url,
+    get_bigdata,
+    get_bigdata_root,
+)
 
 # from romancal.lib.suffix import replace_suffix
 from romancal.stpipe import RomanStep
@@ -177,7 +182,9 @@ class RegtestData:
             file_paths = _data_glob_local(path, glob)
         elif check_url(root):
             root_len = len(self._env) + 1
-            file_paths = _data_glob_url(self._inputs_root, self._env, path, glob, root=root)
+            file_paths = _data_glob_url(
+                self._inputs_root, self._env, path, glob, root=root
+            )
         else:
             raise BigdataError(f"Path cannot be found: {path}")
 

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -17,17 +17,28 @@ from ci_watson.artifactory_helpers import BigdataError, check_url, get_bigdata, 
 from romancal.stpipe import RomanStep
 
 # Define location of default Artifactory API key, for Jenkins use only
-ARTIFACTORY_API_KEY_FILE = '/eng/ssb2/keys/svc_rodata.key'
+ARTIFACTORY_API_KEY_FILE = "/eng/ssb2/keys/svc_rodata.key"
 
 
 class RegtestData:
     """Defines data paths on Artifactory and data retrieval methods"""
 
-    def __init__(self, env="dev", inputs_root="roman-pipeline",
-                 results_root="roman-pipeline-results", docopy=True,
-                 input=None, input_remote=None, output=None, truth=None,
-                 truth_remote=None, remote_results_path=None, test_name=None,
-                 traceback=None, **kwargs):
+    def __init__(
+        self,
+        env="dev",
+        inputs_root="roman-pipeline",
+        results_root="roman-pipeline-results",
+        docopy=True,
+        input=None,
+        input_remote=None,
+        output=None,
+        truth=None,
+        truth_remote=None,
+        remote_results_path=None,
+        test_name=None,
+        traceback=None,
+        **kwargs,
+    ):
         self._env = env
         self._inputs_root = inputs_root
         self._results_root = results_root
@@ -52,11 +63,17 @@ class RegtestData:
 
     def __repr__(self):
         return pprint.pformat(
-            dict(input=self.input, output=self.output, truth=self.truth,
-            input_remote=self.input_remote, truth_remote=self.truth_remote,
-            remote_results_path=self.remote_results_path, test_name=self.test_name,
-            traceback=self.traceback),
-            indent=1
+            dict(
+                input=self.input,
+                output=self.output,
+                truth=self.truth,
+                input_remote=self.input_remote,
+                truth_remote=self.truth_remote,
+                remote_results_path=self.remote_results_path,
+                test_name=self.test_name,
+                traceback=self.traceback,
+            ),
+            indent=1,
         )
 
     @property
@@ -136,13 +153,12 @@ class RegtestData:
             self.input_remote = path
         if docopy is None:
             docopy = self.docopy
-        self.input = get_bigdata(self._inputs_root, self._env, path,
-            docopy=docopy)
+        self.input = get_bigdata(self._inputs_root, self._env, path, docopy=docopy)
         self.input_remote = os.path.join(self._inputs_root, self._env, path)
 
         return self.input
 
-    def data_glob(self, path=None, glob='*', docopy=None):
+    def data_glob(self, path=None, glob="*", docopy=None):
         """Get a list of files"""
         if path is None:
             path = self.input_remote
@@ -161,16 +177,12 @@ class RegtestData:
             file_paths = _data_glob_local(path, glob)
         elif check_url(root):
             root_len = len(self._env) + 1
-            file_paths = _data_glob_url(self._inputs_root, self._env, path,
-                                        glob, root=root)
+            file_paths = _data_glob_url(self._inputs_root, self._env, path, glob, root=root)
         else:
-            raise BigdataError(f'Path cannot be found: {path}')
+            raise BigdataError(f"Path cannot be found: {path}")
 
         # Remove the root from the paths
-        file_paths = [
-            file_path[root_len:]
-            for file_path in file_paths
-        ]
+        file_paths = [file_path[root_len:] for file_path in file_paths]
         return file_paths
 
     def get_truth(self, path=None, docopy=None):
@@ -184,17 +196,15 @@ class RegtestData:
             self.truth_remote = path
         if docopy is None:
             docopy = self.docopy
-        os.makedirs('truth', exist_ok=True)
-        os.chdir('truth')
+        os.makedirs("truth", exist_ok=True)
+        os.chdir("truth")
         try:
-            self.truth = get_bigdata(self._inputs_root, self._env, path,
-                                     docopy=docopy)
-            self.truth_remote = os.path.join(self._inputs_root,
-                                             self._env, path)
+            self.truth = get_bigdata(self._inputs_root, self._env, path, docopy=docopy)
+            self.truth_remote = os.path.join(self._inputs_root, self._env, path)
         except BigdataError:
-            os.chdir('..')
+            os.chdir("..")
             raise
-        os.chdir('..')
+        os.chdir("..")
 
         return self.truth
 
@@ -292,13 +302,13 @@ def run_step_from_dict(rtdata, **step_params):
     #         rtdata.get_data(input_path)
 
     # Figure out whether we have a config or class
-    step = step_params['step']
-    if step.endswith(('.asdf', '.cfg')):
-        step = os.path.join('config', step)
+    step = step_params["step"]
+    if step.endswith((".asdf", ".cfg")):
+        step = os.path.join("config", step)
 
     # Run the step
     full_args = [step, rtdata.input]
-    full_args.extend(step_params['args'])
+    full_args.extend(step_params["args"])
 
     RomanStep.from_cmdline(full_args)
 
@@ -351,13 +361,12 @@ def run_step_from_dict_mock(rtdata, source, **step_params):
     for file_name in os.listdir(source):
         file_path = os.path.join(source, file_name)
         if os.path.isfile(file_path):
-            shutil.copy(file_path, '.')
+            shutil.copy(file_path, ".")
 
     return rtdata
 
 
-def is_like_truth(rtdata, ignore_asdf_paths, output, truth_path,
-                  is_suffix=True):
+def is_like_truth(rtdata, ignore_asdf_paths, output, truth_path, is_suffix=True):
     """Compare step outputs with truth
 
     Parameters
@@ -385,7 +394,7 @@ def is_like_truth(rtdata, ignore_asdf_paths, output, truth_path,
     if is_suffix:
         # suffix = output
         if rtdata.asn:
-            output = rtdata.asn['products'][0]['name']
+            output = rtdata.asn["products"][0]["name"]
         else:
             output = os.path.splitext(os.path.basename(rtdata.input))[0]
         # output = replace_suffix(output, suffix) + '.asdf'
@@ -465,47 +474,49 @@ def _data_glob_url(*url_parts, root=None):
         Full URLS that match the glob criterion
     """
     # Fix root root-ed-ness
-    if root.endswith('/'):
+    if root.endswith("/"):
         root = root[:-1]
 
     # Access
     try:
-        envkey = os.environ['API_KEY_FILE']
+        envkey = os.environ["API_KEY_FILE"]
     except KeyError:
         envkey = ARTIFACTORY_API_KEY_FILE
 
     try:
         with open(envkey) as fp:
-            headers = {'X-JFrog-Art-Api': fp.readline().strip()}
+            headers = {"X-JFrog-Art-Api": fp.readline().strip()}
     except (PermissionError, FileNotFoundError):
-        print("Warning: Anonymous Artifactory search requests are limited to "
-              "1000 results. Use an API key and define API_KEY_FILE environment"
-              "variable to get full search results.", file=sys.stderr)
+        print(
+            "Warning: Anonymous Artifactory search requests are limited to "
+            "1000 results. Use an API key and define API_KEY_FILE environment"
+            "variable to get full search results.",
+            file=sys.stderr,
+        )
         headers = None
 
-    search_url = '/'.join([root, 'api/search/pattern'])
+    search_url = "/".join([root, "api/search/pattern"])
 
     # Join and re-split the url so that every component is identified.
-    url = '/'.join([root] + [idx for idx in url_parts])
-    all_parts = url.split('/')
+    url = "/".join([root] + [idx for idx in url_parts])
+    all_parts = url.split("/")
 
     # Pick out "roman-pipeline", the repo name
     repo = all_parts[4]
 
     # Format the pattern
-    pattern = repo + ':' + '/'.join(all_parts[5:])
+    pattern = repo + ":" + "/".join(all_parts[5:])
 
     # Make the query
-    params = {'pattern': pattern}
+    params = {"pattern": pattern}
     with requests.get(search_url, params=params, headers=headers) as r:
-        url_paths = r.json()['files']
+        url_paths = r.json()["files"]
 
     return url_paths
 
 
 def compare_asdf(result, truth, **kwargs):
     f = StringIO()
-    asdf_diff([result, truth], minimal=False,
-              iostream=f, **kwargs)
+    asdf_diff([result, truth], minimal=False, iostream=f, **kwargs)
     if f.getvalue():
         f.getvalue()

--- a/romancal/regtest/sdp_pools_source.py
+++ b/romancal/regtest/sdp_pools_source.py
@@ -17,12 +17,12 @@ class SDPPoolsSource(BaseRomanTest):
     # of `BaseJWSTTest`, or explicitly during dynamic parametrization
     # The empty string defaults indicate that data source roots have
     # been defined.
-    inputs_root = ''
-    results_root = ''
+    inputs_root = ""
+    results_root = ""
 
-    input_loc = 'associations'
-    test_dir = 'sdp'
-    ref_loc = [test_dir, 'truth']
+    input_loc = "associations"
+    test_dir = "sdp"
+    ref_loc = [test_dir, "truth"]
 
     _pool_paths = None
     _truth_paths = None
@@ -31,12 +31,12 @@ class SDPPoolsSource(BaseRomanTest):
     def pool_paths(self):
         """Get the association pools"""
         if self._pool_paths is None:
-            self._pool_paths = self.data_glob(self.test_dir, 'pools', glob='*.csv')
+            self._pool_paths = self.data_glob(self.test_dir, "pools", glob="*.csv")
         return self._pool_paths
 
     @property
     def truth_paths(self):
         """Get the truth associations"""
         if self._truth_paths is None:
-            self._truth_paths = self.data_glob(*self.ref_loc, glob='*.json')
+            self._truth_paths = self.data_glob(*self.ref_loc, glob="*.json")
         return self._truth_paths

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -31,7 +31,11 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
-    args = ["romancal.step.DarkCurrentStep", rtdata.input, "--output_file=Test_darkcurrent"]
+    args = [
+        "romancal.step.DarkCurrentStep",
+        rtdata.input,
+        "--output_file=Test_darkcurrent",
+    ]
     RomanStep.from_cmdline(args)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
@@ -47,7 +51,12 @@ def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
-    args = ["romancal.step.DarkCurrentStep", rtdata.input, "--output_file=Test_dark", '--suffix="suffix_test"']
+    args = [
+        "romancal.step.DarkCurrentStep",
+        rtdata.input,
+        "--output_file=Test_dark",
+        '--suffix="suffix_test"',
+    ]
     RomanStep.from_cmdline(args)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
@@ -65,7 +74,11 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
     rtdata.input = input_datafile
     dark_output_name = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
 
-    args = ["romancal.step.DarkCurrentStep", rtdata.input, f"--dark_output={dark_output_name}"]
+    args = [
+        "romancal.step.DarkCurrentStep",
+        rtdata.input,
+        f"--dark_output={dark_output_name}",
+    ]
     RomanStep.from_cmdline(args)
     output = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -2,6 +2,7 @@
 import pytest
 
 from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -8,8 +8,8 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
-    """ Function to run and compare Dark Current subtraction files. Note: This
-        should include tests for overrides etc. """
+    """Function to run and compare Dark Current subtraction files. Note: This
+    should include tests for overrides etc."""
 
     input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
@@ -17,69 +17,57 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
     RomanStep.from_cmdline(args)
-    output =\
-        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
-    """ Function to run and compare Dark Current subtraction files. Here the
-        test is for renaming the output file. """
+    """Function to run and compare Dark Current subtraction files. Here the
+    test is for renaming the output file."""
     input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
-    rtdata.get_data(
-        f'WFI/image/{input_datafile}')
+    rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
-    args = ["romancal.step.DarkCurrentStep", rtdata.input,
-            '--output_file=Test_darkcurrent']
+    args = ["romancal.step.DarkCurrentStep", rtdata.input, "--output_file=Test_darkcurrent"]
     RomanStep.from_cmdline(args)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
-    """ Function to run and compare Dark Current subtraction files. Here the
-        test is for renaming the output file. """
+    """Function to run and compare Dark Current subtraction files. Here the
+    test is for renaming the output file."""
     input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
-    args = ["romancal.step.DarkCurrentStep", rtdata.input,
-            '--output_file=Test_dark', '--suffix="suffix_test"']
+    args = ["romancal.step.DarkCurrentStep", rtdata.input, "--output_file=Test_dark", '--suffix="suffix_test"']
     RomanStep.from_cmdline(args)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_dark_current_output(rtdata, ignore_asdf_paths):
-    """ Function to run and compare Dark Current subtraction files. Here the
-        test for overriding the CRDS dark reference file. """
+    """Function to run and compare Dark Current subtraction files. Here the
+    test for overriding the CRDS dark reference file."""
 
     input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
-    dark_output_name = \
-        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    dark_output_name = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
 
-    args = ["romancal.step.DarkCurrentStep",
-            rtdata.input,
-            f"--dark_output={dark_output_name}"]
+    args = ["romancal.step.DarkCurrentStep", rtdata.input, f"--dark_output={dark_output_name}"]
     RomanStep.from_cmdline(args)
-    output =\
-        "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -2,6 +2,7 @@
 import pytest
 
 from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -8,8 +8,8 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_jump_detection_step(rtdata, ignore_asdf_paths):
-    """ Function to run and compare Jump Detection files. Note: This should
-        include tests for overrides etc. """
+    """Function to run and compare Jump Detection files. Note: This should
+    include tests for overrides etc."""
 
     input_file = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
@@ -17,13 +17,15 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
 
     # Note: the thresholds should be reset to the defaults once we have better
     # input data
-    args = ["romancal.step.JumpStep", rtdata.input,
-            '--rejection_threshold=180.',
-            '--three_group_rejection_threshold=185.',
-            '--four_group_rejection_threshold=190.']
+    args = [
+        "romancal.step.JumpStep",
+        rtdata.input,
+        "--rejection_threshold=180.",
+        "--three_group_rejection_threshold=185.",
+        "--four_group_rejection_threshold=190.",
+    ]
     RomanStep.from_cmdline(args)
     output = "r0000101001001001001_01101_0001_WFI01_jump.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -8,34 +8,30 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_linearity_step(rtdata, ignore_asdf_paths):
-    """ Function to run and compare linearity correction files."""
-    input_file = 'r0000101001001001001_01101_0001_WFI01_saturation.asdf'
+    """Function to run and compare linearity correction files."""
+    input_file = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input]
     RomanStep.from_cmdline(args)
-    output =\
-        "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
-    """ Function to run and linearity correction files. Here the
-        test is for renaming the output file. """
-    input_file = 'r0000101001001001001_01101_0001_WFI01_saturation.asdf'
+    """Function to run and linearity correction files. Here the
+    test is for renaming the output file."""
+    input_file = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
-    args = ["romancal.step.LinearityStep", rtdata.input,
-            '--output_file=Test_linearity']
+    args = ["romancal.step.LinearityStep", rtdata.input, "--output_file=Test_linearity"]
     RomanStep.from_cmdline(args)
     output = "Test_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -2,6 +2,7 @@
 import pytest
 
 from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -14,7 +14,12 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
-    args = ["romancal.step.RampFitStep", rtdata.input, "--save_opt=True", "--opt_name=rampfit_opt.asdf"]
+    args = [
+        "romancal.step.RampFitStep",
+        rtdata.input,
+        "--save_opt=True",
+        "--opt_name=rampfit_opt.asdf",
+    ]
     RomanStep.from_cmdline(args)
     output = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
     rtdata.output = output

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -1,7 +1,9 @@
 """ Module to test rampfit with optional output """
 
 import pytest
+
 from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -9,22 +9,19 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
-    """ Testing the ramp fitting step"""
+    """Testing the ramp fitting step"""
     input_data = "r0000101001001001001_01101_0001_WFI01_jump.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
-    args = ["romancal.step.RampFitStep", rtdata.input, '--save_opt=True',
-            '--opt_name=rampfit_opt.asdf']
+    args = ["romancal.step.RampFitStep", rtdata.input, "--save_opt=True", "--opt_name=rampfit_opt.asdf"]
     RomanStep.from_cmdline(args)
     output = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
     output = "rampfit_opt_fitopt.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -1,10 +1,12 @@
 """Tests for the DQ Init module and DMS 25 and DMS 26 requirements"""
 import os
-import pytest
 
+import pytest
 import roman_datamodels as rdm
-from romancal.stpipe import RomanStep
+
 from romancal.step import DQInitStep
+from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -31,7 +31,9 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
 
     step.log.info(f'DMS25 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(f'DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(
+        f'DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}'
+    )
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -47,7 +49,10 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     )
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(f'DMS25 MSG: Does ramp data contain pixeldq from mask file? : {("roman.pixeldq" in ramp_out.to_flat_dict())}')
+    step.log.info(
+        "DMS25 MSG: Does ramp data contain pixeldq from mask file? :"
+        f' {("roman.pixeldq" in ramp_out.to_flat_dict())}'
+    )
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -80,7 +85,9 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
 
     step.log.info(f'DMS26 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(f'DMS26 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(
+        f'DMS26 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}'
+    )
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -96,7 +103,10 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     )
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(f'DMS26 MSG: Does ramp data contain pixeldq from mask file? : {("roman.pixeldq" in ramp_out.to_flat_dict())}')
+    step.log.info(
+        "DMS26 MSG: Does ramp data contain pixeldq from mask file? :"
+        f' {("roman.pixeldq" in ramp_out.to_flat_dict())}'
+    )
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -13,7 +13,7 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     """DMS25 Test: Testing retrieval of best ref file for image data,
-       and creation of a ramp file with CRDS selected mask file applied."""
+    and creation of a ramp file with CRDS selected mask file applied."""
 
     input_file = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
@@ -22,16 +22,16 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info('DMS25 MSG: Testing retrieval of best '
-                  'ref file for image data, '
-                  'Success is creation of a ramp file with CRDS selected '
-                  'mask file applied.')
+    step.log.info(
+        "DMS25 MSG: Testing retrieval of best "
+        "ref file for image data, "
+        "Success is creation of a ramp file with CRDS selected "
+        "mask file applied."
+    )
 
-    step.log.info('DMS25 MSG: First data file: '
-                  f'{rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS25 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info('DMS25 MSG: CRDS matched mask file: '
-                  f'{ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -40,28 +40,29 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     output = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
-    step.log.info('DMS25 MSG: Running data quality initialization step.'
-                  ' The first ERROR is expected, due to extra CRDS parameters'
-                  ' not having been implemented yet.')
+    step.log.info(
+        "DMS25 MSG: Running data quality initialization step."
+        " The first ERROR is expected, due to extra CRDS parameters"
+        " not having been implemented yet."
+    )
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(f'DMS25 MSG: Does ramp data contain '
-                  'pixeldq from mask file? : '
-                  f'{("roman.pixeldq" in ramp_out.to_flat_dict())}')
+    step.log.info(f'DMS25 MSG: Does ramp data contain pixeldq from mask file? : {("roman.pixeldq" in ramp_out.to_flat_dict())}')
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    step.log.info('DMS25 MSG: Was the proper data quality array initialized'
-                  ' for the ramp data produced? : '
-                  f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    step.log.info(
+        "DMS25 MSG: Was the proper data quality array initialized"
+        " for the ramp data produced? : "
+        f"{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}"
+    )
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     """DMS26 Test: Testing retrieval of best ref file for grism data,
-     and creation of a ramp file with CRDS selected mask file applied."""
+    and creation of a ramp file with CRDS selected mask file applied."""
 
     input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
@@ -70,16 +71,16 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info('DMS26 MSG: Testing retrieval of best '
-                  'ref file for grism data, '
-                  'Success is creation of a ramp file with CRDS selected '
-                  'mask file applied.')
+    step.log.info(
+        "DMS26 MSG: Testing retrieval of best "
+        "ref file for grism data, "
+        "Success is creation of a ramp file with CRDS selected "
+        "mask file applied."
+    )
 
-    step.log.info(f'DMS26 MSG: First data file: '
-                  f'{rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS26 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(f'DMS26 MSG: CRDS matched mask file: '
-                  f'{ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS26 MSG: CRDS matched mask file: {ref_file_path.rsplit("/", 1)[1]}')
     ref_file_name = os.path.split(ref_file_path)[-1]
 
     assert "roman_wfi_mask" in ref_file_name
@@ -88,19 +89,20 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     output = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
-    step.log.info('DMS26 MSG: Running data quality initialization step.'
-                  'The first ERROR is expected, due to extra CRDS parameters '
-                  'not having been implemented yet.')
+    step.log.info(
+        "DMS26 MSG: Running data quality initialization step."
+        "The first ERROR is expected, due to extra CRDS parameters "
+        "not having been implemented yet."
+    )
     RomanStep.from_cmdline(args)
     ramp_out = rdm.open(rtdata.output)
-    step.log.info('DMS26 MSG: Does ramp data contain pixeldq '
-                  'from mask file? : '
-                  f'{("roman.pixeldq" in ramp_out.to_flat_dict())}')
+    step.log.info(f'DMS26 MSG: Does ramp data contain pixeldq from mask file? : {("roman.pixeldq" in ramp_out.to_flat_dict())}')
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    step.log.info('DMS26 MSG: Was proper data quality initialized '
-                  'ramp data produced? : '
-                  f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    step.log.info(
+        "DMS26 MSG: Was proper data quality initialized "
+        "ramp data produced? : "
+        f"{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}"
+    )
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -1,10 +1,12 @@
 import os
-import pytest
 
+import pytest
 import roman_datamodels as rdm
 from crds.core.exceptions import CrdsLookupError
-from romancal.stpipe import RomanStep
+
 from romancal.step import FlatFieldStep
+from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -80,16 +80,24 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     # Test CRDS
     step = FlatFieldStep()
     model = rdm.open(rtdata.input)
-    step.log.info("DMS79 MSG: Testing retrieval of best ref file, Success is flat file with correct use after date")
+    step.log.info(
+        "DMS79 MSG: Testing retrieval of best ref file, Success is flat file with"
+        " correct use after date"
+    )
 
     step.log.info(f'DMS79 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
     step.log.info(f"DMS79 MSG: Observation date: {model.meta.exposure.start_time}")
 
     ref_file_path = step.get_reference_file(model, "flat")
-    step.log.info(f'DMS79 MSG: CRDS matched flat file: {ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(
+        f'DMS79 MSG: CRDS matched flat file: {ref_file_path.rsplit("/", 1)[1]}'
+    )
     flat = rdm.open(ref_file_path)
     step.log.info(f"DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}")
-    step.log.info(f"DMS79 MSG: UseAfter date before observation date? : {(flat.meta.useafter < model.meta.exposure.start_time)}")
+    step.log.info(
+        "DMS79 MSG: UseAfter date before observation date? :"
+        f" {(flat.meta.useafter < model.meta.exposure.start_time)}"
+    )
 
     # Test FlatFieldStep
     output = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
@@ -127,10 +135,15 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     step.log.info(f"DMS79 MSG: Observation date: {model.meta.exposure.start_time}")
 
     ref_file_path_b = step.get_reference_file(model, "flat")
-    step.log.info(f'DMS79 MSG: CRDS matched flat file: {ref_file_path_b.rsplit("/", 1)[1]}')
+    step.log.info(
+        f'DMS79 MSG: CRDS matched flat file: {ref_file_path_b.rsplit("/", 1)[1]}'
+    )
     flat = rdm.open(ref_file_path_b)
     step.log.info(f"DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}")
-    step.log.info(f"DMS79 MSG: UseAfter date before observation date? : {(flat.meta.useafter < model.meta.exposure.start_time)}")
+    step.log.info(
+        "DMS79 MSG: UseAfter date before observation date? :"
+        f" {(flat.meta.useafter < model.meta.exposure.start_time)}"
+    )
 
     # Test FlatFieldStep
     output = "r0000101001001001001_01101_0002_WFI01_flat.asdf"
@@ -157,4 +170,6 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
         f'{("/".join(ref_file_path.rsplit("/", 3)[1:]))} != '
         f'{("/".join(ref_file_path_b.rsplit("/", 3)[1:]))}'
     )
-    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(ref_file_path_b.rsplit("/", 1)[1:])
+    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(
+        ref_file_path_b.rsplit("/", 1)[1:]
+    )

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -24,21 +24,20 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     ref_file_path = step.get_reference_file(model, "flat")
     ref_file_name = os.path.split(ref_file_path)[-1]
     assert "roman_wfi_flat" in ref_file_name
-# Test FlatFieldStep
+    # Test FlatFieldStep
     output = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using grism data. The reference file for
-       the grism and prism data should be None, only testing the grism
-       case here."""
+    the grism and prism data should be None, only testing the grism
+    case here."""
 
     input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
@@ -50,13 +49,13 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     try:
         ref_file_path = step.get_reference_file(model, "flat")
         # Check for a valid reference file
-        if ref_file_path != 'N/A':
+        if ref_file_path != "N/A":
             ref_file_name = os.path.split(ref_file_path)[-1]
-        elif ref_file_path == 'N/A':
+        elif ref_file_path == "N/A":
             ref_file_name = ref_file_path
     except CrdsLookupError:
         ref_file_name = None
-    assert ref_file_name == 'N/A'
+    assert ref_file_name == "N/A"
 
     # Test FlatFieldStep
     output = "r0000201001001001002_01101_0001_WFI01_flat.asdf"
@@ -64,15 +63,14 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-                         **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     """DMS79 Test: Testing that different datetimes pull different
-       flat files and successfully make level 2 output"""
+    flat files and successfully make level 2 output"""
 
     # First file
     input_l2_file = "r0000101001001001001_01101_0001_WFI01_assignwcs.asdf"
@@ -82,37 +80,35 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     # Test CRDS
     step = FlatFieldStep()
     model = rdm.open(rtdata.input)
-    step.log.info('DMS79 MSG: Testing retrieval of best ref file, '
-                  'Success is flat file with correct use after date')
+    step.log.info("DMS79 MSG: Testing retrieval of best ref file, Success is flat file with correct use after date")
 
-    step.log.info('DMS79 MSG: First data file: '
-                  f'{rtdata.input.rsplit("/", 1)[1]}')
-    step.log.info('DMS79 MSG: Observation date: '
-                  f'{model.meta.exposure.start_time}')
+    step.log.info(f'DMS79 MSG: First data file: {rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f"DMS79 MSG: Observation date: {model.meta.exposure.start_time}")
 
     ref_file_path = step.get_reference_file(model, "flat")
-    step.log.info('DMS79 MSG: CRDS matched flat file: '
-                  f'{ref_file_path.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS79 MSG: CRDS matched flat file: {ref_file_path.rsplit("/", 1)[1]}')
     flat = rdm.open(ref_file_path)
-    step.log.info(f'DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}')
-    step.log.info(f'DMS79 MSG: UseAfter date before observation date? : '
-                  f'{(flat.meta.useafter < model.meta.exposure.start_time)}')
+    step.log.info(f"DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}")
+    step.log.info(f"DMS79 MSG: UseAfter date before observation date? : {(flat.meta.useafter < model.meta.exposure.start_time)}")
 
     # Test FlatFieldStep
     output = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    step.log.info('DMS79 MSG: Running flat fielding step. The first ERROR is'
-                  'expected, due to extra CRDS parameters not having been '
-                  'implemented yet.')
+    step.log.info(
+        "DMS79 MSG: Running flat fielding step. The first ERROR is"
+        "expected, due to extra CRDS parameters not having been "
+        "implemented yet."
+    )
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
 
-    step.log.info('DMS79 MSG: Was proper flat fielded '
-                  'Level 2 data produced? : '
-                  f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    step.log.info(
+        "DMS79 MSG: Was proper flat fielded "
+        "Level 2 data produced? : "
+        f"{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}"
+    )
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
     # This test requires a second file, in order to meet the DMS79 requirement.
     # The test will show that two files with different observation dates match
@@ -127,38 +123,38 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     step = FlatFieldStep()
     model = rdm.open(rtdata.input)
 
-    step.log.info('DMS79 MSG: Second data file: '
-                  f'{rtdata.input.rsplit("/", 1)[1]}')
-    step.log.info('DMS79 MSG: Observation date: '
-                  f'{model.meta.exposure.start_time}')
+    step.log.info(f'DMS79 MSG: Second data file: {rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f"DMS79 MSG: Observation date: {model.meta.exposure.start_time}")
 
     ref_file_path_b = step.get_reference_file(model, "flat")
-    step.log.info('DMS79 MSG: CRDS matched flat file: '
-                  f'{ref_file_path_b.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS79 MSG: CRDS matched flat file: {ref_file_path_b.rsplit("/", 1)[1]}')
     flat = rdm.open(ref_file_path_b)
-    step.log.info(f'DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}')
-    step.log.info(f'DMS79 MSG: UseAfter date before observation date? : '
-                  f'{(flat.meta.useafter < model.meta.exposure.start_time)}')
+    step.log.info(f"DMS79 MSG: flat file UseAfter date: {flat.meta.useafter}")
+    step.log.info(f"DMS79 MSG: UseAfter date before observation date? : {(flat.meta.useafter < model.meta.exposure.start_time)}")
 
     # Test FlatFieldStep
     output = "r0000101001001001001_01101_0002_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    step.log.info('DMS79 MSG: Running flat fielding step. The first ERROR is'
-                  'expected, due to extra CRDS parameters not having been '
-                  'implemented yet.')
+    step.log.info(
+        "DMS79 MSG: Running flat fielding step. The first ERROR is"
+        "expected, due to extra CRDS parameters not having been "
+        "implemented yet."
+    )
     RomanStep.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    step.log.info('DMS79 MSG: Was proper flat fielded '
-                  'Level 2 data produced? : '
-                  f'{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    step.log.info(
+        "DMS79 MSG: Was proper flat fielded "
+        "Level 2 data produced? : "
+        f"{(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}"
+    )
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
     # Test differing flat matches
-    step.log.info('DMS79 MSG REQUIRED TEST: Are the two data files '
-                  'matched to different flat files? : '
-                  f'{("/".join(ref_file_path.rsplit("/", 3)[1:]))} != '
-                  f'{("/".join(ref_file_path_b.rsplit("/", 3)[1:]))}')
-    assert ("/".join(ref_file_path.rsplit("/", 1)[1:])) != \
-           ("/".join(ref_file_path_b.rsplit("/", 1)[1:]))
+    step.log.info(
+        "DMS79 MSG REQUIRED TEST: Are the two data files "
+        "matched to different flat files? : "
+        f'{("/".join(ref_file_path.rsplit("/", 3)[1:]))} != '
+        f'{("/".join(ref_file_path_b.rsplit("/", 3)[1:]))}'
+    )
+    assert "/".join(ref_file_path.rsplit("/", 1)[1:]) != "/".join(ref_file_path_b.rsplit("/", 1)[1:])

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -14,7 +14,7 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     """DMS140 Test: Testing application of photometric correction using
-       CRDS selected photom file."""
+    CRDS selected photom file."""
 
     input_data = "r0000201001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
@@ -26,13 +26,14 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     #  In Wide Field Imaging mode, the DMS shall generate Level 2 science
     # data products with absolute photometry calibrated in the WFI filter
     # used for the exposure.
-    step.log.info('DMS140 MSG: Testing absolute photometric '
-                  'calibrated image data. '
-                  'Success is creation of a Level 2 image file with '
-                  'CRDS selected photom file applied.')
+    step.log.info(
+        "DMS140 MSG: Testing absolute photometric "
+        "calibrated image data. "
+        "Success is creation of a Level 2 image file with "
+        "CRDS selected photom file applied."
+    )
 
-    step.log.info('DMS140 MSG: Image data file: '
-                  f'{rtdata.input.rsplit("/", 1)[1]}')
+    step.log.info(f'DMS140 MSG: Image data file: {rtdata.input.rsplit("/", 1)[1]}')
 
     # Note: if any of the following tests fail, check for a different
     # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
@@ -41,72 +42,80 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     output = "r0000201001001001001_01101_0001_WFI01_photom.asdf"
     rtdata.output = output
     args = ["romancal.step.PhotomStep", rtdata.input]
-    step.log.info('DMS140 MSG: Running photometric conversion step.'
-                  ' The first ERROR is expected, due to extra CRDS parameters'
-                  ' not having been implemented yet.')
+    step.log.info(
+        "DMS140 MSG: Running photometric conversion step."
+        " The first ERROR is expected, due to extra CRDS parameters"
+        " not having been implemented yet."
+    )
     RomanStep.from_cmdline(args)
     photom_out = rdm.open(rtdata.output)
 
-    step.log.info(f'DMS140 MSG: Photom step recorded as complete? : '
-                  f'{photom_out.meta.cal_step.photom == "COMPLETE"}')
+    step.log.info(f'DMS140 MSG: Photom step recorded as complete? : {photom_out.meta.cal_step.photom == "COMPLETE"}')
     assert photom_out.meta.cal_step.photom == "COMPLETE"
 
-    step.log.info('DMS140 MSG: Photom megajansky conversion calculated? : ' +
-                  str((photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr) and
-                       math.isclose(photom_out.meta.photometry.conversion_megajanskys.value,
-                                    0.3324, abs_tol=0.0001)))
+    step.log.info(
+        "DMS140 MSG: Photom megajansky conversion calculated? : "
+        + str(
+            (photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr)
+            and math.isclose(photom_out.meta.photometry.conversion_megajanskys.value, 0.3324, abs_tol=0.0001)
+        )
+    )
     assert photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr
-    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys.value,
-                        0.3324, abs_tol=0.0001)
+    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys.value, 0.3324, abs_tol=0.0001)
 
-    step.log.info('DMS140 MSG: Photom microjanskys conversion calculated? : ' +
-                  str((photom_out.meta.photometry.conversion_microjanskys.unit ==
-                       u.uJy / u.arcsec ** 2) and
-                      (math.isclose(photom_out.meta.photometry.conversion_microjanskys.value,
-                                    7.81320, abs_tol=0.0001))))
-    assert photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec ** 2
-    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys.value,
-                        7.81320, abs_tol=0.0001)
+    step.log.info(
+        "DMS140 MSG: Photom microjanskys conversion calculated? : "
+        + str(
+            (photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec**2)
+            and (math.isclose(photom_out.meta.photometry.conversion_microjanskys.value, 7.81320, abs_tol=0.0001))
+        )
+    )
+    assert photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec**2
+    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys.value, 7.81320, abs_tol=0.0001)
 
-    step.log.info('DMS140 MSG: Pixel area in steradians calculated? : ' +
-                  str((photom_out.meta.photometry.pixelarea_steradians.unit == u.sr) and
-                      (math.isclose(photom_out.meta.photometry.pixelarea_steradians.value,
-                                    2.8083e-13, abs_tol=1.0e-17))))
+    step.log.info(
+        "DMS140 MSG: Pixel area in steradians calculated? : "
+        + str(
+            (photom_out.meta.photometry.pixelarea_steradians.unit == u.sr)
+            and (math.isclose(photom_out.meta.photometry.pixelarea_steradians.value, 2.8083e-13, abs_tol=1.0e-17))
+        )
+    )
     assert photom_out.meta.photometry.pixelarea_steradians.unit == u.sr
-    assert math.isclose(photom_out.meta.photometry.pixelarea_steradians.value, 2.8083e-13,
-                        abs_tol=1.0e-17)
+    assert math.isclose(photom_out.meta.photometry.pixelarea_steradians.value, 2.8083e-13, abs_tol=1.0e-17)
 
-    step.log.info('DMS140 MSG: Pixel area in square arcseconds calculated? : ' +
-                  str((photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec ** 2) and
-                      (math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value,
-                                    0.011948, abs_tol=1.0e-6))))
-    assert photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec ** 2
-    assert math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948,
-                        abs_tol=1.0e-6)
+    step.log.info(
+        "DMS140 MSG: Pixel area in square arcseconds calculated? : "
+        + str(
+            (photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec**2)
+            and (math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948, abs_tol=1.0e-6))
+        )
+    )
+    assert photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec**2
+    assert math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948, abs_tol=1.0e-6)
 
-    step.log.info('DMS140 MSG: Photom megajansky conversion uncertainty calculated? : ' +
-                  str((photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit
-                       == u.MJy / u.sr) and
-                      (math.isclose(photom_out.meta.photometry.\
-                                    conversion_megajanskys_uncertainty.value, 0.0,
-                                    abs_tol=1.0e-6))))
+    step.log.info(
+        "DMS140 MSG: Photom megajansky conversion uncertainty calculated? : "
+        + str(
+            (photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit == u.MJy / u.sr)
+            and (math.isclose(photom_out.meta.photometry.conversion_megajanskys_uncertainty.value, 0.0, abs_tol=1.0e-6))
+        )
+    )
     assert photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit == u.MJy / u.sr
-    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys_uncertainty.value, 0.0,
-                        abs_tol=1.0e-6)
+    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys_uncertainty.value, 0.0, abs_tol=1.0e-6)
 
-    step.log.info('DMS140 MSG: Photom megajansky conversion uncertainty calculated? : ' +
-                  str((photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit ==
-                       u.uJy / u.arcsec ** 2) and
-                      (math.isclose(photom_out.meta.photometry.\
-                                    conversion_microjanskys_uncertainty.value, 0.0,
-                                    abs_tol=1.0e-6))))
-    assert photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit ==  \
-           u.uJy / u.arcsec ** 2
-    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys_uncertainty.value, 0.0,
-                        abs_tol=1.0e-6)
+    step.log.info(
+        "DMS140 MSG: Photom megajansky conversion uncertainty calculated? : "
+        + str(
+            (photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit == u.uJy / u.arcsec**2)
+            and (math.isclose(photom_out.meta.photometry.conversion_microjanskys_uncertainty.value, 0.0, abs_tol=1.0e-6))
+        )
+    )
+    assert photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit == u.uJy / u.arcsec**2
+    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys_uncertainty.value, 0.0, abs_tol=1.0e-6)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    step.log.info(f'DMS140 MSG: Was the proper absolute photometry calibrated image data produced?'
-                  f' : {(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}')
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    step.log.info(
+        "DMS140 MSG: Was the proper absolute photometry calibrated image data produced?"
+        f" : {(compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None)}"
+    )
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -1,11 +1,13 @@
 """Regression tests for the photom step of the Roman pipeline"""
 import math
-import pytest
 
+import pytest
 import roman_datamodels as rdm
 from astropy import units as u
-from romancal.stpipe import RomanStep
+
 from romancal.step import PhotomStep
+from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -50,68 +50,142 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
     photom_out = rdm.open(rtdata.output)
 
-    step.log.info(f'DMS140 MSG: Photom step recorded as complete? : {photom_out.meta.cal_step.photom == "COMPLETE"}')
+    step.log.info(
+        "DMS140 MSG: Photom step recorded as complete? :"
+        f' {photom_out.meta.cal_step.photom == "COMPLETE"}'
+    )
     assert photom_out.meta.cal_step.photom == "COMPLETE"
 
     step.log.info(
         "DMS140 MSG: Photom megajansky conversion calculated? : "
         + str(
             (photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr)
-            and math.isclose(photom_out.meta.photometry.conversion_megajanskys.value, 0.3324, abs_tol=0.0001)
+            and math.isclose(
+                photom_out.meta.photometry.conversion_megajanskys.value,
+                0.3324,
+                abs_tol=0.0001,
+            )
         )
     )
     assert photom_out.meta.photometry.conversion_megajanskys.unit == u.MJy / u.sr
-    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys.value, 0.3324, abs_tol=0.0001)
+    assert math.isclose(
+        photom_out.meta.photometry.conversion_megajanskys.value, 0.3324, abs_tol=0.0001
+    )
 
     step.log.info(
         "DMS140 MSG: Photom microjanskys conversion calculated? : "
         + str(
-            (photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec**2)
-            and (math.isclose(photom_out.meta.photometry.conversion_microjanskys.value, 7.81320, abs_tol=0.0001))
+            (
+                photom_out.meta.photometry.conversion_microjanskys.unit
+                == u.uJy / u.arcsec**2
+            )
+            and (
+                math.isclose(
+                    photom_out.meta.photometry.conversion_microjanskys.value,
+                    7.81320,
+                    abs_tol=0.0001,
+                )
+            )
         )
     )
-    assert photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec**2
-    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys.value, 7.81320, abs_tol=0.0001)
+    assert (
+        photom_out.meta.photometry.conversion_microjanskys.unit == u.uJy / u.arcsec**2
+    )
+    assert math.isclose(
+        photom_out.meta.photometry.conversion_microjanskys.value,
+        7.81320,
+        abs_tol=0.0001,
+    )
 
     step.log.info(
         "DMS140 MSG: Pixel area in steradians calculated? : "
         + str(
             (photom_out.meta.photometry.pixelarea_steradians.unit == u.sr)
-            and (math.isclose(photom_out.meta.photometry.pixelarea_steradians.value, 2.8083e-13, abs_tol=1.0e-17))
+            and (
+                math.isclose(
+                    photom_out.meta.photometry.pixelarea_steradians.value,
+                    2.8083e-13,
+                    abs_tol=1.0e-17,
+                )
+            )
         )
     )
     assert photom_out.meta.photometry.pixelarea_steradians.unit == u.sr
-    assert math.isclose(photom_out.meta.photometry.pixelarea_steradians.value, 2.8083e-13, abs_tol=1.0e-17)
+    assert math.isclose(
+        photom_out.meta.photometry.pixelarea_steradians.value,
+        2.8083e-13,
+        abs_tol=1.0e-17,
+    )
 
     step.log.info(
         "DMS140 MSG: Pixel area in square arcseconds calculated? : "
         + str(
             (photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec**2)
-            and (math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948, abs_tol=1.0e-6))
+            and (
+                math.isclose(
+                    photom_out.meta.photometry.pixelarea_arcsecsq.value,
+                    0.011948,
+                    abs_tol=1.0e-6,
+                )
+            )
         )
     )
     assert photom_out.meta.photometry.pixelarea_arcsecsq.unit == u.arcsec**2
-    assert math.isclose(photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948, abs_tol=1.0e-6)
+    assert math.isclose(
+        photom_out.meta.photometry.pixelarea_arcsecsq.value, 0.011948, abs_tol=1.0e-6
+    )
 
     step.log.info(
         "DMS140 MSG: Photom megajansky conversion uncertainty calculated? : "
         + str(
-            (photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit == u.MJy / u.sr)
-            and (math.isclose(photom_out.meta.photometry.conversion_megajanskys_uncertainty.value, 0.0, abs_tol=1.0e-6))
+            (
+                photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit
+                == u.MJy / u.sr
+            )
+            and (
+                math.isclose(
+                    photom_out.meta.photometry.conversion_megajanskys_uncertainty.value,
+                    0.0,
+                    abs_tol=1.0e-6,
+                )
+            )
         )
     )
-    assert photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit == u.MJy / u.sr
-    assert math.isclose(photom_out.meta.photometry.conversion_megajanskys_uncertainty.value, 0.0, abs_tol=1.0e-6)
+    assert (
+        photom_out.meta.photometry.conversion_megajanskys_uncertainty.unit
+        == u.MJy / u.sr
+    )
+    assert math.isclose(
+        photom_out.meta.photometry.conversion_megajanskys_uncertainty.value,
+        0.0,
+        abs_tol=1.0e-6,
+    )
 
     step.log.info(
         "DMS140 MSG: Photom megajansky conversion uncertainty calculated? : "
         + str(
-            (photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit == u.uJy / u.arcsec**2)
-            and (math.isclose(photom_out.meta.photometry.conversion_microjanskys_uncertainty.value, 0.0, abs_tol=1.0e-6))
+            (
+                photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit
+                == u.uJy / u.arcsec**2
+            )
+            and (
+                math.isclose(
+                    photom_out.meta.photometry.conversion_microjanskys_uncertainty.value,
+                    0.0,
+                    abs_tol=1.0e-6,
+                )
+            )
         )
     )
-    assert photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit == u.uJy / u.arcsec**2
-    assert math.isclose(photom_out.meta.photometry.conversion_microjanskys_uncertainty.value, 0.0, abs_tol=1.0e-6)
+    assert (
+        photom_out.meta.photometry.conversion_microjanskys_uncertainty.unit
+        == u.uJy / u.arcsec**2
+    )
+    assert math.isclose(
+        photom_out.meta.photometry.conversion_microjanskys_uncertainty.value,
+        0.0,
+        abs_tol=1.0e-6,
+    )
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     step.log.info(

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -49,69 +49,98 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     pipeline = ExposurePipeline()
 
     # DMS86 instrument artifact correction tests
-    pipeline.log.info("Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info(
+        "Status of the step:             assign_wcs    "
+        + str(model.meta.cal_step.assign_wcs)
+    )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of wcs assignment inLevel 2 image output......."
         + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
     )
     assert model.meta.cal_step.assign_wcs == "COMPLETE"
-    pipeline.log.info("Status of the step:             flat_field    " + str(model.meta.cal_step.flat_field))
+    pipeline.log.info(
+        "Status of the step:             flat_field    "
+        + str(model.meta.cal_step.flat_field)
+    )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of flat fielding inLevel 2 image output......."
         + passfail(model.meta.cal_step.flat_field == "PASS")
     )
     assert model.meta.cal_step.flat_field == "COMPLETE"
-    pipeline.log.info("Status of the step:             dark          " + str(model.meta.cal_step.dark))
+    pipeline.log.info(
+        "Status of the step:             dark          " + str(model.meta.cal_step.dark)
+    )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of dark correction inLevel 2 image output......."
         + passfail(model.meta.cal_step.dark == "COMPLETE")
     )
     assert model.meta.cal_step.dark == "COMPLETE"
-    pipeline.log.info("Status of the step:             dq_init       " + str(model.meta.cal_step.dq_init))
     pipeline.log.info(
-        "DMS86 MSG: Testing completion of data quality correction in Level 2 image output......."
-        + passfail(model.meta.cal_step.dq_init == "COMPLETE")
+        "Status of the step:             dq_init       "
+        + str(model.meta.cal_step.dq_init)
+    )
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of data quality correction in Level 2 image"
+        " output......." + passfail(model.meta.cal_step.dq_init == "COMPLETE")
     )
     assert model.meta.cal_step.dq_init == "COMPLETE"
-    pipeline.log.info("Status of the step:             jump          " + str(model.meta.cal_step.jump))
+    pipeline.log.info(
+        "Status of the step:             jump          " + str(model.meta.cal_step.jump)
+    )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of jump detection inLevel 2 image output......."
         + passfail(model.meta.cal_step.jump == "COMPLETE")
     )
     assert model.meta.cal_step.jump == "COMPLETE"
-    pipeline.log.info("Status of the step:             linearity     " + str(model.meta.cal_step.linearity))
     pipeline.log.info(
-        "DMS86 MSG: Testing completion of linearity correction in Level 2 image output......."
-        + passfail(model.meta.cal_step.linearity == "COMPLETE")
+        "Status of the step:             linearity     "
+        + str(model.meta.cal_step.linearity)
+    )
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of linearity correction in Level 2 image"
+        " output......." + passfail(model.meta.cal_step.linearity == "COMPLETE")
     )
     assert model.meta.cal_step.linearity == "COMPLETE"
-    pipeline.log.info("Status of the step:             ramp_fit      " + str(model.meta.cal_step.ramp_fit))
+    pipeline.log.info(
+        "Status of the step:             ramp_fit      "
+        + str(model.meta.cal_step.ramp_fit)
+    )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of ramp fitting inLevel 2 image output......."
         + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
     )
     assert model.meta.cal_step.ramp_fit == "COMPLETE"
-    pipeline.log.info("Status of the step:             saturation    " + str(model.meta.cal_step.saturation))
     pipeline.log.info(
-        "DMS86 MSG: Testing completion of saturation detection in Level 2 image output......."
-        + passfail(model.meta.cal_step.saturation == "COMPLETE")
+        "Status of the step:             saturation    "
+        + str(model.meta.cal_step.saturation)
+    )
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of saturation detection in Level 2 image"
+        " output......." + passfail(model.meta.cal_step.saturation == "COMPLETE")
     )
     assert model.meta.cal_step.saturation == "COMPLETE"
 
     # DMS-129 tests
     # check if assign_wcs step is complete
-    pipeline.log.info("DMS-129 MSG: Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
     pipeline.log.info(
-        "DMS-129 MSG: Testing completion of WCS assignment inLevel 2 image output......."
-        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+        "DMS-129 MSG: Status of the step:             assign_wcs    "
+        + str(model.meta.cal_step.assign_wcs)
+    )
+    pipeline.log.info(
+        "DMS-129 MSG: Testing completion of WCS assignment inLevel 2 image"
+        " output......." + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
     )
     assert model.meta.cal_step.assign_wcs == "COMPLETE"
     # check if WCS exists
     pipeline.log.info("DMS-129 MSG: Testing that a WCS object exists    ")
-    pipeline.log.info("DMS-129 MSG: Testing that WCS exists inLevel 2 image output......." + passfail(model.meta.wcs is not None))
+    pipeline.log.info(
+        "DMS-129 MSG: Testing that WCS exists inLevel 2 image output......."
+        + passfail(model.meta.wcs is not None)
+    )
     assert model.meta.wcs is not None
     pipeline.log.info(
-        "DMS-129 MSG: Testing that geometric distortion information is available inLevel 2 image output......."
+        "DMS-129 MSG: Testing that geometric distortion information is available"
+        " inLevel 2 image output......."
         + passfail("v2v3" in model.meta.wcs.available_frames)
     )
     assert "v2v3" in model.meta.wcs.available_frames
@@ -125,42 +154,47 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     # compare both results to make sure they don't match
     # (which means the distortion correction was actually applied to the model)
     pipeline.log.info(
-        "DMS-129 MSG: Testing that distortion correction was applied toLevel 2 image output......."
-        + passfail((corrected_coords[0] != original_coords[0]).all() & (corrected_coords[1] != original_coords[1]).all())
+        "DMS-129 MSG: Testing that distortion correction was applied toLevel 2 image"
+        " output......."
+        + passfail(
+            (corrected_coords[0] != original_coords[0]).all()
+            & (corrected_coords[1] != original_coords[1]).all()
+        )
     )
     assert (corrected_coords[0] != original_coords[0]).all()
     assert (corrected_coords[1] != original_coords[1]).all()
 
     # DMS87 data quality tests
     pipeline.log.info(
-        "DMS87 MSG: Testing existence of data quality array (dq) in Level 2 image output......." + passfail("dq" in model.keys())
+        "DMS87 MSG: Testing existence of data quality array (dq) in Level 2 image"
+        " output......." + passfail("dq" in model.keys())
     )
     assert "dq" in model.keys()
     pipeline.log.info(
-        "DMS87 MSG: Testing existence of general error array (err) in Level 2 image output......."
-        + passfail("err" in model.keys())
+        "DMS87 MSG: Testing existence of general error array (err) in Level 2 image"
+        " output......." + passfail("err" in model.keys())
     )
     assert "err" in model.keys()
     pipeline.log.info(
-        "DMS87 MSG: Testing existence of Poisson noise variancearray (var_poisson) in Level 2 image output......."
-        + passfail("var_poisson" in model.keys())
+        "DMS87 MSG: Testing existence of Poisson noise variancearray (var_poisson) in"
+        " Level 2 image output......." + passfail("var_poisson" in model.keys())
     )
     assert "var_poisson" in model.keys()
     pipeline.log.info(
-        "DMS87 MSG: Testing existence of read noise variance array (var_rnoise) in level 2 image output......."
-        + passfail("var_rnoise" in model.keys())
+        "DMS87 MSG: Testing existence of read noise variance array (var_rnoise) in"
+        " level 2 image output......." + passfail("var_rnoise" in model.keys())
     )
     assert "var_rnoise" in model.keys()
     pipeline.log.info(
-        "DMS87 MSG: Testing existence of flatfield uncertainty variance array (var_flat) in Level 2 image output...."
-        + passfail("var_flat" in model.keys())
+        "DMS87 MSG: Testing existence of flatfield uncertainty variance array"
+        " (var_flat) in Level 2 image output...." + passfail("var_flat" in model.keys())
     )
     assert "var_flat" in model.keys()
 
     # DMS88 total exposure time test
     pipeline.log.info(
-        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2 image output......."
-        + passfail("exposure_time" in model.meta.exposure)
+        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2"
+        " image output......." + passfail("exposure_time" in model.meta.exposure)
     )
     assert "exposure_time" in model.meta.exposure
 
@@ -175,7 +209,8 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
     # DMS89 WCS tests
     pipeline.log.info(
-        "DMS89 MSG: Testing that the wcs boundingbox was generated......." + passfail(len(model.meta.wcs.bounding_box) == 2)
+        "DMS89 MSG: Testing that the wcs boundingbox was generated......."
+        + passfail(len(model.meta.wcs.bounding_box) == 2)
     )
     assert len(model.meta.wcs.bounding_box) == 2
 
@@ -208,10 +243,15 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
     pipeline.log.info(
         "DMS89 MSG: Testing that the different pointings create differing wcs......."
-        + passfail(((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0) < 1.0)
+        + passfail(
+            ((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0)
+            < 1.0
+        )
     )
     assert_allclose(
-        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]], model.meta.wcs(2048, 2048), atol=1.0
+        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]],
+        model.meta.wcs(2048, 2048),
+        atol=1.0,
     )
 
 
@@ -244,87 +284,111 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     pipeline = ExposurePipeline()
 
     # DMS90 instrument artifact correction tests
-    pipeline.log.info("Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of wcs assignment inLevel 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+        "Status of the step:             assign_wcs    "
+        + str(model.meta.cal_step.assign_wcs)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of wcs assignment inLevel 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
     )
     assert model.meta.cal_step.assign_wcs == "COMPLETE"
-    pipeline.log.info("Status of the step:             flat_field    " + str(model.meta.cal_step.flat_field))
     pipeline.log.info(
-        "DMS90 MSG: Testing expected skip of flat fielding inLevel 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.flat_field == "SKIPPED")
+        "Status of the step:             flat_field    "
+        + str(model.meta.cal_step.flat_field)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing expected skip of flat fielding inLevel 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.flat_field == "SKIPPED")
     )
     assert model.meta.cal_step.flat_field == "SKIPPED"
-    pipeline.log.info("Status of the step:             dark          " + str(model.meta.cal_step.dark))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of dark correction inLevel 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.dark == "COMPLETE")
+        "Status of the step:             dark          " + str(model.meta.cal_step.dark)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of dark correction inLevel 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.dark == "COMPLETE")
     )
     assert model.meta.cal_step.dark == "COMPLETE"
-    pipeline.log.info("Status of the step:             dq_init       " + str(model.meta.cal_step.dq_init))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of data quality correction in Level 2 spectroscopic output......."
+        "Status of the step:             dq_init       "
+        + str(model.meta.cal_step.dq_init)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of data quality correction in Level 2"
+        " spectroscopic output......."
         + passfail(model.meta.cal_step.dq_init == "COMPLETE")
     )
     assert model.meta.cal_step.dq_init == "COMPLETE"
-    pipeline.log.info("Status of the step:             jump          " + str(model.meta.cal_step.jump))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of jump detection inLevel 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.jump == "COMPLETE")
+        "Status of the step:             jump          " + str(model.meta.cal_step.jump)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of jump detection inLevel 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.jump == "COMPLETE")
     )
     assert model.meta.cal_step.jump == "COMPLETE"
-    pipeline.log.info("Status of the step:             linearity     " + str(model.meta.cal_step.assign_wcs))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of linearity correction in Level 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.linearity == "COMPLETE")
+        "Status of the step:             linearity     "
+        + str(model.meta.cal_step.assign_wcs)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of linearity correction in Level 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.linearity == "COMPLETE")
     )
     assert model.meta.cal_step.linearity == "COMPLETE"
-    pipeline.log.info("Status of the step:             ramp_fit      " + str(model.meta.cal_step.ramp_fit))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of ramp fitting inLevel 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
+        "Status of the step:             ramp_fit      "
+        + str(model.meta.cal_step.ramp_fit)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of ramp fitting inLevel 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
     )
     assert model.meta.cal_step.ramp_fit == "COMPLETE"
-    pipeline.log.info("Status of the step:             saturation    " + str(model.meta.cal_step.saturation))
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of saturation detection in Level 2 spectroscopic output......."
-        + passfail(model.meta.cal_step.saturation == "COMPLETE")
+        "Status of the step:             saturation    "
+        + str(model.meta.cal_step.saturation)
+    )
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of saturation detection in Level 2 spectroscopic"
+        " output......." + passfail(model.meta.cal_step.saturation == "COMPLETE")
     )
     assert model.meta.cal_step.saturation == "COMPLETE"
 
     # DMS91 data quality tests
     pipeline.log.info(
-        "DMS91 MSG: Testing existence of data quality array (dq) in Level 2 spectroscopic output......."
-        + passfail("dq" in model.keys())
+        "DMS91 MSG: Testing existence of data quality array (dq) in Level 2"
+        " spectroscopic output......." + passfail("dq" in model.keys())
     )
     assert "dq" in model.keys()
     pipeline.log.info(
-        "DMS91 MSG: Testing existence of general error array (err) in Level 2 spectroscopic output......."
-        + passfail("err" in model.keys())
+        "DMS91 MSG: Testing existence of general error array (err) in Level 2"
+        " spectroscopic output......." + passfail("err" in model.keys())
     )
     assert "err" in model.keys()
     pipeline.log.info(
-        "DMS91 MSG: Testing existence of Poisson noise variance array (var_poisson) in Level 2 spectroscopic output.."
-        + passfail("var_poisson" in model.keys())
+        "DMS91 MSG: Testing existence of Poisson noise variance array (var_poisson) in"
+        " Level 2 spectroscopic output.." + passfail("var_poisson" in model.keys())
     )
     assert "var_poisson" in model.keys()
     pipeline.log.info(
-        "DMS91 MSG: Testing existence of read noise variance array (var_rnoise) in Level 2 spectroscopic output..."
-        + passfail("var_rnoise" in model.keys())
+        "DMS91 MSG: Testing existence of read noise variance array (var_rnoise) in"
+        " Level 2 spectroscopic output..." + passfail("var_rnoise" in model.keys())
     )
     assert "var_rnoise" in model.keys()
 
     # DMS88 total exposure time test
     pipeline.log.info(
-        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2 spectroscopic output."
-        + passfail("exposure_time" in model.meta.exposure)
+        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2"
+        " spectroscopic output." + passfail("exposure_time" in model.meta.exposure)
     )
     assert "exposure_time" in model.meta.exposure
 
     # DMS93 WCS tests
     pipeline.log.info(
-        "DMS93 MSG: Testing that the wcs boundingbox was generated......." + passfail(len(model.meta.wcs.bounding_box) == 2)
+        "DMS93 MSG: Testing that the wcs boundingbox was generated......."
+        + passfail(len(model.meta.wcs.bounding_box) == 2)
     )
     assert len(model.meta.wcs.bounding_box) == 2
 
@@ -357,10 +421,15 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
 
     pipeline.log.info(
         "DMS93 MSG: Testing that the different pointings create differing wcs......."
-        + passfail(((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0) < 1.0)
+        + passfail(
+            ((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0)
+            < 1.0
+        )
     )
     assert_allclose(
-        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]], model.meta.wcs(2048, 2048), atol=1.0
+        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]],
+        model.meta.wcs(2048, 2048),
+        atol=1.0,
     )
 
 

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -1,16 +1,16 @@
 """ Roman tests for flat field correction """
 import copy
-import pytest
 
 import numpy as np
+import pytest
+import roman_datamodels as rdm
+from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose
 
-import roman_datamodels as rdm
-from romancal.pipeline.exposure_pipeline import ExposurePipeline
 from romancal.assign_wcs.assign_wcs_step import AssignWcsStep
-from .regtestdata import compare_asdf
+from romancal.pipeline.exposure_pipeline import ExposurePipeline
 
-from gwcs.wcstools import grid_from_bounding_box
+from .regtestdata import compare_asdf
 
 
 def passfail(bool_expr):

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -14,7 +14,7 @@ from .regtestdata import compare_asdf
 
 
 def passfail(bool_expr):
-    """ set pass fail"""
+    """set pass fail"""
     if bool_expr:
         return "Pass"
     return "Fail"
@@ -23,7 +23,7 @@ def passfail(bool_expr):
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
-    """Tests for flat field imaging processing requirements DMS86 & DMS 87 """
+    """Tests for flat field imaging processing requirements DMS86 & DMS 87"""
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
@@ -31,16 +31,17 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     # Test Pipeline
     output = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
     rtdata.output = output
-    args = ["--disable-crds-steppars",
-            "--steps.jump.rejection_threshold=180.0",
-            "--steps.jump.three_group_rejection_threshold=185.0",
-            "--steps.jump.four_group_rejection_threshold=190",
-            "roman_elp", rtdata.input,
-            ]
+    args = [
+        "--disable-crds-steppars",
+        "--steps.jump.rejection_threshold=180.0",
+        "--steps.jump.three_group_rejection_threshold=185.0",
+        "--steps.jump.four_group_rejection_threshold=190",
+        "roman_elp",
+        rtdata.input,
+    ]
     ExposurePipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
     # Perform DMS tests
     # Initial prep
@@ -48,133 +49,139 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     pipeline = ExposurePipeline()
 
     # DMS86 instrument artifact correction tests
-    pipeline.log.info('Status of the step:             assign_wcs    ' +
-                      str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS86 MSG: Testing completion of wcs assignment in'
-                      'Level 2 image output.......' +
-                      passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
-    assert model.meta.cal_step.assign_wcs == 'COMPLETE'
-    pipeline.log.info('Status of the step:             flat_field    ' +
-                      str(model.meta.cal_step.flat_field))
-    pipeline.log.info('DMS86 MSG: Testing completion of flat fielding in'
-                      'Level 2 image output.......' +
-                      passfail(model.meta.cal_step.flat_field == 'PASS'))
-    assert model.meta.cal_step.flat_field == 'COMPLETE'
-    pipeline.log.info('Status of the step:             dark          ' +
-                      str(model.meta.cal_step.dark))
-    pipeline.log.info('DMS86 MSG: Testing completion of dark correction in'
-                      'Level 2 image output.......' +
-                      passfail(model.meta.cal_step.dark == 'COMPLETE'))
-    assert model.meta.cal_step.dark == 'COMPLETE'
-    pipeline.log.info('Status of the step:             dq_init       ' +
-                      str(model.meta.cal_step.dq_init))
-    pipeline.log.info('DMS86 MSG: Testing completion of data quality'
-                      ' correction in Level 2 image output.......' +
-                      passfail(model.meta.cal_step.dq_init == 'COMPLETE'))
-    assert model.meta.cal_step.dq_init == 'COMPLETE'
-    pipeline.log.info('Status of the step:             jump          ' +
-                      str(model.meta.cal_step.jump))
-    pipeline.log.info('DMS86 MSG: Testing completion of jump detection in'
-                      'Level 2 image output.......' +
-                      passfail(model.meta.cal_step.jump == 'COMPLETE'))
-    assert model.meta.cal_step.jump == 'COMPLETE'
-    pipeline.log.info('Status of the step:             linearity     ' +
-                      str(model.meta.cal_step.linearity))
-    pipeline.log.info('DMS86 MSG: Testing completion of linearity correction'
-                      ' in Level 2 image output.......' +
-                      passfail(model.meta.cal_step.linearity == 'COMPLETE'))
-    assert model.meta.cal_step.linearity == 'COMPLETE'
-    pipeline.log.info('Status of the step:             ramp_fit      ' +
-                      str(model.meta.cal_step.ramp_fit))
-    pipeline.log.info('DMS86 MSG: Testing completion of ramp fitting in'
-                      'Level 2 image output.......' +
-                      passfail(model.meta.cal_step.ramp_fit == 'COMPLETE'))
-    assert model.meta.cal_step.ramp_fit == 'COMPLETE'
-    pipeline.log.info('Status of the step:             saturation    ' +
-                      str(model.meta.cal_step.saturation))
-    pipeline.log.info('DMS86 MSG: Testing completion of saturation detection '
-                      'in Level 2 image output.......' +
-                      passfail(model.meta.cal_step.saturation == 'COMPLETE'))
-    assert model.meta.cal_step.saturation == 'COMPLETE'
+    pipeline.log.info("Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of wcs assignment inLevel 2 image output......."
+        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+    )
+    assert model.meta.cal_step.assign_wcs == "COMPLETE"
+    pipeline.log.info("Status of the step:             flat_field    " + str(model.meta.cal_step.flat_field))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of flat fielding inLevel 2 image output......."
+        + passfail(model.meta.cal_step.flat_field == "PASS")
+    )
+    assert model.meta.cal_step.flat_field == "COMPLETE"
+    pipeline.log.info("Status of the step:             dark          " + str(model.meta.cal_step.dark))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of dark correction inLevel 2 image output......."
+        + passfail(model.meta.cal_step.dark == "COMPLETE")
+    )
+    assert model.meta.cal_step.dark == "COMPLETE"
+    pipeline.log.info("Status of the step:             dq_init       " + str(model.meta.cal_step.dq_init))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of data quality correction in Level 2 image output......."
+        + passfail(model.meta.cal_step.dq_init == "COMPLETE")
+    )
+    assert model.meta.cal_step.dq_init == "COMPLETE"
+    pipeline.log.info("Status of the step:             jump          " + str(model.meta.cal_step.jump))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of jump detection inLevel 2 image output......."
+        + passfail(model.meta.cal_step.jump == "COMPLETE")
+    )
+    assert model.meta.cal_step.jump == "COMPLETE"
+    pipeline.log.info("Status of the step:             linearity     " + str(model.meta.cal_step.linearity))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of linearity correction in Level 2 image output......."
+        + passfail(model.meta.cal_step.linearity == "COMPLETE")
+    )
+    assert model.meta.cal_step.linearity == "COMPLETE"
+    pipeline.log.info("Status of the step:             ramp_fit      " + str(model.meta.cal_step.ramp_fit))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of ramp fitting inLevel 2 image output......."
+        + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
+    )
+    assert model.meta.cal_step.ramp_fit == "COMPLETE"
+    pipeline.log.info("Status of the step:             saturation    " + str(model.meta.cal_step.saturation))
+    pipeline.log.info(
+        "DMS86 MSG: Testing completion of saturation detection in Level 2 image output......."
+        + passfail(model.meta.cal_step.saturation == "COMPLETE")
+    )
+    assert model.meta.cal_step.saturation == "COMPLETE"
 
     # DMS-129 tests
     # check if assign_wcs step is complete
-    pipeline.log.info('DMS-129 MSG: Status of the step:             assign_wcs    ' +
-                    str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS-129 MSG: Testing completion of WCS assignment in'
-                    'Level 2 image output.......' +
-                    passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
-    assert model.meta.cal_step.assign_wcs == 'COMPLETE'
+    pipeline.log.info("DMS-129 MSG: Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info(
+        "DMS-129 MSG: Testing completion of WCS assignment inLevel 2 image output......."
+        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+    )
+    assert model.meta.cal_step.assign_wcs == "COMPLETE"
     # check if WCS exists
-    pipeline.log.info('DMS-129 MSG: Testing that a WCS object exists    ')
-    pipeline.log.info('DMS-129 MSG: Testing that WCS exists in'
-                    'Level 2 image output.......' +
-                    passfail(model.meta.wcs is not None))
+    pipeline.log.info("DMS-129 MSG: Testing that a WCS object exists    ")
+    pipeline.log.info("DMS-129 MSG: Testing that WCS exists inLevel 2 image output......." + passfail(model.meta.wcs is not None))
     assert model.meta.wcs is not None
-    pipeline.log.info('DMS-129 MSG: Testing that geometric distortion information is available in'
-                    'Level 2 image output.......' +
-                    passfail('v2v3' in model.meta.wcs.available_frames))
-    assert 'v2v3' in model.meta.wcs.available_frames
+    pipeline.log.info(
+        "DMS-129 MSG: Testing that geometric distortion information is available inLevel 2 image output......."
+        + passfail("v2v3" in model.meta.wcs.available_frames)
+    )
+    assert "v2v3" in model.meta.wcs.available_frames
     # compare coordinates before and after distortion correction has been applied
     # 1 - get new image array based on the model
     x0, y0 = grid_from_bounding_box(model.meta.wcs.bounding_box)
     # 2 - apply the distortion-corrected WCS solution to new image array
     corrected_coords = model.meta.wcs(x0, y0)
     # 3 - apply the transformation from 'v2v3' to 'world' without distortion correction
-    original_coords = model.meta.wcs.get_transform('v2v3', 'world')(x0, y0)
+    original_coords = model.meta.wcs.get_transform("v2v3", "world")(x0, y0)
     # compare both results to make sure they don't match
     # (which means the distortion correction was actually applied to the model)
-    pipeline.log.info('DMS-129 MSG: Testing that distortion correction was applied to'
-                'Level 2 image output.......' +
-                passfail((corrected_coords[0] != original_coords[0]).all() & (corrected_coords[1] != original_coords[1]).all()))
+    pipeline.log.info(
+        "DMS-129 MSG: Testing that distortion correction was applied toLevel 2 image output......."
+        + passfail((corrected_coords[0] != original_coords[0]).all() & (corrected_coords[1] != original_coords[1]).all())
+    )
     assert (corrected_coords[0] != original_coords[0]).all()
     assert (corrected_coords[1] != original_coords[1]).all()
 
     # DMS87 data quality tests
-    pipeline.log.info('DMS87 MSG: Testing existence of data quality array (dq)'
-                      ' in Level 2 image output.......' +
-                      passfail("dq" in model.keys()))
+    pipeline.log.info(
+        "DMS87 MSG: Testing existence of data quality array (dq) in Level 2 image output......." + passfail("dq" in model.keys())
+    )
     assert "dq" in model.keys()
-    pipeline.log.info('DMS87 MSG: Testing existence of general error array '
-                      '(err) in Level 2 image output.......' +
-                      passfail("err" in model.keys()))
+    pipeline.log.info(
+        "DMS87 MSG: Testing existence of general error array (err) in Level 2 image output......."
+        + passfail("err" in model.keys())
+    )
     assert "err" in model.keys()
-    pipeline.log.info('DMS87 MSG: Testing existence of Poisson noise variance'
-                      'array (var_poisson) in Level 2 image output.......' +
-                      passfail("var_poisson" in model.keys()))
+    pipeline.log.info(
+        "DMS87 MSG: Testing existence of Poisson noise variancearray (var_poisson) in Level 2 image output......."
+        + passfail("var_poisson" in model.keys())
+    )
     assert "var_poisson" in model.keys()
-    pipeline.log.info('DMS87 MSG: Testing existence of read noise variance '
-                      'array (var_rnoise) in level 2 image output.......' +
-                      passfail("var_rnoise" in model.keys()))
+    pipeline.log.info(
+        "DMS87 MSG: Testing existence of read noise variance array (var_rnoise) in level 2 image output......."
+        + passfail("var_rnoise" in model.keys())
+    )
     assert "var_rnoise" in model.keys()
-    pipeline.log.info('DMS87 MSG: Testing existence of flatfield uncertainty '
-                      'variance array (var_flat) in Level 2 image output....' +
-                      passfail("var_flat" in model.keys()))
+    pipeline.log.info(
+        "DMS87 MSG: Testing existence of flatfield uncertainty variance array (var_flat) in Level 2 image output...."
+        + passfail("var_flat" in model.keys())
+    )
     assert "var_flat" in model.keys()
 
     # DMS88 total exposure time test
-    pipeline.log.info('DMS88 MSG: Testing existence of total exposure time '
-                      '(exposure_time) in Level 2 image output.......' +
-                      passfail("exposure_time" in model.meta.exposure))
+    pipeline.log.info(
+        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2 image output......."
+        + passfail("exposure_time" in model.meta.exposure)
+    )
     assert "exposure_time" in model.meta.exposure
 
     # DMS-136 PSF tests
-    pipeline.log.info('DMS8136MSG: Testing existence of  detector and '
-                      'optical element (detector & optical_element) in Level 2 '
-                      'image output.......' +
-                      passfail("exposure_time" in model.meta.exposure))
+    pipeline.log.info(
+        "DMS8136MSG: Testing existence of  detector and "
+        "optical element (detector & optical_element) in Level 2 "
+        "image output......." + passfail("exposure_time" in model.meta.exposure)
+    )
     assert "detector" in model.meta.instrument
     assert "optical_element" in model.meta.instrument
 
     # DMS89 WCS tests
-    pipeline.log.info('DMS89 MSG: Testing that the wcs bounding'
-                      'box was generated.......' +
-                      passfail(len(model.meta.wcs.bounding_box) == 2))
+    pipeline.log.info(
+        "DMS89 MSG: Testing that the wcs boundingbox was generated......." + passfail(len(model.meta.wcs.bounding_box) == 2)
+    )
     assert len(model.meta.wcs.bounding_box) == 2
 
     # Save original wcs information
     orig_wcs = copy.deepcopy(model.meta.wcs)
-    del model.meta['wcs']
+    del model.meta["wcs"]
 
     # Create new pointing for the model
     # RA & Dec are each shifted + 10 degrees, unless they are near
@@ -196,25 +203,22 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     model.to_asdf(rtdata.output)
 
     # Test that repointed file matches truth
-    rtdata.get_truth("truth/WFI/image/" + output.rsplit(".", 1)[0] +
-                     "_repoint.asdf")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    rtdata.get_truth("truth/WFI/image/" + output.rsplit(".", 1)[0] + "_repoint.asdf")
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
-    pipeline.log.info('DMS89 MSG: Testing that the different pointings '
-                      'create differing wcs.......'
-                      + passfail(((np.abs(orig_wcs(2048, 2048)[0] -
-                                          model.meta.wcs(2048, 2048)[0])) -
-                                  10.0) < 1.0))
-    assert_allclose([orig_wcs(2048, 2048)[0] +
-                    delta[0], orig_wcs(2048, 2048)[1] + delta[1]],
-                    model.meta.wcs(2048, 2048), atol=1.0)
+    pipeline.log.info(
+        "DMS89 MSG: Testing that the different pointings create differing wcs......."
+        + passfail(((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0) < 1.0)
+    )
+    assert_allclose(
+        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]], model.meta.wcs(2048, 2048), atol=1.0
+    )
 
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
 def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
-    """Tests for flat field grism processing requirements DMS90 & DMS 91 """
+    """Tests for flat field grism processing requirements DMS90 & DMS 91"""
     input_data = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data
@@ -222,16 +226,17 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     # Test Pipeline
     output = "r0000201001001001002_01101_0001_WFI01_cal.asdf"
     rtdata.output = output
-    args = ["--disable-crds-steppars",
-            "--steps.jump.rejection_threshold=180.0",
-            "--steps.jump.three_group_rejection_threshold=185.0",
-            "--steps.jump.four_group_rejection_threshold=190",
-            "roman_elp", rtdata.input,
-            ]
+    args = [
+        "--disable-crds-steppars",
+        "--steps.jump.rejection_threshold=180.0",
+        "--steps.jump.three_group_rejection_threshold=185.0",
+        "--steps.jump.four_group_rejection_threshold=190",
+        "roman_elp",
+        rtdata.input,
+    ]
     ExposurePipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
     # Perform DMS tests
     # Initial prep
@@ -239,88 +244,93 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     pipeline = ExposurePipeline()
 
     # DMS90 instrument artifact correction tests
-    pipeline.log.info('Status of the step:             assign_wcs    ' +
-                      str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS90 MSG: Testing completion of wcs assignment in'
-                      'Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.assign_wcs == 'COMPLETE'))
-    assert model.meta.cal_step.assign_wcs == 'COMPLETE'
-    pipeline.log.info('Status of the step:             flat_field    ' +
-                      str(model.meta.cal_step.flat_field))
-    pipeline.log.info('DMS90 MSG: Testing expected skip of flat fielding in'
-                      'Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.flat_field == 'SKIPPED'))
-    assert model.meta.cal_step.flat_field == 'SKIPPED'
-    pipeline.log.info('Status of the step:             dark          ' +
-                      str(model.meta.cal_step.dark))
-    pipeline.log.info('DMS90 MSG: Testing completion of dark correction in'
-                      'Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.dark == 'COMPLETE'))
-    assert model.meta.cal_step.dark == 'COMPLETE'
-    pipeline.log.info('Status of the step:             dq_init       ' +
-                      str(model.meta.cal_step.dq_init))
-    pipeline.log.info('DMS90 MSG: Testing completion of data quality '
-                      'correction in Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.dq_init == 'COMPLETE'))
-    assert model.meta.cal_step.dq_init == 'COMPLETE'
-    pipeline.log.info('Status of the step:             jump          ' +
-                      str(model.meta.cal_step.jump))
-    pipeline.log.info('DMS90 MSG: Testing completion of jump detection in'
-                      'Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.jump == 'COMPLETE'))
-    assert model.meta.cal_step.jump == 'COMPLETE'
-    pipeline.log.info('Status of the step:             linearity     ' +
-                      str(model.meta.cal_step.assign_wcs))
-    pipeline.log.info('DMS90 MSG: Testing completion of linearity correction '
-                      'in Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.linearity == 'COMPLETE'))
-    assert model.meta.cal_step.linearity == 'COMPLETE'
-    pipeline.log.info('Status of the step:             ramp_fit      ' +
-                      str(model.meta.cal_step.ramp_fit))
-    pipeline.log.info('DMS90 MSG: Testing completion of ramp fitting in'
-                      'Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.ramp_fit == 'COMPLETE'))
-    assert model.meta.cal_step.ramp_fit == 'COMPLETE'
-    pipeline.log.info('Status of the step:             saturation    ' +
-                      str(model.meta.cal_step.saturation))
-    pipeline.log.info('DMS90 MSG: Testing completion of saturation detection '
-                      'in Level 2 spectroscopic output.......' +
-                      passfail(model.meta.cal_step.saturation == 'COMPLETE'))
-    assert model.meta.cal_step.saturation == 'COMPLETE'
+    pipeline.log.info("Status of the step:             assign_wcs    " + str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of wcs assignment inLevel 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+    )
+    assert model.meta.cal_step.assign_wcs == "COMPLETE"
+    pipeline.log.info("Status of the step:             flat_field    " + str(model.meta.cal_step.flat_field))
+    pipeline.log.info(
+        "DMS90 MSG: Testing expected skip of flat fielding inLevel 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.flat_field == "SKIPPED")
+    )
+    assert model.meta.cal_step.flat_field == "SKIPPED"
+    pipeline.log.info("Status of the step:             dark          " + str(model.meta.cal_step.dark))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of dark correction inLevel 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.dark == "COMPLETE")
+    )
+    assert model.meta.cal_step.dark == "COMPLETE"
+    pipeline.log.info("Status of the step:             dq_init       " + str(model.meta.cal_step.dq_init))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of data quality correction in Level 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.dq_init == "COMPLETE")
+    )
+    assert model.meta.cal_step.dq_init == "COMPLETE"
+    pipeline.log.info("Status of the step:             jump          " + str(model.meta.cal_step.jump))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of jump detection inLevel 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.jump == "COMPLETE")
+    )
+    assert model.meta.cal_step.jump == "COMPLETE"
+    pipeline.log.info("Status of the step:             linearity     " + str(model.meta.cal_step.assign_wcs))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of linearity correction in Level 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.linearity == "COMPLETE")
+    )
+    assert model.meta.cal_step.linearity == "COMPLETE"
+    pipeline.log.info("Status of the step:             ramp_fit      " + str(model.meta.cal_step.ramp_fit))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of ramp fitting inLevel 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
+    )
+    assert model.meta.cal_step.ramp_fit == "COMPLETE"
+    pipeline.log.info("Status of the step:             saturation    " + str(model.meta.cal_step.saturation))
+    pipeline.log.info(
+        "DMS90 MSG: Testing completion of saturation detection in Level 2 spectroscopic output......."
+        + passfail(model.meta.cal_step.saturation == "COMPLETE")
+    )
+    assert model.meta.cal_step.saturation == "COMPLETE"
 
     # DMS91 data quality tests
-    pipeline.log.info('DMS91 MSG: Testing existence of data quality array (dq)'
-                      ' in Level 2 spectroscopic output.......' +
-                      passfail("dq" in model.keys()))
+    pipeline.log.info(
+        "DMS91 MSG: Testing existence of data quality array (dq) in Level 2 spectroscopic output......."
+        + passfail("dq" in model.keys())
+    )
     assert "dq" in model.keys()
-    pipeline.log.info('DMS91 MSG: Testing existence of general error '
-                      'array (err) in Level 2 spectroscopic output.......' +
-                      passfail("err" in model.keys()))
+    pipeline.log.info(
+        "DMS91 MSG: Testing existence of general error array (err) in Level 2 spectroscopic output......."
+        + passfail("err" in model.keys())
+    )
     assert "err" in model.keys()
-    pipeline.log.info('DMS91 MSG: Testing existence of Poisson noise variance '
-                      'array (var_poisson) in Level 2 spectroscopic output..' +
-                      passfail("var_poisson" in model.keys()))
+    pipeline.log.info(
+        "DMS91 MSG: Testing existence of Poisson noise variance array (var_poisson) in Level 2 spectroscopic output.."
+        + passfail("var_poisson" in model.keys())
+    )
     assert "var_poisson" in model.keys()
-    pipeline.log.info('DMS91 MSG: Testing existence of read noise variance '
-                      'array (var_rnoise) in Level 2 spectroscopic output...' +
-                      passfail("var_rnoise" in model.keys()))
+    pipeline.log.info(
+        "DMS91 MSG: Testing existence of read noise variance array (var_rnoise) in Level 2 spectroscopic output..."
+        + passfail("var_rnoise" in model.keys())
+    )
     assert "var_rnoise" in model.keys()
 
     # DMS88 total exposure time test
-    pipeline.log.info('DMS88 MSG: Testing existence of total exposure '
-                      'time (exposure_time) in Level 2 spectroscopic output.' +
-                      passfail("exposure_time" in model.meta.exposure))
+    pipeline.log.info(
+        "DMS88 MSG: Testing existence of total exposure time (exposure_time) in Level 2 spectroscopic output."
+        + passfail("exposure_time" in model.meta.exposure)
+    )
     assert "exposure_time" in model.meta.exposure
 
     # DMS93 WCS tests
-    pipeline.log.info('DMS93 MSG: Testing that the wcs bounding'
-                      'box was generated.......' +
-                      passfail(len(model.meta.wcs.bounding_box) == 2))
+    pipeline.log.info(
+        "DMS93 MSG: Testing that the wcs boundingbox was generated......." + passfail(len(model.meta.wcs.bounding_box) == 2)
+    )
     assert len(model.meta.wcs.bounding_box) == 2
 
     # Save original wcs information
     orig_wcs = copy.deepcopy(model.meta.wcs)
-    del model.meta['wcs']
+    del model.meta["wcs"]
 
     # Create new pointing for the model
     # RA & Dec are each shifted + 10 degrees, unless they are near
@@ -342,25 +352,21 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     model.to_asdf(rtdata.output)
 
     # Test that repointed file matches truth
-    rtdata.get_truth("truth/WFI/grism/" + output.rsplit(".", 1)[0] +
-                     "_repoint.asdf")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    rtdata.get_truth("truth/WFI/grism/" + output.rsplit(".", 1)[0] + "_repoint.asdf")
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
-    pipeline.log.info('DMS93 MSG: Testing that the different pointings '
-                      'create differing wcs.......'
-                      + passfail(((np.abs(orig_wcs(2048, 2048)[0] -
-                                          model.meta.wcs(2048, 2048)[0])) -
-                                  10.0) < 1.0))
-    assert_allclose([orig_wcs(2048, 2048)[0] + delta[0],
-                    orig_wcs(2048, 2048)[1] + delta[1]],
-                    model.meta.wcs(2048, 2048),
-                    atol=1.0)
+    pipeline.log.info(
+        "DMS93 MSG: Testing that the different pointings create differing wcs......."
+        + passfail(((np.abs(orig_wcs(2048, 2048)[0] - model.meta.wcs(2048, 2048)[0])) - 10.0) < 1.0)
+    )
+    assert_allclose(
+        [orig_wcs(2048, 2048)[0] + delta[0], orig_wcs(2048, 2048)[1] + delta[1]], model.meta.wcs(2048, 2048), atol=1.0
+    )
+
 
 @pytest.mark.bigdata
-
 def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
-    """ Tests for fully saturated data skipping steps in the pipeline """
+    """Tests for fully saturated data skipping steps in the pipeline"""
     input_data = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
@@ -368,9 +374,11 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
     # Test Pipeline
     output = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_cal.asdf"
     rtdata.output = output
-    args = ["--disable-crds-steppars",
-            "roman_elp", rtdata.input,
-            ]
+    args = [
+        "--disable-crds-steppars",
+        "roman_elp",
+        rtdata.input,
+    ]
     ExposurePipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
 

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -1,10 +1,12 @@
 """ Tests for the saturation step"""
 import os
-import pytest
 
+import pytest
 import roman_datamodels as rdm
-from romancal.stpipe import RomanStep
+
 from romancal.step import SaturationStep
+from romancal.stpipe import RomanStep
+
 from .regtestdata import compare_asdf
 
 

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -12,8 +12,8 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_saturation_image_step(rtdata, ignore_asdf_paths):
-    """ Testing retrieval of best ref file for image data,
-    and creation of a ramp file with CRDS selected saturation file applied. """
+    """Testing retrieval of best ref file for image data,
+    and creation of a ramp file with CRDS selected saturation file applied."""
 
     input_file = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
@@ -39,14 +39,13 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
-    assert (compare_asdf(rtdata.output, rtdata.truth,
-            **ignore_asdf_paths) is None)
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None
 
 
 @pytest.mark.bigdata
 def test_saturation_grism_step(rtdata, ignore_asdf_paths):
-    """ Testing retrieval of best ref file for grism data,
-     and creation of a ramp file with CRDS selected saturation file applied."""
+    """Testing retrieval of best ref file for grism data,
+    and creation of a ramp file with CRDS selected saturation file applied."""
 
     input_file = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
@@ -72,5 +71,4 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")
-    assert compare_asdf(rtdata.output, rtdata.truth,
-                        **ignore_asdf_paths) is None
+    assert compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths) is None

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -9,12 +9,16 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def make_output_wcs(input_models,
-                    pscale_ratio=None, pscale=None,
-                    rotation=None, shape=None,
-                    ref_pixel:Tuple[float, float]=None,
-                    ref_coord:Tuple[float, float]=None):
-    """ Generate output WCS here based on footprints of all input WCS objects
+def make_output_wcs(
+    input_models,
+    pscale_ratio=None,
+    pscale=None,
+    rotation=None,
+    shape=None,
+    ref_pixel: Tuple[float, float] = None,
+    ref_coord: Tuple[float, float] = None,
+):
+    """Generate output WCS here based on footprints of all input WCS objects
     Parameters
     ----------
     input_models : list of `~roman_datamodels.datamodels.DataModel`
@@ -63,8 +67,7 @@ def make_output_wcs(input_models,
     naxes = wcslist[0].output_frame.naxes
 
     if naxes != 2:
-        raise RuntimeError("Output WCS needs 2 axes."
-                           f"{wcslist[0]} has {naxes}.")
+        raise RuntimeError(f"Output WCS needs 2 axes.{wcslist[0]} has {naxes}.")
 
     output_wcs = wcs_from_footprints(
         input_models,
@@ -73,7 +76,7 @@ def make_output_wcs(input_models,
         rotation=rotation,
         shape=shape,
         ref_pixel=ref_pixel,
-        ref_coord=ref_coord
+        ref_coord=ref_coord,
     )
 
     # Check that the output data shape has no zero length dimensions

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -81,6 +81,9 @@ def make_output_wcs(
 
     # Check that the output data shape has no zero length dimensions
     if not np.product(output_wcs.array_shape):
-        raise ValueError(f"Invalid output frame shape: {tuple(output_wcs.array_shape)}; dimensions must have length > 0.")
+        raise ValueError(
+            f"Invalid output frame shape: {tuple(output_wcs.array_shape)}; dimensions"
+            " must have length > 0."
+        )
 
     return output_wcs

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -1,11 +1,9 @@
 import logging
+from typing import Tuple
 
 import numpy as np
 
-from romancal.assign_wcs.utils import wcs_from_footprints, wcs_bbox_from_shape
-
-from typing import Tuple
-
+from romancal.assign_wcs.utils import wcs_bbox_from_shape, wcs_from_footprints
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/romancal/saturation/__init__.py
+++ b/romancal/saturation/__init__.py
@@ -1,3 +1,3 @@
 from .saturation_step import SaturationStep
 
-__all__ = ['SaturationStep']
+__all__ = ["SaturationStep"]

--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -48,7 +48,9 @@ def flag_saturation(input_model, ref_model):
     # Obtain dq arrays updated for saturation
     # The third variable is the processed ZEROFRAME, which is not
     # used in romancal, so is always None.
-    gdq_new, pdq_new, _ = flag_saturated_pixels(data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel, n_pix_grow_sat=0)
+    gdq_new, pdq_new, _ = flag_saturated_pixels(
+        data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel, n_pix_grow_sat=0
+    )
 
     # Save the flags in the output GROUPDQ array
     output_model.groupdq = gdq_new[0, :]

--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -10,7 +10,7 @@ from romancal.lib import dqflags
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-ATOD_LIMIT = 65535.  # Hard DN limit of 16-bit A-to-D converter
+ATOD_LIMIT = 65535.0  # Hard DN limit of 16-bit A-to-D converter
 
 
 def flag_saturation(input_model, ref_model):
@@ -48,9 +48,7 @@ def flag_saturation(input_model, ref_model):
     # Obtain dq arrays updated for saturation
     # The third variable is the processed ZEROFRAME, which is not
     # used in romancal, so is always None.
-    gdq_new, pdq_new, _ = flag_saturated_pixels(
-        data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel,
-        n_pix_grow_sat=0)
+    gdq_new, pdq_new, _ = flag_saturated_pixels(data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, dqflags.pixel, n_pix_grow_sat=0)
 
     # Save the flags in the output GROUPDQ array
     output_model.groupdq = gdq_new[0, :]

--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -1,11 +1,11 @@
 #  Module for 2d saturation
 #
 import logging
+
 import numpy as np
+from stcal.saturation.saturation import flag_saturated_pixels
 
 from romancal.lib import dqflags
-
-from stcal.saturation.saturation import flag_saturated_pixels
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -14,7 +14,7 @@ class SaturationStep(RomanStep):
     This Step sets saturation flags.
     """
 
-    reference_file_types = ['saturation']
+    reference_file_types = ["saturation"]
 
     def process(self, input):
 
@@ -22,15 +22,15 @@ class SaturationStep(RomanStep):
         with rdm.open(input) as input_model:
 
             # Get the name of the saturation reference file
-            self.ref_name = self.get_reference_file(input_model, 'saturation')
-            self.log.info('Using SATURATION reference file %s', self.ref_name)
+            self.ref_name = self.get_reference_file(input_model, "saturation")
+            self.log.info("Using SATURATION reference file %s", self.ref_name)
 
             # Check for a valid reference file
-            if self.ref_name == 'N/A':
-                self.log.warning('No SATURATION reference file found')
-                self.log.warning('Saturation step will be skipped')
+            if self.ref_name == "N/A":
+                self.log.warning("No SATURATION reference file found")
+                self.log.warning("Saturation step will be skipped")
                 result = input_model.copy()
-                result.meta.cal_step.saturation = 'SKIPPED'
+                result.meta.cal_step.saturation = "SKIPPED"
                 return result
 
             # Open the reference file data model
@@ -41,12 +41,12 @@ class SaturationStep(RomanStep):
 
             # Close the reference file and update the step status
             ref_model.close()
-            sat.meta.cal_step.saturation = 'COMPLETE'
+            sat.meta.cal_step.saturation = "COMPLETE"
 
             if self.save_results:
                 try:
-                    self.suffix = 'saturation'
+                    self.suffix = "saturation"
                 except AttributeError:
-                    self['suffix'] = 'saturation'
+                    self["suffix"] = "saturation"
 
         return sat

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -2,9 +2,9 @@
 
 import roman_datamodels as rdm
 from roman_datamodels.datamodels import SaturationRefModel
-from romancal.stpipe import RomanStep
-from romancal.saturation import saturation
 
+from romancal.saturation import saturation
+from romancal.stpipe import RomanStep
 
 __all__ = ["SaturationStep"]
 

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -70,7 +70,10 @@ def test_ad_floor_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[satindxs, 5, 5] == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"])
+    assert np.all(
+        output.groupdq[satindxs, 5, 5]
+        == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"]
+    )
 
 
 def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
@@ -104,7 +107,10 @@ def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Check if the right frames are flagged as ad_floor
-    assert np.all(output.groupdq[floorindxs, 5, 5] == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"])
+    assert np.all(
+        output.groupdq[floorindxs, 5, 5]
+        == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"]
+    )
     # Check if the right frames are flagged as saturated
     assert np.all(output.groupdq[satindxs, 5, 5] == dqflags.group["SATURATED"])
 
@@ -224,8 +230,13 @@ def test_no_sat_check(setup_wfi_datamodels):
     # Make sure PIXELDQ is set to NO_SAT_CHECK and original flag
     assert np.all(output.groupdq[:, 5, 5] != dqflags.group["SATURATED"])
     # Test that saturation bit is NOT set
-    assert np.all(output.groupdq[:, 5, 5] & (1 << dqflags.group["SATURATED"].bit_length() - 1) == 0)
-    assert output.pixeldq[5, 5] == (dqflags.pixel["NO_SAT_CHECK"] + dqflags.pixel["DO_NOT_USE"])
+    assert np.all(
+        output.groupdq[:, 5, 5] & (1 << dqflags.group["SATURATED"].bit_length() - 1)
+        == 0
+    )
+    assert output.pixeldq[5, 5] == (
+        dqflags.pixel["NO_SAT_CHECK"] + dqflags.pixel["DO_NOT_USE"]
+    )
 
 
 def test_nans_in_mask(setup_wfi_datamodels):

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -4,12 +4,12 @@ Unit tests for saturation flagging
 
 """
 
-import pytest
 import numpy as np
-
-from romancal.saturation.saturation import flag_saturation
-from romancal.lib import dqflags
+import pytest
 from roman_datamodels import maker_utils
+
+from romancal.lib import dqflags
+from romancal.saturation.saturation import flag_saturation
 
 
 def test_basic_saturation_flagging(setup_wfi_datamodels):

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -77,8 +77,10 @@ def test_ad_floor_flagging(setup_wfi_datamodels):
 
 
 def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
-    """Check that the ad_floor flag is set when a pixel value is zero or
-    negative and the saturation flag when the pixel is above the saturation threshold."""
+    """
+    Check that the ad_floor flag is set when a pixel value is zero or
+    negative and the saturation flag when the pixel is above the saturation threshold.
+    """
 
     # Create inputs, and data and saturation models
     ngroups = 5

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -13,8 +13,8 @@ from romancal.saturation.saturation import flag_saturation
 
 
 def test_basic_saturation_flagging(setup_wfi_datamodels):
-    '''Check that the saturation flag is set when a pixel value is above the
-       threshold given by the reference file.'''
+    """Check that the saturation flag is set when a pixel value is above the
+    threshold given by the reference file."""
 
     # Create inputs, and data and saturation models
     ngroups = 5
@@ -38,7 +38,8 @@ def test_basic_saturation_flagging(setup_wfi_datamodels):
 
     # Make sure that groups with signal > saturation limit get flagged
     satindex = np.argmax(output.data.value[:, 5, 5] == satvalue)
-    assert np.all(output.groupdq[satindex:, 5, 5] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[satindex:, 5, 5] == dqflags.group["SATURATED"])
+
 
 def test_ad_floor_flagging(setup_wfi_datamodels):
     """Check that the ad_floor flag is set when a pixel value is zero or
@@ -53,8 +54,8 @@ def test_ad_floor_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 0 * ramp.data.unit   # Signal at bottom rail - low saturation
-    ramp.data[1, 5, 5] = 0 * ramp.data.unit   # Signal at bottom rail - low saturation
+    ramp.data[0, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
+    ramp.data[1, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
     ramp.data[2, 5, 5] = 20 * ramp.data.unit
     ramp.data[3, 5, 5] = 40 * ramp.data.unit
     ramp.data[4, 5, 5] = 60 * ramp.data.unit
@@ -69,8 +70,7 @@ def test_ad_floor_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[satindxs, 5, 5]
-                  == dqflags.group['DO_NOT_USE'] | dqflags.group['AD_FLOOR'])
+    assert np.all(output.groupdq[satindxs, 5, 5] == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"])
 
 
 def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
@@ -104,16 +104,15 @@ def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Check if the right frames are flagged as ad_floor
-    assert np.all(output.groupdq[floorindxs, 5, 5]
-                  == dqflags.group['DO_NOT_USE'] | dqflags.group['AD_FLOOR'])
+    assert np.all(output.groupdq[floorindxs, 5, 5] == dqflags.group["DO_NOT_USE"] | dqflags.group["AD_FLOOR"])
     # Check if the right frames are flagged as saturated
-    assert np.all(output.groupdq[satindxs, 5, 5] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[satindxs, 5, 5] == dqflags.group["SATURATED"])
 
 
 def test_signal_fluctuation_flagging(setup_wfi_datamodels):
-    '''Check that once a pixel is flagged as saturated in a group, all
-       subsequent groups should also be flagged as saturated, even if the
-       signal value drops back below saturation.'''
+    """Check that once a pixel is flagged as saturated in a group, all
+    subsequent groups should also be flagged as saturated, even if the
+    signal value drops back below saturation."""
 
     # Create inputs, and data and saturation models
     ngroups = 5
@@ -127,8 +126,8 @@ def test_signal_fluctuation_flagging(setup_wfi_datamodels):
     ramp.data[0, 5, 5] = 10 * ramp.data.unit
     ramp.data[1, 5, 5] = 20000 * ramp.data.unit
     ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit   # Signal reaches saturation limit
-    ramp.data[4, 5, 5] = 40000 * ramp.data.unit   # Signal drops below saturation limit
+    ramp.data[3, 5, 5] = 60000 * ramp.data.unit  # Signal reaches saturation limit
+    ramp.data[4, 5, 5] = 40000 * ramp.data.unit  # Signal drops below saturation limit
 
     # Set saturation value in the saturation model
     satmap.data[5, 5] = satvalue * satmap.data.unit
@@ -138,11 +137,11 @@ def test_signal_fluctuation_flagging(setup_wfi_datamodels):
 
     # Make sure that all groups after first saturated group are flagged
     satindex = np.argmax(output.data.value[:, 5, 5] == satvalue)
-    assert np.all(output.groupdq[satindex:, 5, 5] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[satindex:, 5, 5] == dqflags.group["SATURATED"])
 
 
 def test_all_groups_saturated(setup_wfi_datamodels):
-    '''Check case where all groups are saturated.'''
+    """Check case where all groups are saturated."""
 
     # Create inputs, and data and saturation models
     ngroups = 5
@@ -166,10 +165,11 @@ def test_all_groups_saturated(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Make sure all groups are flagged
-    assert np.all(output.groupdq[:, 5, 5] == dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[:, 5, 5] == dqflags.group["SATURATED"])
+
 
 def test_dq_propagation(setup_wfi_datamodels):
-    '''Check PIXELDQ propagation.'''
+    """Check PIXELDQ propagation."""
 
     # Create inputs, data, and saturation maps
     ngroups = 5
@@ -192,8 +192,8 @@ def test_dq_propagation(setup_wfi_datamodels):
 
 
 def test_no_sat_check(setup_wfi_datamodels):
-    '''Check that pixels flagged with NO_SAT_CHECK in the reference file get
-       added to the DQ mask and are not flagged as saturated.'''
+    """Check that pixels flagged with NO_SAT_CHECK in the reference file get
+    added to the DQ mask and are not flagged as saturated."""
 
     # Create inputs, and data and saturation models
     ngroups = 5
@@ -208,31 +208,30 @@ def test_no_sat_check(setup_wfi_datamodels):
     ramp.data[1, 5, 5] = 20000 * ramp.data.unit
     ramp.data[2, 5, 5] = 40000 * ramp.data.unit
     ramp.data[3, 5, 5] = 60000 * ramp.data.unit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit   # Signal reaches saturation limit
+    ramp.data[4, 5, 5] = 62000 * ramp.data.unit  # Signal reaches saturation limit
 
     # Set saturation value in the saturation model & DQ value for NO_SAT_CHECK
     satmap.data[5, 5] = satvalue * satmap.data.unit
-    satmap.dq[5, 5] = dqflags.pixel['NO_SAT_CHECK']
+    satmap.dq[5, 5] = dqflags.pixel["NO_SAT_CHECK"]
 
     # Also set an existing DQ flag in input science data
-    ramp.pixeldq[5, 5] = dqflags.pixel['DO_NOT_USE']
+    ramp.pixeldq[5, 5] = dqflags.pixel["DO_NOT_USE"]
 
     # Run the pipeline
     output = flag_saturation(ramp, satmap)
 
     # Make sure output GROUPDQ does not get flagged as saturated
     # Make sure PIXELDQ is set to NO_SAT_CHECK and original flag
-    assert np.all(output.groupdq[:, 5, 5] != dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[:, 5, 5] != dqflags.group["SATURATED"])
     # Test that saturation bit is NOT set
-    assert np.all(output.groupdq[:, 5, 5] & (1 << dqflags.group['SATURATED'].bit_length()-1) == 0)
-    assert output.pixeldq[5, 5] == (dqflags.pixel['NO_SAT_CHECK'] +
-                                    dqflags.pixel['DO_NOT_USE'])
+    assert np.all(output.groupdq[:, 5, 5] & (1 << dqflags.group["SATURATED"].bit_length() - 1) == 0)
+    assert output.pixeldq[5, 5] == (dqflags.pixel["NO_SAT_CHECK"] + dqflags.pixel["DO_NOT_USE"])
 
 
 def test_nans_in_mask(setup_wfi_datamodels):
-    '''Check that pixels in the reference files that have value NaN are not
-       flagged as saturated in the data and that in the PIXELDQ array the
-       pixel is set to NO_SAT_CHECK.'''
+    """Check that pixels in the reference files that have value NaN are not
+    flagged as saturated in the data and that in the PIXELDQ array the
+    pixel is set to NO_SAT_CHECK."""
 
     # Create inputs, and data and saturation models
     ngroups = 5
@@ -255,13 +254,14 @@ def test_nans_in_mask(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Check that output GROUPDQ is not flagged as saturated
-    assert np.all(output.groupdq[:, 5, 5] != dqflags.group['SATURATED'])
+    assert np.all(output.groupdq[:, 5, 5] != dqflags.group["SATURATED"])
     # Check that output PIXELDQ is set to NO_SAT_CHECK
-    assert output.pixeldq[5, 5] == dqflags.pixel['NO_SAT_CHECK']
+    assert output.pixeldq[5, 5] == dqflags.pixel["NO_SAT_CHECK"]
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def setup_wfi_datamodels():
-    ''' Set up fake WFI data to test.'''
+    """Set up fake WFI data to test."""
 
     def _models(ngroups, nrows, ncols):
 

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -59,7 +59,7 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     An example search would be:
 
     jfrog rt search roman-pipeline-results/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
-    """
+    """  # noqa: E501
     build_name = f"RT :: {job_name}"
 
     # Retreive all the okify specfiles for failed tests.

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -16,28 +16,26 @@ from glob import glob
 
 import asdf
 
-ARTIFACTORY_REPO = 'roman-pipeline-results'
-SPECFILE_SUFFIX = '_okify.json'
-RTDATA_SUFFIX = '_rtdata.asdf'
+ARTIFACTORY_REPO = "roman-pipeline-results"
+SPECFILE_SUFFIX = "_okify.json"
+RTDATA_SUFFIX = "_rtdata.asdf"
 TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
 
 
 def parse_args():
-    parser = ArgumentParser(description='Okify regression test results')
+    parser = ArgumentParser(description="Okify regression test results")
     parser.add_argument(
-        'build_number',
-        help='Jenkins build number for Roman builds',
-        metavar='build-number',
+        "build_number",
+        help="Jenkins build number for Roman builds",
+        metavar="build-number",
     )
     parser.add_argument(
-        '--job-name',
-        help='Jenkins job name under [RT] (default: romancal)',
-        default='romancal',
-        metavar='job-name',
+        "--job-name",
+        help="Jenkins job name under [RT] (default: romancal)",
+        default="romancal",
+        metavar="job-name",
     )
-    parser.add_argument(
-        '--dry-run', action='store_true', help='pass the --dry-run flag to JFrog CLI'
-    )
+    parser.add_argument("--dry-run", action="store_true", help="pass the --dry-run flag to JFrog CLI")
 
     return parser.parse_args()
 
@@ -46,9 +44,9 @@ def artifactory_copy(specfile, dry_run=False):
     jfrog_args = []
 
     if dry_run:
-        jfrog_args.append('--dry-run')
+        jfrog_args.append("--dry-run")
 
-    args = list(['jfrog', 'rt', 'cp'] + jfrog_args + [f'--spec={specfile}'])
+    args = list(["jfrog", "rt", "cp"] + jfrog_args + [f"--spec={specfile}"])
     subprocess.run(args, check=True)
 
 
@@ -60,18 +58,15 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
 
     jfrog rt search roman-pipeline-results/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
     """
-    build_name = f'RT :: {job_name}'
+    build_name = f"RT :: {job_name}"
 
     # Retreive all the okify specfiles for failed tests.
     args = list(
-        ['jfrog', 'rt', 'dl']
-        + [f'{ARTIFACTORY_REPO}/*/*{suffix}']
-        + [f'--build={build_name}/{build_number}']
-        + ['--flat']
+        ["jfrog", "rt", "dl"] + [f"{ARTIFACTORY_REPO}/*/*{suffix}"] + [f"--build={build_name}/{build_number}"] + ["--flat"]
     )
     subprocess.run(args, check=True, capture_output=True)
 
-    return sorted(glob(f'*{suffix}'))
+    return sorted(glob(f"*{suffix}"))
 
 
 def artifactory_get_build_artifacts(build_number, job_name):
@@ -79,11 +74,11 @@ def artifactory_get_build_artifacts(build_number, job_name):
     asdffiles = artifactory_get_breadcrumbs(build_number, job_name, RTDATA_SUFFIX)
 
     if len(specfiles) != len(asdffiles):
-        raise RuntimeError('Different number of _okify.json and _rtdata.asdf files')
+        raise RuntimeError("Different number of _okify.json and _rtdata.asdf files")
 
     for a, b in zip(specfiles, asdffiles):
-        if a.replace(SPECFILE_SUFFIX, '') != b.replace(RTDATA_SUFFIX, ''):
-            raise RuntimeError('The _okify.json and _rtdata.asdf files are not matched')
+        if a.replace(SPECFILE_SUFFIX, "") != b.replace(RTDATA_SUFFIX, ""):
+            raise RuntimeError("The _okify.json and _rtdata.asdf files are not matched")
 
     return specfiles, asdffiles
 
@@ -106,59 +101,53 @@ def main():
 
     # Create and chdir to a temporary directory to store specfiles
     with tempfile.TemporaryDirectory() as tmpdir:
-        print(f'Downloading test okify artifacts to local directory {tmpdir}')
+        print(f"Downloading test okify artifacts to local directory {tmpdir}")
         with pushd(tmpdir):
             # Retreive all the okify specfiles for failed tests.
             specfiles, asdffiles = artifactory_get_build_artifacts(build, name)
 
             number_failed_tests = len(specfiles)
 
-            print(f'{number_failed_tests} failed tests to okify')
+            print(f"{number_failed_tests} failed tests to okify")
 
             for i, (specfile, asdffile) in enumerate(zip(specfiles, asdffiles)):
 
                 # Print traceback and OKify info for this test failure
                 with asdf.open(asdffile) as af:
-                    traceback = af.tree['traceback']
-                    remote_results_path = af.tree['remote_results_path']
-                    output = af.tree['output']
-                    truth_remote = af.tree['truth_remote']
+                    traceback = af.tree["traceback"]
+                    remote_results_path = af.tree["remote_results_path"]
+                    output = af.tree["output"]
+                    truth_remote = af.tree["truth_remote"]
                     try:
-                        test_name = af.tree['test_name']
+                        test_name = af.tree["test_name"]
                     except KeyError:
-                        test_name = 'test_name'
+                        test_name = "test_name"
 
-                remote_results = os.path.join(
-                    remote_results_path, os.path.basename(output)
-                )
+                remote_results = os.path.join(remote_results_path, os.path.basename(output))
 
                 test_number = i + 1
 
-                print(f' {test_name} '.center(TERMINAL_WIDTH, '—'))
+                print(f" {test_name} ".center(TERMINAL_WIDTH, "—"))
                 print(traceback)
-                print('—' * TERMINAL_WIDTH)
-                print(f'OK: {remote_results}')
-                print(f'--> {truth_remote}')
-                print(
-                    f'[ test {test_number} of {number_failed_tests} ]'.center(
-                        TERMINAL_WIDTH, '—'
-                    )
-                )
+                print("—" * TERMINAL_WIDTH)
+                print(f"OK: {remote_results}")
+                print(f"--> {truth_remote}")
+                print(f"[ test {test_number} of {number_failed_tests} ]".center(TERMINAL_WIDTH, "—"))
 
                 # Ask if user wants to okify this test
                 while True:
-                    result = input('Enter \'o\' to okify, \'s\' to skip: ')
-                    if result not in ['o', 's']:
-                        print(f'Unrecognized command \'{result}\', try again')
+                    result = input("Enter 'o' to okify, 's' to skip: ")
+                    if result not in ["o", "s"]:
+                        print(f"Unrecognized command '{result}', try again")
                     else:
                         break
 
-                if result == 's':
-                    print('Skipping\n')
+                if result == "s":
+                    print("Skipping\n")
                 else:
                     artifactory_copy(os.path.abspath(specfile), dry_run=args.dry_run)
-                    print('')
+                    print("")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -35,7 +35,9 @@ def parse_args():
         default="romancal",
         metavar="job-name",
     )
-    parser.add_argument("--dry-run", action="store_true", help="pass the --dry-run flag to JFrog CLI")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="pass the --dry-run flag to JFrog CLI"
+    )
 
     return parser.parse_args()
 
@@ -62,7 +64,10 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
 
     # Retreive all the okify specfiles for failed tests.
     args = list(
-        ["jfrog", "rt", "dl"] + [f"{ARTIFACTORY_REPO}/*/*{suffix}"] + [f"--build={build_name}/{build_number}"] + ["--flat"]
+        ["jfrog", "rt", "dl"]
+        + [f"{ARTIFACTORY_REPO}/*/*{suffix}"]
+        + [f"--build={build_name}/{build_number}"]
+        + ["--flat"]
     )
     subprocess.run(args, check=True, capture_output=True)
 
@@ -123,7 +128,9 @@ def main():
                     except KeyError:
                         test_name = "test_name"
 
-                remote_results = os.path.join(remote_results_path, os.path.basename(output))
+                remote_results = os.path.join(
+                    remote_results_path, os.path.basename(output)
+                )
 
                 test_number = i + 1
 
@@ -132,7 +139,11 @@ def main():
                 print("—" * TERMINAL_WIDTH)
                 print(f"OK: {remote_results}")
                 print(f"--> {truth_remote}")
-                print(f"[ test {test_number} of {number_failed_tests} ]".center(TERMINAL_WIDTH, "—"))
+                print(
+                    f"[ test {test_number} of {number_failed_tests} ]".center(
+                        TERMINAL_WIDTH, "—"
+                    )
+                )
 
                 # Ask if user wants to okify this test
                 while True:

--- a/romancal/scripts/verify_install_requires.py
+++ b/romancal/scripts/verify_install_requires.py
@@ -18,9 +18,7 @@ def main():
     example, accidentally adding a runtime dependency on pytest.
     """
 
-    parser = argparse.ArgumentParser(
-        description="Check if install_requires is up-to-date"
-    )
+    parser = argparse.ArgumentParser(description="Check if install_requires is up-to-date")
     parser.parse_args()
 
     pytest.main(

--- a/romancal/scripts/verify_install_requires.py
+++ b/romancal/scripts/verify_install_requires.py
@@ -18,7 +18,9 @@ def main():
     example, accidentally adding a runtime dependency on pytest.
     """
 
-    parser = argparse.ArgumentParser(description="Check if install_requires is up-to-date")
+    parser = argparse.ArgumentParser(
+        description="Check if install_requires is up-to-date"
+    )
     parser.parse_args()
 
     pytest.main(

--- a/romancal/step.py
+++ b/romancal/step.py
@@ -2,6 +2,7 @@
 This module collects all of the stpipe.Step subclasses
 made available by this package.
 """
+from .assign_wcs.assign_wcs_step import AssignWcsStep
 from .dark_current.dark_current_step import DarkCurrentStep
 from .dq_init.dq_init_step import DQInitStep
 from .flatfield.flat_field_step import FlatFieldStep
@@ -10,8 +11,6 @@ from .linearity.linearity_step import LinearityStep
 from .photom.photom_step import PhotomStep
 from .ramp_fitting.ramp_fit_step import RampFitStep
 from .saturation.saturation_step import SaturationStep
-from .assign_wcs.assign_wcs_step import AssignWcsStep
-
 
 __all__ = [
     "DarkCurrentStep",

--- a/romancal/step.py
+++ b/romancal/step.py
@@ -22,4 +22,4 @@ __all__ = [
     "RampFitStep",
     "SaturationStep",
     "AssignWcsStep",
-    ]
+]

--- a/romancal/stpipe/__init__.py
+++ b/romancal/stpipe/__init__.py
@@ -1,3 +1,3 @@
-from .core import RomanStep, RomanPipeline
+from .core import RomanPipeline, RomanStep
 
 __all__ = ["RomanPipeline", "RomanStep"]

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -5,11 +5,10 @@ import logging
 import os
 import time
 
-from stpipe import Step, Pipeline
-
-
 import roman_datamodels as rdm
 from roman_datamodels.datamodels import ImageModel
+from stpipe import Pipeline, Step
+
 from ..lib.suffix import remove_suffix
 
 if os.environ.get("CI") == "false":

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -65,8 +65,8 @@ class RomanStep(Step):
                     setattr(model.meta.ref_file, ref_name, ref_file)
                     # getattr(model.meta.ref_file, ref_name).name = ref_file
 
-        # this will only run if 'parent' is none, which happens when an individual step is being run
-        # or if self is a RomanPipeline and not a RomanStep.
+        # this will only run if 'parent' is none, which happens when an individual
+        # step is being run or if self is a RomanPipeline and not a RomanStep.
 
         if os.environ.get("CI") == "false":  # no CRDS connection, do not run
             if self.parent is None:

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -16,7 +16,8 @@ if os.environ.get("CI") == "false":
 
 
 _LOG_FORMATTER = logging.Formatter(
-    "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
+    "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
 )
 _LOG_FORMATTER.converter = time.gmtime
 
@@ -70,7 +71,9 @@ class RomanStep(Step):
         if os.environ.get("CI") == "false":  # no CRDS connection, do not run
             if self.parent is None:
                 model.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
-                model.meta.ref_file.crds.context_used = crds_client.get_context_used(model.crds_observatory)
+                model.meta.ref_file.crds.context_used = crds_client.get_context_used(
+                    model.crds_observatory
+                )
 
     def record_step_status(self, model, step_name, success=True):
         """

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -16,8 +16,7 @@ if os.environ.get("CI") == "false":
 
 
 _LOG_FORMATTER = logging.Formatter(
-    "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%S"
+    "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
 )
 _LOG_FORMATTER.converter = time.gmtime
 
@@ -26,6 +25,7 @@ class RomanStep(Step):
     """
     Base class for Roman calibration pipeline steps.
     """
+
     spec = """
     output_ext =  string(default='.asdf')    # Default type of output
     """
@@ -58,21 +58,19 @@ class RomanStep(Step):
             for log_record in self.log_records:
                 model.cal_logs.append(_LOG_FORMATTER.format(log_record))
 
-
         if len(reference_files_used) > 0:
             for ref_name, ref_file in reference_files_used:
                 if hasattr(model.meta.ref_file, ref_name):
                     setattr(model.meta.ref_file, ref_name, ref_file)
-                    #getattr(model.meta.ref_file, ref_name).name = ref_file
+                    # getattr(model.meta.ref_file, ref_name).name = ref_file
 
         # this will only run if 'parent' is none, which happens when an individual step is being run
         # or if self is a RomanPipeline and not a RomanStep.
 
         if os.environ.get("CI") == "false":  # no CRDS connection, do not run
-            if (self.parent is None):
+            if self.parent is None:
                 model.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
                 model.meta.ref_file.crds.context_used = crds_client.get_context_used(model.crds_observatory)
-
 
     def record_step_status(self, model, step_name, success=True):
         """

--- a/romancal/stpipe/integration.py
+++ b/romancal/stpipe/integration.py
@@ -21,7 +21,7 @@ def get_steps():
     # class definitions.  We need to avoid importing romancal.pipeline and
     # romancal.step to keep the CLI snappy.
     return [
-        ("romancal.pipeline.ExposurePipeline", 'roman_elp', True),
+        ("romancal.pipeline.ExposurePipeline", "roman_elp", True),
         ("romancal.step.DarkCurrentStep", None, False),
         ("romancal.step.DQInitStep", None, False),
         ("romancal.step.FlatFieldStep", None, False),

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -20,7 +20,7 @@ def test_open_model(step_class, tmp_path):
 
     with asdf.AsdfFile() as af:
         imod = mk_level2_image(shape=(20, 20))
-        af.tree = {'roman': imod}
+        af.tree = {"roman": imod}
         af.write_to(file_path)
 
     step = step_class()
@@ -30,8 +30,7 @@ def test_open_model(step_class, tmp_path):
 
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently \
-    available outside the internal network"
+    reason="Roman CRDS servers are not currently available outside the internal network",
 )
 @pytest.mark.parametrize("step_class", [RomanPipeline, RomanStep])
 def test_get_reference_file(step_class):
@@ -43,7 +42,7 @@ def test_get_reference_file(step_class):
     # If this test starts failing mysteriously, check the
     # metadata values against the flat rmap.
     im.meta.instrument.optical_element = "F158"
-    im.meta.exposure.start_time = Time('2021-01-01T12:00:00')
+    im.meta.exposure.start_time = Time("2021-01-01T12:00:00")
     model = ImageModel(im)
 
     step = step_class()
@@ -56,8 +55,7 @@ def test_get_reference_file(step_class):
 @pytest.mark.skip(reason="There are no grism flats.")
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently \
-    available outside the internal network"
+    reason="Roman CRDS servers are not currently available outside the internal network",
 )
 @pytest.mark.parametrize("step_class", [RomanPipeline, RomanStep])
 def test_get_reference_file_spectral(step_class):
@@ -69,7 +67,7 @@ def test_get_reference_file_spectral(step_class):
     # If this test starts failing mysteriously, check the
     # metadata values against the flat rmap.
     im.meta.instrument.optical_element = "GRISM"
-    im.meta.exposure.start_time = Time('2021-01-01T12:00:00')
+    im.meta.exposure.start_time = Time("2021-01-01T12:00:00")
     model = ImageModel(im)
 
     step = step_class()

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -3,10 +3,9 @@ import os
 import asdf
 import pytest
 from astropy.time import Time
-
-
+from roman_datamodels.datamodels import FlatRefModel, ImageModel
 from roman_datamodels.maker_utils import mk_level2_image
-from roman_datamodels.datamodels import ImageModel, FlatRefModel
+
 from romancal.stpipe import RomanPipeline, RomanStep
 
 

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -30,7 +30,9 @@ def test_open_model(step_class, tmp_path):
 
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 @pytest.mark.parametrize("step_class", [RomanPipeline, RomanStep])
 def test_get_reference_file(step_class):
@@ -55,7 +57,9 @@ def test_get_reference_file(step_class):
 @pytest.mark.skip(reason="There are no grism flats.")
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal network",
+    reason=(
+        "Roman CRDS servers are not currently available outside the internal network"
+    ),
 )
 @pytest.mark.parametrize("step_class", [RomanPipeline, RomanStep])
 def test_get_reference_file_spectral(step_class):

--- a/romancal/stpipe/tests/test_integration.py
+++ b/romancal/stpipe/tests/test_integration.py
@@ -1,11 +1,10 @@
 from stpipe import entry_points
 from stpipe.utilities import import_class
 
-from romancal.stpipe.integration import get_steps
-from romancal.stpipe import RomanStep, RomanPipeline
-
 import romancal.pipeline
 import romancal.step
+from romancal.stpipe import RomanPipeline, RomanStep
+from romancal.stpipe.integration import get_steps
 
 
 def test_get_steps():

--- a/romancal/stpipe/tests/test_integration.py
+++ b/romancal/stpipe/tests/test_integration.py
@@ -10,7 +10,9 @@ from romancal.stpipe.integration import get_steps
 def test_get_steps():
     tuples = get_steps()
 
-    assert {t[0].split(".")[-1] for t in tuples} == set(romancal.step.__all__ + romancal.pipeline.__all__)
+    assert {t[0].split(".")[-1] for t in tuples} == set(
+        romancal.step.__all__ + romancal.pipeline.__all__
+    )
 
     for class_name, class_alias, is_pipeline in tuples:
         step_class = import_class(class_name)

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -14,15 +14,15 @@ logger.addHandler(logging.NullHandler())
 
 # Step classes that are not user-api steps
 NON_STEPS = [
-    'EngDBLogStep',
-    'FunctionWrapper',
-    'RomancalPipeline',
-    'RomanPipeline',
-    'ExposurePipeline',
-    'RomanStep',
-    'Pipeline',
-    'Step',
-    'SystemCall',
+    "EngDBLogStep",
+    "FunctionWrapper",
+    "RomancalPipeline",
+    "RomanPipeline",
+    "ExposurePipeline",
+    "RomanStep",
+    "Pipeline",
+    "Step",
+    "SystemCall",
 ]
 
 
@@ -36,17 +36,14 @@ def all_steps():
     """
     from romancal.stpipe import RomanStep as Step
 
-    romancal = import_module('romancal')
+    romancal = import_module("romancal")
     romancal_fpath = os.path.split(romancal.__file__)[0]
 
     steps = {}
     for module in load_local_pkg(romancal_fpath):
         more_steps = {
             klass_name: klass
-            for klass_name, klass in inspect.getmembers(
-                module,
-                lambda o: inspect.isclass(o) and issubclass(o, Step)
-            )
+            for klass_name, klass in inspect.getmembers(module, lambda o: inspect.isclass(o) and issubclass(o, Step))
             if klass_name not in NON_STEPS
         }
         steps.update(more_steps)
@@ -70,16 +67,13 @@ def load_local_pkg(fpath):
     package_fpath, package = os.path.split(fpath)
     package_fpath_len = len(package_fpath) + 1
     try:
-        for module_fpath in folder_traverse(
-            fpath, basename_regex=r'[^_].+\.py$', path_exclude_regex='tests'
-        ):
+        for module_fpath in folder_traverse(fpath, basename_regex=r"[^_].+\.py$", path_exclude_regex="tests"):
             folder_path, fname = os.path.split(module_fpath[package_fpath_len:])
-            module_path = folder_path.split('/')
+            module_path = folder_path.split("/")
             module_path.append(os.path.splitext(fname)[0])
-            module_path = '.'.join(module_path)
+            module_path = ".".join(module_path)
             try:
-                spec = importlib.util.spec_from_file_location(module_path,
-                                                              module_fpath)
+                spec = importlib.util.spec_from_file_location(module_path, module_fpath)
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
             except Exception as err:
@@ -90,7 +84,7 @@ def load_local_pkg(fpath):
         logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
 
 
-def folder_traverse(folder_path, basename_regex='.+', path_exclude_regex='^$'):
+def folder_traverse(folder_path, basename_regex=".+", path_exclude_regex="^$"):
     """Generator of full file paths for all files
     in a folder.
 

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -43,7 +43,9 @@ def all_steps():
     for module in load_local_pkg(romancal_fpath):
         more_steps = {
             klass_name: klass
-            for klass_name, klass in inspect.getmembers(module, lambda o: inspect.isclass(o) and issubclass(o, Step))
+            for klass_name, klass in inspect.getmembers(
+                module, lambda o: inspect.isclass(o) and issubclass(o, Step)
+            )
             if klass_name not in NON_STEPS
         }
         steps.update(more_steps)
@@ -67,7 +69,9 @@ def load_local_pkg(fpath):
     package_fpath, package = os.path.split(fpath)
     package_fpath_len = len(package_fpath) + 1
     try:
-        for module_fpath in folder_traverse(fpath, basename_regex=r"[^_].+\.py$", path_exclude_regex="tests"):
+        for module_fpath in folder_traverse(
+            fpath, basename_regex=r"[^_].+\.py$", path_exclude_regex="tests"
+        ):
             folder_path, fname = os.path.split(module_fpath[package_fpath_len:])
             module_path = folder_path.split("/")
             module_path.append(os.path.splitext(fname)[0])
@@ -81,7 +85,9 @@ def load_local_pkg(fpath):
             else:
                 yield module
     except Exception as err:
-        logger.debug(f'Cannot complete package loading: Exception occurred: "{str(err)}"')
+        logger.debug(
+            f'Cannot complete package loading: Exception occurred: "{str(err)}"'
+        )
 
 
 def folder_traverse(folder_path, basename_regex=".+", path_exclude_regex="^$"):

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -2,11 +2,11 @@
 Utilities
 """
 import importlib.util
-from importlib import import_module
 import inspect
 import logging
 import os
 import re
+from importlib import import_module
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/romancal/tests/base_classes.py
+++ b/romancal/tests/base_classes.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 import requests
-from ci_watson.artifactory_helpers import BigdataError, check_url, get_bigdata, get_bigdata_root
+from ci_watson.artifactory_helpers import (
+    BigdataError,
+    check_url,
+    get_bigdata,
+    get_bigdata_root,
+)
 
 # from jwst.associations import load_asn
 

--- a/romancal/tests/base_classes.py
+++ b/romancal/tests/base_classes.py
@@ -1,18 +1,13 @@
 """Base classes for Roman tests"""
-from glob import glob as _sys_glob
 import os
+import sys
+from glob import glob as _sys_glob
 from os import path as op
 from pathlib import Path
-import sys
+
 import pytest
 import requests
-
-from ci_watson.artifactory_helpers import (
-    BigdataError,
-    check_url,
-    get_bigdata,
-    get_bigdata_root,
-)
+from ci_watson.artifactory_helpers import BigdataError, check_url, get_bigdata, get_bigdata_root
 
 # from jwst.associations import load_asn
 

--- a/romancal/tests/test_import.py
+++ b/romancal/tests/test_import.py
@@ -11,7 +11,9 @@ import romancal
 def dependencies(package, exclude: [str]):
     return [
         module[1]
-        for module in pkgutil.walk_packages(package.__path__, prefix=package.__name__ + ".")
+        for module in pkgutil.walk_packages(
+            package.__path__, prefix=package.__name__ + "."
+        )
         if not any(exclude_module in module[1] for exclude_module in exclude)
     ]
 

--- a/romancal/tests/test_import.py
+++ b/romancal/tests/test_import.py
@@ -11,9 +11,7 @@ import romancal
 def dependencies(package, exclude: [str]):
     return [
         module[1]
-        for module in pkgutil.walk_packages(
-            package.__path__, prefix=package.__name__ + "."
-        )
+        for module in pkgutil.walk_packages(package.__path__, prefix=package.__name__ + ".")
         if not any(exclude_module in module[1] for exclude_module in exclude)
     ]
 

--- a/romancal/tweakreg/astrometric_utils.py
+++ b/romancal/tweakreg/astrometric_utils.py
@@ -1,13 +1,13 @@
 import os
+
 import requests
-
 from astropy import table
-from astropy.table import Table
-from astropy.coordinates import SkyCoord
 from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
 
-from ..resample import resample_utils
 from ..assign_wcs import utils as wcsutil
+from ..resample import resample_utils
 
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -3,18 +3,18 @@ Roman pipeline step for image alignment.
 """
 from os import path
 
-from astropy.table import Table
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from tweakwcs.imalign import align_wcs
+from astropy.table import Table
+from roman_datamodels import datamodels
+from roman_datamodels.util import is_association
 from tweakwcs.correctors import JWSTWCSCorrector
+from tweakwcs.imalign import align_wcs
 from tweakwcs.matchutils import XYXYMatch
 
 # LOCAL
 from ..stpipe import RomanStep
-from roman_datamodels import datamodels
 from . import astrometric_utils as amutils
-from roman_datamodels.util import is_association
 
 
 def _oxford_or_str_join(str_list):

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -75,7 +75,7 @@ class TweakRegStep(RomanStep):
         abs_nclip = integer(min=0, default=3) # Number of clipping iterations in fit when performing absolute astrometry
         abs_sigma = float(min=0.0, default=3.0) # Clipping limit in sigma units when performing absolute astrometry
         output_use_model = boolean(default=True)  # When saving use `DataModel.meta.filename`
-    """
+    """  # noqa: E501
 
     reference_file_types = []
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -225,7 +225,7 @@ class TweakRegStep(RomanStep):
             self.log.info(f"* Images in GROUP '{group_name}':")
             for im in imcats:
                 im.meta["group_id"] = group_name
-                self.log.info("     {}".format(im.meta["name"]))
+                self.log.info(f"     {im.meta['name']}")
 
             self.log.info("")
 
@@ -244,7 +244,7 @@ class TweakRegStep(RomanStep):
                     self.log.info(f"* Images in GROUP '{group_name}':")
                     for im in wcsimlist:
                         im.meta["group_id"] = group_name
-                        self.log.info("     {}".format(im.meta["name"]))
+                        self.log.info(f"     {im.meta['name']}")
                     imcats.extend(wcsimlist)
 
             self.log.info("")

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -119,7 +119,10 @@ class TweakRegStep(RomanStep):
                     for im in images:
                         filename = im.meta.filename
                         if filename in catdict:
-                            print(f"setting {filename}.tweakreg_catalog = {repr(catdict[filename])}")
+                            print(
+                                f"setting {filename}.tweakreg_catalog ="
+                                f" {repr(catdict[filename])}"
+                            )
                             im.meta.tweakreg_catalog = catdict[filename]
 
             else:
@@ -133,7 +136,11 @@ class TweakRegStep(RomanStep):
             ) + e.args[1:]
             raise e
 
-        if self.abs_refcat is not None and self.abs_refcat.strip() and self.abs_refcat != DEFAULT_ABS_REFCAT:
+        if (
+            self.abs_refcat is not None
+            and self.abs_refcat.strip()
+            and self.abs_refcat != DEFAULT_ABS_REFCAT
+        ):
             # Set expand_refcat to True to eliminate possibility of duplicate
             # entries when aligning to absolute astrometric reference catalog
             self.expand_refcat = True
@@ -156,7 +163,8 @@ class TweakRegStep(RomanStep):
                         catalog.rename_column(long_axis, axis)
                     else:
                         raise ValueError(
-                            "'tweakreg' source catalogs must contain either columns 'x' and 'y' or 'xcentroid' and 'ycentroid'."
+                            "'tweakreg' source catalogs must contain either columns 'x'"
+                            " and 'y' or 'xcentroid' and 'ycentroid'."
                         )
 
             # filter out sources outside the WCS bounding box
@@ -176,7 +184,9 @@ class TweakRegStep(RomanStep):
                 self.log.info(f"Detected {len(catalog)} sources in {filename}.")
 
             if new_cat and self.save_catalogs:
-                catalog_filename = filename.replace(".fits", f"_cat.{self.catalog_format}")
+                catalog_filename = filename.replace(
+                    ".fits", f"_cat.{self.catalog_format}"
+                )
                 if self.catalog_format == "ecsv":
                     fmt = "ascii.ecsv"
                 elif self.catalog_format == "fits":
@@ -221,7 +231,11 @@ class TweakRegStep(RomanStep):
             imcats = list(map(self._imodel2wcsim, g))
             # Remove the attached catalogs
             for model in g:
-                model = model if isinstance(model, datamodels.DataModel) else datamodels.open(path.basename(model))
+                model = (
+                    model
+                    if isinstance(model, datamodels.DataModel)
+                    else datamodels.open(path.basename(model))
+                )
             self.log.info(f"* Images in GROUP '{group_name}':")
             for im in imcats:
                 im.meta["group_id"] = group_name
@@ -274,10 +288,15 @@ class TweakRegStep(RomanStep):
 
             except ValueError as e:
                 msg = e.args[0]
-                if msg == "Too few input images (or groups of images) with non-empty catalogs.":
+                if (
+                    msg == "Too few input images (or groups of images) with non-empty"
+                    " catalogs."
+                ):
                     # we need at least two exposures to perform image alignment
                     self.log.warning(msg)
-                    self.log.warning("At least two exposures are required for image alignment.")
+                    self.log.warning(
+                        "At least two exposures are required for image alignment."
+                    )
                     self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
                     for model in images:
                         model.meta.cal_step.tweakreg = "SKIPPED"
@@ -314,7 +333,10 @@ class TweakRegStep(RomanStep):
                 if not self._is_wcs_correction_small(wcs, twcs):
                     # Large corrections are typically a result of source
                     # mis-matching or poorly-conditioned fit. Skip such models.
-                    self.log.warning(f"WCS has been tweaked by more than {10 * self.tolerance} arcsec")
+                    self.log.warning(
+                        "WCS has been tweaked by more than"
+                        f" {10 * self.tolerance} arcsec"
+                    )
 
                     for model in images:
                         model.meta.cal_step.tweakreg = "SKIPPED"
@@ -345,7 +367,9 @@ class TweakRegStep(RomanStep):
             gaia_cat_name = self.abs_refcat.upper()
 
             if gaia_cat_name in SINGLE_GROUP_REFCAT:
-                ref_cat = amutils.create_astrometric_catalog(images, gaia_cat_name, output=output_name)
+                ref_cat = amutils.create_astrometric_catalog(
+                    images, gaia_cat_name, output=output_name
+                )
 
             elif path.isfile(self.abs_refcat):
                 ref_cat = Table.read(self.abs_refcat)
@@ -388,7 +412,10 @@ class TweakRegStep(RomanStep):
                 # earlier in this step.
                 for imcat in imcats:
                     imcat.meta["group_id"] = 987654
-                    if "fit_info" in imcat.meta and "REFERENCE" in imcat.meta["fit_info"]["status"]:
+                    if (
+                        "fit_info" in imcat.meta
+                        and "REFERENCE" in imcat.meta["fit_info"]["status"]
+                    ):
                         del imcat.meta["fit_info"]
 
                 # Perform fit
@@ -444,7 +471,9 @@ class TweakRegStep(RomanStep):
 
     def _imodel2wcsim(self, image_model):
         image_model = (
-            image_model if isinstance(image_model, datamodels.DataModel) else datamodels.open(path.basename(image_model))
+            image_model
+            if isinstance(image_model, datamodels.DataModel)
+            else datamodels.open(path.basename(image_model))
         )
         catalog = image_model.meta.tweakreg_catalog
         model_name = path.splitext(image_model.meta.filename)[0].strip("_- ")
@@ -464,7 +493,8 @@ class TweakRegStep(RomanStep):
                     catalog.rename_column(long_axis, axis)
                 else:
                     raise ValueError(
-                        "'tweakreg' source catalogs must contain either columns 'x' and 'y' or 'xcentroid' and 'ycentroid'."
+                        "'tweakreg' source catalogs must contain either columns 'x' and"
+                        " 'y' or 'xcentroid' and 'ycentroid'."
                     )
 
         # create WCSImageCatalog object:

--- a/scripts/asn_from_list
+++ b/scripts/asn_from_list
@@ -2,5 +2,5 @@
 
 from romancal.associations.asn_from_list import Main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     Main()


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Apply code formatters to `romancal`. This applies:

- `isort` for import sorting
- `black` for code formatting

I also noticed that for the most part his code respects a much tighter line length constraint than the 130 that is listed for flake8. So I used the code formatters to reduce the line length to the default for black of 88 characters.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
