### PR TITLE
SCSB-63 inject dependency overrides after build

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -89,7 +89,7 @@ bc0.build_cmds = [
     "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
-bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
+bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.test_cmds = [
     "pytest --cov-report=xml --cov=./ -r sxf -n auto --bigdata --slow \
     --ddtrace \
@@ -109,7 +109,7 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-stable-deps'
 bc1.build_cmds = ["pip install -e ."]
-bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
+bc1.build_cmds = bc1.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc1.test_cmds = []
 bc1.test_configs = []
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -87,7 +87,7 @@ bc0.build_cmds = [
     "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
-bc0.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc0.build_cmds
+bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.test_cmds = [
     "pytest -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
@@ -103,7 +103,7 @@ bc1 = utils.copy(bc0)
 bc1.nodetype = 'macos'
 bc1.name = 'macos-unstable-deps'
 bc1.build_cmds = ["pip install -e ."]
-bc1.build_cmds = PipInject(env.OVERRIDE_REQUIREMENTS) + bc1.build_cmds
+bc1.build_cmds = bc1.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc1.test_cmds = []
 bc1.test_configs = []
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-63](https://jira.stsci.edu/browse/SCSB-63)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where override requirements were overridden themselves during the Jenkins regression test build.

Related to https://github.com/spacetelescope/jwst/pull/7553

**Checklist**
- [N/A] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [ ] ~updated relevant tests~
- [ ] ~updated relevant documentation~
- [ ] ~updated relevant milestone(s)~
- [x] added relevant label(s)
