### PR TITLE
RCAL-482

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ general
 -------
 - Updated datamodel maker utility imports. [#654]
 
+- Update non-VOunits to using ``astropy.units``. [#658]
+
 0.10.0 (2023-02-21)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 ]
 dependencies = [
     'asdf >=2.13.0',
+    'asdf-astropy >=0.4.0',
     'astropy >=5.0.4',
     'crds >=11.16.16',
     'gwcs >=0.18.1',
@@ -20,9 +21,10 @@ dependencies = [
     'numpy >=1.20',
     'pyparsing >=2.4.7',
     'requests >=2.22',
-    'rad >=0.14.1',
+    # 'rad >=0.14.1',
+    'rad @ git+https://github.com/spacetelescope/rad.git@main',
     #'roman_datamodels >=0.14.1',
-    'roman_datamodels @git+https://github.com/spacetelescope/roman_datamodels.git@main',
+    'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git@main',
     'stcal >=1.3.3',
     'stpipe >=0.4.2',
     'tweakwcs >=0.8.0'

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -4,7 +4,6 @@ import numpy as np
 from astropy import units as u
 from roman_datamodels import datamodels as rdd
 from roman_datamodels import maker_utils
-from roman_datamodels import units as ru
 from stcal.dark_current import dark_sub
 
 from romancal.stpipe import RomanStep
@@ -143,10 +142,10 @@ def dark_output_data_as_ramp_model(out_data, input_model):
     # Removing integration dimension from variables (added for stcal
     # compatibility)
     # Roman 3D
-    out_model.data = u.Quantity(out_data.data[0], ru.DN, dtype=out_data.data.dtype)
+    out_model.data = u.Quantity(out_data.data[0], u.DN, dtype=out_data.data.dtype)
     out_model.groupdq = out_data.groupdq[0]
     # Roman 2D
     out_model.pixeldq = out_data.pixeldq
-    out_model.err = u.Quantity(out_data.err[0], ru.DN, dtype=out_data.err.dtype)
+    out_model.err = u.Quantity(out_data.err[0], u.DN, dtype=out_data.err.dtype)
 
     return out_model

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -9,7 +9,6 @@ import pytest
 import roman_datamodels as rdm
 from astropy import units as u
 from roman_datamodels import maker_utils
-from roman_datamodels import units as ru
 from roman_datamodels.datamodels import DarkRefModel, RampModel
 
 from romancal.dark_current import DarkCurrentStep
@@ -138,7 +137,7 @@ def create_ramp_and_dark(shape, instrument, exptype):
     ramp.meta.instrument.detector = "WFI01"
     ramp.meta.instrument.optical_element = "F158"
     ramp.meta.exposure.type = exptype
-    ramp.data = u.Quantity(np.ones(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp.data = u.Quantity(np.ones(shape, dtype=np.float32), u.DN, dtype=np.float32)
     ramp_model = RampModel(ramp)
 
     # Create dark model

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from astropy import units as u
 from roman_datamodels import maker_utils, stnode
-from roman_datamodels import units as ru
 from roman_datamodels.datamodels import MaskRefModel, ScienceRawModel
 from stdatamodels.validate import ValidationWarning
 
@@ -216,7 +215,7 @@ def test_dqinit_step_interface(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16
+        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
     )
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
@@ -273,7 +272,7 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), ru.DN, dtype=np.uint16
+        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
     )
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -6,7 +6,6 @@ import logging
 
 import numpy as np
 from astropy import units as u
-from roman_datamodels import units as ru
 
 from romancal.lib import dqflags
 
@@ -111,7 +110,7 @@ def apply_flat_field(science, flat):
     # Now let's apply the correction to science data and error arrays.  Rely
     # on array broadcasting to handle the cubes
     science.data = u.Quantity(
-        (science.data.value / flat_data), ru.electron / u.s, dtype=science.data.dtype
+        (science.data.value / flat_data), u.electron / u.s, dtype=science.data.dtype
     )
 
     # Update the variances using BASELINE algorithm.  For guider data, it has

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -5,7 +5,6 @@ import pytest
 from astropy import units as u
 from astropy.time import Time
 from roman_datamodels import maker_utils, stnode
-from roman_datamodels import units as ru
 from roman_datamodels.datamodels import FlatRefModel, ImageModel
 
 from romancal.flatfield import FlatFieldStep
@@ -34,20 +33,20 @@ def test_flatfield_step_interface(instrument, exptype):
     wfi_image.meta.instrument.optical_element = "F158"
     wfi_image.meta.exposure.type = exptype
     wfi_image.data = u.Quantity(
-        np.ones(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32
+        np.ones(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32
     )
     wfi_image.dq = np.zeros(shape, dtype=np.uint32)
     wfi_image.err = u.Quantity(
-        np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32
+        np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32
     )
     wfi_image.var_poisson = u.Quantity(
-        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+        np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32
     )
     wfi_image.var_rnoise = u.Quantity(
-        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+        np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32
     )
     wfi_image.var_flat = u.Quantity(
-        np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32
+        np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32
     )
 
     wfi_image_model = ImageModel(wfi_image)

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -11,7 +11,6 @@ from astropy import units as u
 from astropy.time import Time
 from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
-from roman_datamodels import units as ru
 from roman_datamodels.datamodels import GainRefModel, ReadnoiseRefModel
 
 from romancal.jump import JumpStep
@@ -50,12 +49,12 @@ def generate_wfi_reffiles(tmpdir_factory):
 
     gain_ref["meta"] = meta
     gain_ref["data"] = u.Quantity(
-        np.ones(shape, dtype=np.float32) * ingain, ru.electron / ru.DN, dtype=np.float32
+        np.ones(shape, dtype=np.float32) * ingain, u.electron / u.DN, dtype=np.float32
     )
     gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     gain_ref["err"] = u.Quantity(
         (np.random.random(shape) * 0.05).astype(np.float64),
-        ru.electron / ru.DN,
+        u.electron / u.DN,
         dtype=np.float64,
     )
 
@@ -79,11 +78,11 @@ def generate_wfi_reffiles(tmpdir_factory):
 
     rn_ref["meta"] = meta
     rn_ref["data"] = u.Quantity(
-        np.ones(shape, dtype=np.float32), ru.DN, dtype=np.float32
+        np.ones(shape, dtype=np.float32), u.DN, dtype=np.float32
     )
     rn_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     rn_ref["err"] = u.Quantity(
-        (np.random.random(shape) * 0.05).astype(np.float64), ru.DN, dtype=np.float64
+        (np.random.random(shape) * 0.05).astype(np.float64), u.DN, dtype=np.float64
     )
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)
@@ -122,10 +121,10 @@ def setup_inputs():
         dm_ramp.meta.instrument.name = "WFI"
         dm_ramp.meta.instrument.optical_element = "F158"
 
-        dm_ramp.data = u.Quantity(data + 6.0, ru.DN, dtype=np.float32)
+        dm_ramp.data = u.Quantity(data + 6.0, u.DN, dtype=np.float32)
         dm_ramp.pixeldq = pixdq
         dm_ramp.groupdq = gdq
-        dm_ramp.err = u.Quantity(err, ru.DN, dtype=np.float32)
+        dm_ramp.err = u.Quantity(err, u.DN, dtype=np.float32)
 
         dm_ramp.meta.exposure.type = "WFI_IMAGE"
         dm_ramp.meta.exposure.group_time = deltatime

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -6,7 +6,6 @@ import numpy as np
 import roman_datamodels as rdm
 from astropy import units as u
 from roman_datamodels import datamodels as rdd
-from roman_datamodels import units as ru
 from stcal.linearity.linearity import linearity_correction
 
 from romancal.lib import dqflags
@@ -63,7 +62,7 @@ class LinearityStep(RomanStep):
             )
 
             output_model.data = u.Quantity(
-                new_data[0, :, :, :], ru.DN, dtype=new_data.dtype
+                new_data[0, :, :, :], u.DN, dtype=new_data.dtype
             )
             output_model.pixeldq = new_pdq
 

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -7,7 +7,6 @@ from astropy import units as u
 from roman_datamodels import datamodels as rdd
 from roman_datamodels import maker_utils
 from roman_datamodels import stnode as rds
-from roman_datamodels import units as ru
 from stcal.ramp_fitting import ramp_fit
 
 from romancal.lib import dqflags
@@ -54,23 +53,21 @@ def create_optional_results_model(input_model, opt_info):
 
     inst = {
         "meta": meta,
-        "slope": u.Quantity(np.squeeze(slope), ru.electron / u.s, dtype=slope.dtype),
+        "slope": u.Quantity(np.squeeze(slope), u.electron / u.s, dtype=slope.dtype),
         "sigslope": u.Quantity(
-            np.squeeze(sigslope), ru.electron / u.s, dtype=sigslope.dtype
+            np.squeeze(sigslope), u.electron / u.s, dtype=sigslope.dtype
         ),
         "var_poisson": u.Quantity(
-            np.squeeze(var_poisson),
-            ru.electron**2 / u.s**2,
-            dtype=var_poisson.dtype,
+            np.squeeze(var_poisson), u.electron**2 / u.s**2, dtype=var_poisson.dtype
         ),
         "var_rnoise": u.Quantity(
-            np.squeeze(var_rnoise), ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+            np.squeeze(var_rnoise), u.electron**2 / u.s**2, dtype=var_rnoise.dtype
         ),
-        "yint": u.Quantity(np.squeeze(yint), ru.electron, dtype=yint.dtype),
-        "sigyint": u.Quantity(np.squeeze(sigyint), ru.electron, dtype=sigyint.dtype),
-        "pedestal": u.Quantity(np.squeeze(pedestal), ru.electron, dtype=pedestal.dtype),
+        "yint": u.Quantity(np.squeeze(yint), u.electron, dtype=yint.dtype),
+        "sigyint": u.Quantity(np.squeeze(sigyint), u.electron, dtype=sigyint.dtype),
+        "pedestal": u.Quantity(np.squeeze(pedestal), u.electron, dtype=pedestal.dtype),
         "weights": np.squeeze(weights),
-        "crmag": u.Quantity(crmag, ru.electron, dtype=pedestal.dtype),
+        "crmag": u.Quantity(crmag, u.electron, dtype=pedestal.dtype),
     }
 
     out_node = rds.RampFitOutput(inst)
@@ -100,14 +97,14 @@ def create_image_model(input_model, image_info):
     """
     data, dq, var_poisson, var_rnoise, err = image_info
 
-    data = u.Quantity(data, ru.electron / u.s, dtype=data.dtype)
+    data = u.Quantity(data, u.electron / u.s, dtype=data.dtype)
     var_poisson = u.Quantity(
-        var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype
+        var_poisson, u.electron**2 / u.s**2, dtype=var_poisson.dtype
     )
     var_rnoise = u.Quantity(
-        var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+        var_rnoise, u.electron**2 / u.s**2, dtype=var_rnoise.dtype
     )
-    err = u.Quantity(err, ru.electron / u.s, dtype=err.dtype)
+    err = u.Quantity(err, u.electron / u.s, dtype=err.dtype)
 
     # Create output datamodel
     # ... and add all keys from input
@@ -117,15 +114,15 @@ def create_image_model(input_model, image_info):
     meta["photometry"] = maker_utils.mk_photometry()
     inst = {
         "meta": meta,
-        "data": u.Quantity(data, ru.electron / u.s, dtype=data.dtype),
+        "data": u.Quantity(data, u.electron / u.s, dtype=data.dtype),
         "dq": dq,
         "var_poisson": u.Quantity(
-            var_poisson, ru.electron**2 / u.s**2, dtype=var_poisson.dtype
+            var_poisson, u.electron**2 / u.s**2, dtype=var_poisson.dtype
         ),
         "var_rnoise": u.Quantity(
-            var_rnoise, ru.electron**2 / u.s**2, dtype=var_rnoise.dtype
+            var_rnoise, u.electron**2 / u.s**2, dtype=var_rnoise.dtype
         ),
-        "err": u.Quantity(err, ru.electron / u.s, dtype=err.dtype),
+        "err": u.Quantity(err, u.electron / u.s, dtype=err.dtype),
         "amp33": input_model.amp33,
         "border_ref_pix_left": input_model.border_ref_pix_left,
         "border_ref_pix_right": input_model.border_ref_pix_right,

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -5,7 +5,6 @@ import pytest
 from astropy import units as u
 from astropy.time import Time
 from roman_datamodels import maker_utils
-from roman_datamodels import units as ru
 from roman_datamodels.datamodels import (
     GainRefModel,
     ImageModel,
@@ -31,19 +30,19 @@ dqflags = {
 
 def generate_ramp_model(shape, deltatime=1):
     data = u.Quantity(
-        (np.random.random(shape) * 0.5).astype(np.float32), ru.DN, dtype=np.float32
+        (np.random.random(shape) * 0.5).astype(np.float32), u.DN, dtype=np.float32
     )
     err = u.Quantity(
-        (np.random.random(shape) * 0.0001).astype(np.float32), ru.DN, dtype=np.float32
+        (np.random.random(shape) * 0.0001).astype(np.float32), u.DN, dtype=np.float32
     )
     pixdq = np.zeros(shape=shape[1:], dtype=np.uint32)
     gdq = np.zeros(shape=shape, dtype=np.uint8)
 
     dm_ramp = maker_utils.mk_ramp(shape)
-    dm_ramp.data = u.Quantity(data, ru.DN, dtype=np.float32)
+    dm_ramp.data = u.Quantity(data, u.DN, dtype=np.float32)
     dm_ramp.pixeldq = pixdq
     dm_ramp.groupdq = gdq
-    dm_ramp.err = u.Quantity(err, ru.DN, dtype=np.float32)
+    dm_ramp.err = u.Quantity(err, u.DN, dtype=np.float32)
 
     dm_ramp.meta.exposure.frame_time = deltatime
     dm_ramp.meta.exposure.ngroups = shape[0]
@@ -66,13 +65,13 @@ def generate_wfi_reffiles(shape, ingain=6):
 
     gain_ref["data"] = u.Quantity(
         (np.random.random(shape) * 0.5).astype(np.float32) * ingain,
-        ru.electron / ru.DN,
+        u.electron / u.DN,
         dtype=np.float32,
     )
     gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     gain_ref["err"] = u.Quantity(
         (np.random.random(shape) * 0.05).astype(np.float32),
-        ru.electron / ru.DN,
+        u.electron / u.DN,
         dtype=np.float32,
     )
 
@@ -89,7 +88,7 @@ def generate_wfi_reffiles(shape, ingain=6):
     rn_ref["meta"]["exposure"]["frame_time"] = 666
 
     rn_ref["data"] = u.Quantity(
-        (np.random.random(shape) * 0.01).astype(np.float32), ru.DN, dtype=np.float32
+        (np.random.random(shape) * 0.01).astype(np.float32), u.DN, dtype=np.float32
     )
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-482](https://jira.stsci.edu/browse/RCAL-482)

astropy/asdf-astropy#142 added native support for non-VOunit serialization for ASDF for any non-VOunits defined by `astropy`. All of the non-VOunits used by Roman are directly defined by `astropy`; however, previous to this new support by `asdf-astropy` they had to be wrapped in `roman_datamodels` in order to enable ASDF support for their use, see spacetelescope/roman_datamodels#109.

With the original changes in spacetelescope/roman_datamodels#109, this required changes to `romancal` in order to add the correct non-VOunits derived from `roman_datamodels.units` instead of `astropy.units`. Now with the changes introduced by:

- spacetelescope/rad#220
- spacetelescope/roman_datamodels#131

`astropy.units` non-VOunits can be used without issue in `romancal` and spacetelescope/roman_datamodels#131 introduces a deprecation of `roman_datamodels.units`.

This PR switches all the uses of `roman_datamodels.units` to purely `astropy.units` to avoid the deprecation, and demonstrate that Roman non-longer needs custom ASDF support for non-VOunits.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
