### PR TITLE
RCAL-490

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ general
 
 - Remove the ``codecov`` dependency [#677]
 
+- Remove explicit dependence on ``stdatamodels``. [#676]
+
 source_detection
 ----------------
 - Added SourceDetection Step to pipeline [#608]

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -4,20 +4,6 @@ import os
 import tempfile
 
 import pytest
-from stdatamodels import s3_utils
-
-# from jwst.associations import (AssociationRegistry, AssociationPool)
-# from jwst.associations.tests.helpers import t_path
-from romancal.lib.tests import helpers as lib_helpers
-
-# @pytest.fixture(scope='session')
-# def full_pool_rules(request):
-#     """Setup to use the full example pool and registry"""
-#     pool_fname = t_path('data/mega_pool.csv')
-#     pool = AssociationPool.read(pool_fname)
-#     rules = AssociationRegistry()
-#
-#     return (pool, rules, pool_fname)
 
 
 @pytest.fixture
@@ -33,21 +19,6 @@ def mk_tmp_dirs():
         yield (tmp_current_path, tmp_data_path, tmp_config_path)
     finally:
         os.chdir(old_path)
-
-
-@pytest.fixture(autouse=True)
-def monkey_patch_s3_client(monkeypatch, request):
-    # If tmpdir is used in the test, then it is providing the file.  Map to it.
-    if "s3_root_dir" in request.fixturenames:
-        path = request.getfixturevalue("s3_root_dir")
-    else:
-        path = None
-    monkeypatch.setattr(s3_utils, "_CLIENT", lib_helpers.MockS3Client(path))
-
-
-@pytest.fixture
-def s3_root_dir(tmpdir):
-    return tmpdir
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-490](https://jira.stsci.edu/browse/RCAL-490)

<!-- describe the changes comprising this PR here -->
Together with spacetelescope/stpipe#91, this PR will remove the `romancal` dependency on `stdatamodels`.

This is a result of the use of the `stdatamodels.s3_utils` in both `stpipe` and here in `romancal`. However, the `romancal` usage of `s3_utils` is entirely the result of copying test fixtures from `jwst` to `romancal` during its setup, and there is actual usage of these fixtures by `romancal`. The `stpipe` usage of `s3_utils` can be eliminated as `s3_utils` is unused by `jwst` and `romancal`. @eslavich can provide further details.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
