### PR TITLE
import `tomli` as `tomllib` for `docs` builds before Python 3.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import sphinx
 import stsci_rtd_theme
+
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
@@ -42,7 +43,7 @@ sys.path.insert(0, os.path.abspath("exts/"))
 # -- General configuration ------------------------------------------------
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
     conf = tomllib.load(configuration_file)
-setup_cfg = conf['project']
+setup_cfg = conf["project"]
 
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.3'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,10 @@ from pathlib import Path
 
 import sphinx
 import stsci_rtd_theme
-import tomli
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 
 def setup(app):
@@ -38,7 +41,7 @@ sys.path.insert(0, os.path.abspath('exts/'))
 
 # -- General configuration ------------------------------------------------
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
-    conf = tomli.load(configuration_file)
+    conf = tomllib.load(configuration_file)
 setup_cfg = conf['project']
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`tomli` is implemented read-only as `tomllib` in Python 3.11

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
