### PR TITLE
RCAL-479 Test for PSF keywords (DMS-136)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,12 @@
 
 general
 -------
+- Adds explicit test for PSF keywords are present in the  cal files. [#]
 
 - Add ``pre-commit`` configuration to repository. [#622]
+
 - Update the suffix for the stored filename to match the filename [#609]
+
 - DQ step flags science data affected by guide window read [#599]
 
 - Fix deprecation warnings introduced by ``pytest`` ``7.2`` ahead of ``8.0`` [#597]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 general
 -------
-- Adds explicit test for PSF keywords are present in the  cal files. [#]
+- Adds explicit test for PSF keywords are present in the  cal files. [#648]
 
 - Add ``pre-commit`` configuration to repository. [#622]
 

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -158,6 +158,14 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
                       passfail("exposure_time" in model.meta.exposure))
     assert "exposure_time" in model.meta.exposure
 
+    # DMS-136 PSF tests
+    pipeline.log.info('DMS8136MSG: Testing existence of  detector and '
+                      'optical element (detector & optical_element) in Level 2 '
+                      'image output.......' +
+                      passfail("exposure_time" in model.meta.exposure))
+    assert "detector" in model.meta.instrument
+    assert "optical_element" in model.meta.instrument
+
     # DMS89 WCS tests
     pipeline.log.info('DMS89 MSG: Testing that the wcs bounding'
                       'box was generated.......' +


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-479](https://jira.stsci.edu/browse/rcal-479)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds tests for the PSF determination as described in, [Build 9 Planning](https://innerspace.stsci.edu/pages/viewpage.action?spaceKey=ROMAN&title=Build+9+requirements+and+test+planning) SOC-565 Success Criteria:
We test for detector and optical_element in the final level 2 file. 

The regression tests are passing and can be seen at,
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/96/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
