### PR TITLE
Remove `codecov` test dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ general
 
 - Remove use of ``pytest-openfiles`` [#666]
 
+- Remove the ``codecov`` dependency [#677]
+
 source_detection
 ----------------
 - Added SourceDetection Step to pipeline [#608]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -95,6 +95,8 @@ bc0.test_cmds = [
     --ddtrace \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
+    "curl -Os https://uploader.codecov.io/latest/linux/codecov",
+    "chmod +x codecov",
     'codecov --token=${codecov_token} -F nightly',
 ]
 bc0.test_configs = [data_config]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,8 @@ lint = [
 ]
 test = [
     'ci-watson >=0.5.0',
-    'codecov >=1.6.0',
     'pytest >=4.6.0',
     'pytest-astropy',
-    'codecov >=1.6.0',
 ]
 aws = [
     'stsci-aws-utils >=0.1.2',


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
The `codecov-python` (`codecov` dependency) uploader has been deprecated for some time and now it has been yanked from PyPi. This means installing `romancal` with the `test` dependencies will no-longer succeed. The `codecov` dependency was only used by the regression tests to upload coverage of the regression tests, this has been replaced by the new non-python-based `codecov-uploader` in just the regression test jobs.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
