### PR TITLE
override package dependencies with requirements file when requested

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,12 +57,12 @@ extras =
     alldeps: all
 deps =
     xdist: pytest-xdist
-    devdeps: -rrequirements-dev.txt
     ddtrace: ddtrace
     oldestdeps: minimum_dependencies
 commands_pre =
     oldestdeps: minimum_dependencies romancal --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
+    devdeps: pip install -r requirements-dev.txt
     pip freeze
 commands =
     pytest \


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-66](https://jira.stsci.edu/browse/SCSB-66)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Currently, `tox` installs the `requirements-dev.txt` *before* installing the package with `pip install .`; this could result in the possible edge case where package dependencies override the requirements file, where the opposite should be the case, as seen in https://github.com/spacetelescope/jwst/pull/7557

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
