### PR TITLE
add seed for random noise/gaussian generation in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ general
 source_detection
 ----------------
 - Added SourceDetection Step to pipeline [#608]
+- Added option of fixed random seed for unit tests to avoid intermittent failures from randomness. [#668]
 
 
 0.10.0 (2023-02-21)

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -16,7 +16,7 @@ from romancal.source_detection import SourceDetectionStep
 
 @pytest.fixture
 def setup_inputs():
-    def _setup(nrows=100, ncols=100, noise=1.0):
+    def _setup(nrows=100, ncols=100, noise=1.0, seed=None):
 
         """Return ImageModel of lvl 2 image"""
 
@@ -29,6 +29,8 @@ def setup_inputs():
 
         # add noise to data
         if noise is not None:
+            if seed is not None:
+                np.random.seed(seed)
             wfi_image.data += u.Quantity(
                 noise * np.random.random(shape), u.electron / u.s, dtype=np.float32
             )
@@ -44,40 +46,30 @@ def setup_inputs():
     return _setup
 
 
-# @pytest.mark.skipif(
-#     os.environ.get("CI") == "true",
-#     reason="Roman CRDS servers are not currently available outside the internal "
-#     "network",
-# )
-def add_random_gauss(arr, x_positions, y_positions, min_amp=200, max_amp=500):
+def add_random_gauss(arr, x_positions, y_positions, min_amp=200, max_amp=500, seed=None):
 
     """Add random 2D Gaussians to `arr` at specified positions,
     with random amplitudes from `min_amp` to  `max_amp`. Assumes
     units of e-/s."""
 
-    # choosing a random seed for now, total randomness was causing issues
-    np.random.seed(0)
+    if seed is not None:
+        np.random.seed(seed)
 
     for i, x in enumerate(x_positions):
         y = y_positions[i]
         gauss = Gaussian2DKernel(2, x_size=21, y_size=21).array
         amp = np.random.randint(200, 700)
-        arr[y - 10 : y + 11, x - 10 : x + 11] += (
+        arr[y - 10: y + 11, x - 10: x + 11] += (
             u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amp
         )
 
 
-# @pytest.mark.skipif(
-#     os.environ.get("CI") == "true",
-#     reason="Roman CRDS servers are not currently available outside the internal "
-#     "network",
-# )
 def test_source_detection_defaults(setup_inputs):
 
     """Test SourceDetectionStep with its default parameters. The detection
     threshold will be chosen based on the image's background level."""
 
-    model = setup_inputs()
+    model = setup_inputs(seed=0)
 
     # add in 12 sources, roughly evenly distributed
     # sort by true_x so they can be matched up to output
@@ -87,7 +79,7 @@ def test_source_detection_defaults(setup_inputs):
 
     # at each position, place a 2d gaussian
     # randomly vary flux from 100 to 500 for each source
-    add_random_gauss(model.data, true_x, true_y)
+    add_random_gauss(model.data, true_x, true_y, seed=0)
 
     # call SourceDetectionStep with default parameters
     sd = SourceDetectionStep()
@@ -111,17 +103,12 @@ def test_source_detection_defaults(setup_inputs):
     assert np.allclose(np.abs(ycentroid - true_y), 0.0, atol=0.25)
 
 
-# @pytest.mark.skipif(
-#     os.environ.get("CI") == "true",
-#     reason="Roman CRDS servers are not currently available outside the internal "
-#     "network",
-# )
 def test_source_detection_scalar_threshold(setup_inputs):
 
     """Test SourceDetectionStep using the option to choose a detection
     threshold for entire image."""
 
-    model = setup_inputs()
+    model = setup_inputs(seed=0)
 
     # add in 12 sources, roughly evenly distributed
     # sort by true_x so they can be matched up to output
@@ -131,7 +118,7 @@ def test_source_detection_scalar_threshold(setup_inputs):
 
     # at each position, place a 2d gaussian
     # randomly vary flux from 100 to 500 for each source
-    add_random_gauss(model.data, true_x, true_y)
+    add_random_gauss(model.data, true_x, true_y, seed=0)
 
     # call SourceDetectionStep with default parameters
     sd = SourceDetectionStep()
@@ -188,10 +175,10 @@ def test_outputs(tmp_path, setup_inputs):
         context = ctx()
 
     with context:
-        model = setup_inputs()
+        model = setup_inputs(seed=0)
 
         # add a single source to image so a non-empty catalog is produced
-        add_random_gauss(model.data, [50], [50])
+        add_random_gauss(model.data, [50], [50], seed=0)
 
         # run step and direct it to save catalog. default format should be asdf
         sd = SourceDetectionStep()
@@ -210,24 +197,19 @@ def test_outputs(tmp_path, setup_inputs):
         assert os.path.isfile(expected_output_path)
 
 
-# @pytest.mark.skipif(
-#     os.environ.get("CI") == "true",
-#     reason="Roman CRDS servers are not currently available outside the internal "
-#     "network",
-# )
 def test_limiting_catalog_size(setup_inputs):
 
     """Test to make sure setting `max_sources` limits the size of the
     output catalog to contain only the N brightest sources"""
 
-    model = setup_inputs()
+    model = setup_inputs(seed=0)
 
     amps = [200, 300, 400]  # flux
     pos = [20, 50, 80]  # 3 sources in a line
     for i in range(3):
         xy = pos[i]
         gauss = Gaussian2DKernel(2, x_size=20, y_size=20).array
-        model.data[xy - 10 : xy + 10, xy - 10 : xy + 10] += (
+        model.data[xy - 10: xy + 10, xy - 10: xy + 10] += (
             u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amps[i]
         )
 

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -46,7 +46,9 @@ def setup_inputs():
     return _setup
 
 
-def add_random_gauss(arr, x_positions, y_positions, min_amp=200, max_amp=500, seed=None):
+def add_random_gauss(
+    arr, x_positions, y_positions, min_amp=200, max_amp=500, seed=None
+):
 
     """Add random 2D Gaussians to `arr` at specified positions,
     with random amplitudes from `min_amp` to  `max_amp`. Assumes
@@ -59,7 +61,7 @@ def add_random_gauss(arr, x_positions, y_positions, min_amp=200, max_amp=500, se
         y = y_positions[i]
         gauss = Gaussian2DKernel(2, x_size=21, y_size=21).array
         amp = np.random.randint(200, 700)
-        arr[y - 10: y + 11, x - 10: x + 11] += (
+        arr[y - 10 : y + 11, x - 10 : x + 11] += (
             u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amp
         )
 
@@ -209,7 +211,7 @@ def test_limiting_catalog_size(setup_inputs):
     for i in range(3):
         xy = pos[i]
         gauss = Gaussian2DKernel(2, x_size=20, y_size=20).array
-        model.data[xy - 10: xy + 10, xy - 10: xy + 10] += (
+        model.data[xy - 10 : xy + 10, xy - 10 : xy + 10] += (
             u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amps[i]
         )
 


### PR DESCRIPTION
Closes https://github.com/spacetelescope/romancal/issues/667

Randomness in tests for source detection was causing them to intermittently fail. Tests now use np.random.seed(0) by default, and have an option to change or not use this seed. 


**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
