### PR TITLE
Raise exception whenever tweakreg_catalog is missing.

### DIFF
--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -141,15 +141,11 @@ class TweakRegStep(RomanStep):
 
         # Build the catalogs for input images
         for i, image_model in enumerate(images):
-            try:
-                # use user-supplied catalog:
-                self.log.info("Using user-provided input catalog "
-                              f"'{image_model.meta.tweakreg_catalog}'")
+            if hasattr(image_model.meta, "tweakreg_catalog"):
                 catalog = Table.read(image_model.meta.tweakreg_catalog)
                 new_cat = False
-
-            except OSError:
-                self.log.error("Failed to read 'meta.tweakreg_catalog' from source detection step ")
+            else:
+                raise AttributeError("Attribute 'meta.tweakreg_catalog' is missing.")
 
             for axis in ['x', 'y']:
                 if axis not in catalog.colnames:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses the case when the user wants to run TweakRegStep without running source detection first.

In addition to creating an output file with the results, the source detection step adds an attribute (`tweakreg_catalog`) to the `meta` indicating the filename that should be used in `TweakRegStep` for alignment with Gaia. Such attribute will always be present when the romancal pipeline is executed through the `ExposurePipeline` class.

In the case where the user wants to execute TweakRegStep separately without first running source detection, then `tweakreg_catalog` will be missing. For now, we will only raise an `AttributeError` and stop processing.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
