### PR TITLE
Upgrade romancal python to python-3.11, update crds context

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0040.pmap",
+    "CRDS_CONTEXT=roman_0043.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
     'DD_ENV=ci',

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -43,7 +43,7 @@ jobconfig.publish_env_on_success_only = true
 jobconfig.publish_env_filter = "spacetelescope/main"
 
 // Define python version for conda
-python_version = "3.9"
+python_version = "3.11"
 
 // pip related setup
 def pip_index = "https://bytesalad.stsci.edu/artifactory/api/pypi/datb-pypi-virtual/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
     'sphinx-automodapi',
     'sphinx-rtd-theme',
     'stsci-rtd-theme',
-    'tomli; python_version <"3.11"',
+    'tomli; python_version <="3.11"',
 ]
 lint = [
     'pyproject-flake8',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     #'roman_datamodels >=0.14.1',
     'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git@main',
     'stcal >=1.3.3',
-    'stpipe >=0.4.2',
+    'stpipe >=0.5.0',
     'tweakwcs >=0.8.0',
 ]
 dynamic = ['version']

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -198,7 +198,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
     # DMS-136 PSF tests
     pipeline.log.info(
-        "DMS8136MSG: Testing existence of  detector and "
+        "DMS-136 MSG: Testing existence of  detector and "
         "optical element (detector & optical_element) in Level 2 "
         "image output......." + passfail("exposure_time" in model.meta.exposure)
     )
@@ -285,7 +285,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         + str(model.meta.cal_step.assign_wcs)
     )
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of wcs assignment inLevel 2 spectroscopic"
+        "DMS90 MSG: Testing completion of wcs assignment in Level 2 spectroscopic"
         " output......." + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
     )
     assert model.meta.cal_step.assign_wcs == "COMPLETE"
@@ -294,7 +294,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         + str(model.meta.cal_step.flat_field)
     )
     pipeline.log.info(
-        "DMS90 MSG: Testing expected skip of flat fielding inLevel 2 spectroscopic"
+        "DMS90 MSG: Testing expected skip of flat fielding in Level 2 spectroscopic"
         " output......." + passfail(model.meta.cal_step.flat_field == "SKIPPED")
     )
     assert model.meta.cal_step.flat_field == "SKIPPED"
@@ -302,7 +302,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         "Status of the step:             dark          " + str(model.meta.cal_step.dark)
     )
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of dark correction inLevel 2 spectroscopic"
+        "DMS90 MSG: Testing completion of dark correction in Level 2 spectroscopic"
         " output......." + passfail(model.meta.cal_step.dark == "COMPLETE")
     )
     assert model.meta.cal_step.dark == "COMPLETE"
@@ -320,7 +320,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         "Status of the step:             jump          " + str(model.meta.cal_step.jump)
     )
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of jump detection inLevel 2 spectroscopic"
+        "DMS90 MSG: Testing completion of jump detection in Level 2 spectroscopic"
         " output......." + passfail(model.meta.cal_step.jump == "COMPLETE")
     )
     assert model.meta.cal_step.jump == "COMPLETE"
@@ -338,7 +338,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         + str(model.meta.cal_step.ramp_fit)
     )
     pipeline.log.info(
-        "DMS90 MSG: Testing completion of ramp fitting inLevel 2 spectroscopic"
+        "DMS90 MSG: Testing completion of ramp fitting in Level 2 spectroscopic"
         " output......." + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
     )
     assert model.meta.cal_step.ramp_fit == "COMPLETE"

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -33,7 +33,6 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.source_detection.skip=True",
         "roman_elp",
         rtdata.input,
     ]
@@ -266,7 +265,6 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.source_detection.skip=True",
         "roman_elp",
         rtdata.input,
     ]

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -33,9 +33,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.jump.rejection_threshold=180.0",
-        "--steps.jump.three_group_rejection_threshold=185.0",
-        "--steps.jump.four_group_rejection_threshold=190",
+        "--steps.source_detection.skip=True",
         "roman_elp",
         rtdata.input,
     ]
@@ -268,9 +266,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.jump.rejection_threshold=180.0",
-        "--steps.jump.three_group_rejection_threshold=185.0",
-        "--steps.jump.four_group_rejection_threshold=190",
+        "--steps.source_detection.skip=True",
         "roman_elp",
         rtdata.input,
     ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #692 

<!-- describe the changes comprising this PR here -->
This PR upgrades python to 3.11, updates the CRDS context to 0043, and fixes some spelling and message syntax issues. 

The regression tests can be found at https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/902/

for the unit tests
python --version
Python 3.11.0
= 363 passed, 22 skipped, 6 warnings in 135.82s

```
pytest ~/src/Roman/romancal/romancal/
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, hypothesis-6.75.1, asdf-2.15.0, mock-3.10.0, filter-subpackage-0.1.2, astropy-header-0.2.2, doctestplus-0.12.1, astropy-0.10.0, cov-4.0.0, ci-watson-0.6.1, openfiles-0.5.0, arraydiff-0.5.0
collected 385 items

../../../romancal/romancal/assign_wcs/tests/test_wcs.py ....                                                                                        [  1%]
../../../romancal/romancal/associations/registry.py .                                                                                               [  1%]
../../../romancal/romancal/associations/lib/constraint.py ..                                                                                        [  1%]
../../../romancal/romancal/associations/lib/tests/test_asn_from_list_lib.py .....                                                                   [  3%]
../../../romancal/romancal/associations/tests/test_asn_from_list.py ............                                                                    [  6%]
../../../romancal/romancal/associations/tests/test_constraints.py ..........................                                                        [ 12%]
../../../romancal/romancal/associations/tests/test_generate.py ..                                                                                   [ 13%]
../../../romancal/romancal/associations/tests/test_level2_basics.py .                                                                               [ 13%]
../../../romancal/romancal/associations/tests/test_level2_candidates.py .....                                                                       [ 15%]
../../../romancal/romancal/associations/tests/test_pool.py .                                                                                        [ 15%]
../../../romancal/romancal/associations/tests/test_registry.py s.....                                                                               [ 16%]
../../../romancal/romancal/associations/tests/test_update_path.py ..                                                                                [ 17%]
../../../romancal/romancal/associations/tests/test_version.py .                                                                                     [ 17%]
../../../romancal/romancal/dark_current/tests/test_dark.py ...                                                                                      [ 18%]
../../../romancal/romancal/dq_init/tests/test_dq_init.py ......                                                                                     [ 20%]
../../../romancal/romancal/flatfield/tests/test_flatfield.py ....                                                                                   [ 21%]
../../../romancal/romancal/jump/tests/test_jump_step.py ..............                                                                              [ 24%]
../../../romancal/romancal/lib/basic_utils.py .                                                                                                     [ 24%]
../../../romancal/romancal/lib/tests/test_basic_utils.py ....                                                                                       [ 25%]
../../../romancal/romancal/lib/tests/test_suffix.py .................................................................                               [ 42%]
../../../romancal/romancal/photom/tests/test_photom.py .....                                                                                        [ 44%]
../../../romancal/romancal/ramp_fitting/tests/test_ramp_fit.py .........                                                                            [ 46%]
../../../romancal/romancal/regtest/test_dark_current.py ssss                                                                                        [ 47%]
../../../romancal/romancal/regtest/test_jump_det.py s                                                                                               [ 47%]
../../../romancal/romancal/regtest/test_linearity.py ss                                                                                             [ 48%]
../../../romancal/romancal/regtest/test_ramp_fitting.py s                                                                                           [ 48%]
../../../romancal/romancal/regtest/test_wfi_dq_init.py ss                                                                                           [ 49%]
../../../romancal/romancal/regtest/test_wfi_flat_field.py sss                                                                                       [ 49%]
../../../romancal/romancal/regtest/test_wfi_photom.py s                                                                                             [ 50%]
../../../romancal/romancal/regtest/test_wfi_pipeline.py sss                                                                                         [ 50%]
../../../romancal/romancal/regtest/test_wfi_saturation.py ss                                                                                        [ 51%]
../../../romancal/romancal/saturation/tests/test_saturation.py ........                                                                             [ 53%]
../../../romancal/romancal/source_detection/tests/test_source_detection_step.py ....                                                                [ 54%]
../../../romancal/romancal/stpipe/tests/test_core.py ....ss.                                                                                        [ 56%]
../../../romancal/romancal/stpipe/tests/test_integration.py ..                                                                                      [ 56%]
../../../romancal/romancal/tests/test_import.py ............................................................................                        [ 76%]
../../../romancal/romancal/tweakreg/tests/test_astrometric_utils.py ....................................                                            [ 85%]
../../../romancal/romancal/tweakreg/tests/test_tweakreg.py ......................................................                                   [100%]

==================================================================== warnings summary =====================================================================
romancal/tweakreg/tests/test_astrometric_utils.py::test_create_astrometric_catalog_write_results_to_disk
romancal/tweakreg/tests/test_astrometric_utils.py::test_create_astrometric_catalog_write_results_to_disk
  /Users/ddavis/miniconda3/envs/rcal_python311/lib/python3.11/site-packages/astropy/io/ascii/ipac.py:539: AstropyUserWarning: Table metadata keyword(s) ['catalog', 'gaia_only'] were not written.  IPAC metadata must be in the form {{'keywords':{{'keyword': {{'value': value}} }}
    warn(

romancal/tweakreg/tests/test_tweakreg.py::test_tweakreg_use_custom_catalogs[ascii.mrt]
  /Users/ddavis/miniconda3/envs/rcal_python311/lib/python3.11/site-packages/astropy/utils/metadata.py:386: MergeConflictWarning: In merged column 'x' the 'description' attribute does not match ([341.18/1806.34] Description of x != [351.18/1816.34] Description of x).  Using [351.18/1816.34] Description of x for merged output
    warnings.warn(

romancal/tweakreg/tests/test_tweakreg.py::test_tweakreg_use_custom_catalogs[ascii.mrt]
  /Users/ddavis/miniconda3/envs/rcal_python311/lib/python3.11/site-packages/astropy/utils/metadata.py:386: MergeConflictWarning: In merged column 'x' the 'description' attribute does not match ([351.18/1816.34] Description of x != [361.18/1826.34] Description of x).  Using [361.18/1826.34] Description of x for merged output
    warnings.warn(

romancal/tweakreg/tests/test_tweakreg.py::test_tweakreg_use_custom_catalogs[ascii.mrt]
  /Users/ddavis/miniconda3/envs/rcal_python311/lib/python3.11/site-packages/astropy/utils/metadata.py:386: MergeConflictWarning: In merged column 'y' the 'description' attribute does not match ([29.08/1674.38] Description of y != [39.08/1684.38] Description of y).  Using [39.08/1684.38] Description of y for merged output
    warnings.warn(

romancal/tweakreg/tests/test_tweakreg.py::test_tweakreg_use_custom_catalogs[ascii.mrt]
  /Users/ddavis/miniconda3/envs/rcal_python311/lib/python3.11/site-packages/astropy/utils/metadata.py:386: MergeConflictWarning: In merged column 'y' the 'description' attribute does not match ([39.08/1684.38] Description of y != [49.08/1694.38] Description of y).  Using [49.08/1694.38] Description of y for merged output
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 363 passed, 22 skipped, 6 warnings in 135.82s
```


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
