### PR TITLE
Bug fix: make sure ASDF is not closed prematurely.

### DIFF
--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -526,8 +526,10 @@ class TweakRegStep(RomanStep):
 def _common_name(group):
     file_names = []
     for im in group:
-        im = im if isinstance(im, datamodels.DataModel) else datamodels.open(im)
-        file_names.append(path.splitext(im.meta.filename)[0].strip('_- '))
+        if isinstance(im, datamodels.DataModel):
+            file_names.append(path.splitext(im.meta.filename)[0].strip('_- '))
+        else:
+            raise TypeError("Input must be a list of datamodels list.")
 
     cn = path.commonprefix(file_names)
     return cn

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -528,7 +528,6 @@ def _common_name(group):
     for im in group:
         im = im if isinstance(im, datamodels.DataModel) else datamodels.open(im)
         file_names.append(path.splitext(im.meta.filename)[0].strip('_- '))
-        im.close()
 
     cn = path.commonprefix(file_names)
     return cn


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses a bug in `TweakReg` where an ASDF object was being closed prematurely.
The object was being closed while `TweakReg` was determining the common name of the ASDF files in the input list.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
