### PR TITLE
move pytest markers to pyproject.toml

### DIFF
--- a/docs/roman/datamodels/datamodels_asdf.rst
+++ b/docs/roman/datamodels/datamodels_asdf.rst
@@ -144,9 +144,9 @@ asdf tree.
 
 .. code:: python
 
-    >>> from roman_datamodels import datamodels as rdm
-    >>> d_uncal = rdm.open('r0000101001001001001_01101_0001_WFI01_uncal.asdf')
-    >>> d_uncal.info()
+    >>> from roman_datamodels import datamodels as rdm  # doctest: +SKIP
+    >>> d_uncal = rdm.open('r0000101001001001001_01101_0001_WFI01_uncal.asdf')  # doctest: +SKIP
+    >>> d_uncal.info()  # doctest: +SKIP
     root (AsdfObject)
     ├─asdf_library (Software)
     │ ├─author (str): The ASDF Developers
@@ -181,7 +181,7 @@ For example, to show all top-level nodes and 5 of each's children:
 
 .. code:: python
 
-    >>> d_uncal.info(max_rows=(None,5))
+    >>> d_uncal.info(max_rows=(None,5))  # doctest: +SKIP
     root (AsdfObject)
     ├─asdf_library (Software)
     │ ├─author (str): The ASDF Developers
@@ -208,7 +208,7 @@ lines for each of the meta entries,
 
 .. code:: python
 
-    >>> asdf.info(d_uncal.meta,max_rows=(None, 3))
+    >>> asdf.info(d_uncal.meta,max_rows=(None, 3))  # doctest: +SKIP
     root (DNode)
     ├─aperture (Aperture)
     │ ├─name (str): WFI_CEN
@@ -233,7 +233,7 @@ in `cal_step` without listing the values,
 
 .. code:: python
 
-    >>> asdf.info(d_uncal.meta.cal_step,max_rows=(None, 3),show_values=False)
+    >>> asdf.info(d_uncal.meta.cal_step,max_rows=(None, 3),show_values=False)  # doctest: +SKIP
     root (CalStep)
     ├─assign_wcs (str)
     ├─flat_field (str)
@@ -254,7 +254,7 @@ You can also use the search method to find attributes,
 
 .. code:: python
 
-    >>> d_uncal.search('cal_step')
+    >>> d_uncal.search('cal_step')  # doctest: +SKIP
     root (AsdfObject)
     └─roman (WfiScienceRaw)
       └─meta (dict)
@@ -264,7 +264,7 @@ or a a general search for all attributes with cal in the name
 
 .. code:: python
 
-    >>> d_uncal.search('cal')
+    >>> d_uncal.search('cal')  # doctest: +SKIP
     root (AsdfObject)
     └─roman (WfiScienceRaw)
      └─meta (dict)
@@ -283,7 +283,7 @@ To search only within the meta tree,
 
 .. code:: python
 
-    >>> d_uncal.search('cal_')['roman']['meta']
+    >>> d_uncal.search('cal_')['roman']['meta']  # doctest: +SKIP
     meta (dict)
     ├─cal_step (CalStep)
     └─instrument (WfiMode)
@@ -295,7 +295,7 @@ keyword,
 
 .. code:: python
 
-    >>> d_uncal.search(type=bool)
+    >>> d_uncal.search(type=bool)  # doctest: +SKIP
     root (AsdfObject)
     └─roman (WfiScienceRaw)
       └─meta (dict)
@@ -305,7 +305,7 @@ keyword,
           ├─internal_target (bool): False
           └─target_of_opportunity (bool): False
 
-    d_uncal.search(type=bool, value=True)
+    >>> d_uncal.search(type=bool, value=True)  # doctest: +SKIP
     No results found.
 
 More information and options for the search method can be found in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,10 @@ doctest_plus = 'enabled'
 doctest_rst = 'enabled'
 text_file_format = 'rst'
 addopts = '--show-capture=no --open-files --doctest-ignore-import-errors'
+markers = [
+    'soctests: run only the SOC tests in the suite.',
+]
+
 
 [tool.coverage]
 run = { omit = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-	soctests: run only the SOC tests in the suite.

--- a/romancal/associations/registry.py
+++ b/romancal/associations/registry.py
@@ -60,7 +60,7 @@ class AssociationRegistry(dict):
     The general workflow is as follows:
 
         * Create the registry
-            >>> from jwst.associations.registry import AssociationRegistry
+            >>> from romancal.associations.registry import AssociationRegistry
             >>> registry = AssociationRegistry()
 
         * Create associations from an item
@@ -71,7 +71,7 @@ class AssociationRegistry(dict):
 
     In practice, this is one step in a larger loop over all items to
     be associated. This does not account for adding items to already
-    existing associations. See :py:func:`~jwst.associations.generate` for more information.
+    existing associations. See :py:func:`~romancal.associations.generate` for more information.
     """
 
     def __init__(self,


### PR DESCRIPTION
remove pytest.ini

The existence of pytest.ini (introduced in https://github.com/spacetelescope/romancal/pull/411) prevented pytest from
reading options from pyproject.toml that for one
example disabled doctests

~~I'm expecting this will fail ci as at least one doctest contains a use of jwst:~~ Edited: fixed this reference
https://github.com/spacetelescope/romancal/blob/393d60f4702489d9e1d2f8b1fa7054e678b619b2/romancal/associations/registry.py#L63

which appears as a failure in the stpipe downstream ci testing of romancal:
https://github.com/spacetelescope/stpipe/actions/runs/4161774078/jobs/7200153620#step:8:39


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
