### PR TITLE
enable step summary for pytest results

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -69,16 +69,24 @@ jobs:
       envs: |
         - linux: test-oldestdeps-cov-xdist
           python-version: 3.8
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.8
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - linux: test-xdist-ddtrace
           python-version: 3.11
+          pytest-results-summary: true
         - macos: test-xdist-ddtrace
           python-version: 3.11
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
+          pytest-results-summary: true
         - linux: test-cov-xdist
           coverage: codecov
+          pytest-results-summary: true

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -46,22 +46,33 @@ jobs:
       envs: |
         - macos: test-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - macos: test-sdpdeps-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - macos: test-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - linux: test-pyargs-xdist
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
           python-version: 3.8
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
           python-version: 3.8
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
           python-version: 3.9
+          pytest-results-summary: true
         - linux: test-devdeps-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - macos: test-devdeps-xdist
           python-version: 3.10
+          pytest-results-summary: true
         - macos: test-devdeps-xdist
           python-version: 3.11
+          pytest-results-summary: true


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR uses the new `pytest-results-summary` keyword in the OpenAstronomy reusable workflow to display test summaries on the job page:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/16024299/235205377-1ea102cc-6f92-4fa9-a53c-5be381ebe2d3.png">

If tests fail, the [`test-summary` action](https://github.com/marketplace/actions/testforest-dashboard) will create a Markdown table of failures:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/16024299/235216379-ea1cf023-7f7e-4162-8f24-ab7202363a54.png">

**Checklist**
- [N/A] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [N/A] ~updated relevant documentation~
- [N/A] ~updated relevant milestone(s)~
- [x] added relevant label(s)
