### PR TITLE
RCAL-481: Remove use of pytest-openfiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ general
 
 - update minimum version of ``asdf`` to ``2.14.2`` and ``jsonschema`` to ``4.0.1`` and added minimum dependency checks to CI [#664]
 
+- Remove use of ``pytest-openfiles`` [#666]
+
 source_detection
 ----------------
 - Added SourceDetection Step to pipeline [#608]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ norecursedirs = [
     '.eggs',
     'build',
 ]
+filterwarnings = [
+    "error::ResourceWarning",
+]
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false
 asdf_schema_root = 'romancal/datamodels/schemas'
@@ -121,7 +124,7 @@ results_root = 'roman-pipeline-results'
 doctest_plus = 'enabled'
 doctest_rst = 'enabled'
 text_file_format = 'rst'
-addopts = '--show-capture=no --open-files --doctest-ignore-import-errors'
+addopts = '--show-capture=no --doctest-ignore-import-errors'
 markers = [
     'soctests: run only the SOC tests in the suite.',
 ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-481](https://jira.stsci.edu/browse/RCAL-481)

<!-- describe the changes comprising this PR here -->
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed. 

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
