### PR TITLE
fix output catalog attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,9 +19,12 @@ general
 source_detection
 ----------------
 - Added SourceDetection Step to pipeline [#608]
+
 - Added option of fixed random seed for unit tests to avoid intermittent failures from randomness. [#668]
 
 - Fix source detection object instantiation. [#669]
+
+- Small bug fix to ensure that output catalogs are not attached to the file when save_catalogs=False [#684]
 
 
 0.10.0 (2023-02-21)

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -175,10 +175,10 @@ class SourceDetectionStep(RomanStep):
                 input_model.meta.source_detection[
                     "tweakreg_catalog_name"
                 ] = cat_filename
-
-            # only attach catalog to file if its being passed to the next step
-            # and save_catalogs is false, since it is not in the schema
-            input_model.meta.source_detection["tweakreg_catalog"] = catalog_as_array
+            else:
+                # only attach catalog to file if its being passed to the next step
+                # and save_catalogs is false, since it is not in the schema
+                input_model.meta.source_detection["tweakreg_catalog"] = catalog_as_array
 
             # just pass input model to next step - catalog is stored in meta
             return input_model


### PR DESCRIPTION
Small fix to ensure that a catalog is only attached to the output model if save_catalogs=False.
