### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -68,10 +68,7 @@ jobs:
       cache-key: crds-${{ needs.crds_context.outputs.pmap }}
       envs: |
         - linux: test-oldestdeps-cov-xdist
-          python-version: 3.8
-          pytest-results-summary: true
-        - linux: test-xdist
-          python-version: 3.8
+          python-version: 3.9
           pytest-results-summary: true
         - linux: test-xdist
           python-version: 3.9

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -44,30 +44,24 @@ jobs:
       cache-path: ${{ needs.crds.outputs.path }}
       cache-key: crds-${{ needs.crds.outputs.context }}
       envs: |
+        - linux: test-devdeps-xdist
+          python-version: 3.9
+          pytest-results-summary: true
         - macos: test-xdist
           python-version: 3.9
           pytest-results-summary: true
         - macos: test-sdpdeps-xdist
           python-version: 3.9
           pytest-results-summary: true
-        - macos: test-xdist
-          python-version: 3.10
-          pytest-results-summary: true
         - linux: test-pyargs-xdist
           pytest-results-summary: true
         - linux: test-devdeps-xdist
-          python-version: 3.8
-          pytest-results-summary: true
-        - linux: test-devdeps-xdist
-          python-version: 3.8
-          pytest-results-summary: true
-        - linux: test-devdeps-xdist
           python-version: 3.9
           pytest-results-summary: true
         - linux: test-devdeps-xdist
-          python-version: 3.9
+          python-version: 3.10
           pytest-results-summary: true
-        - linux: test-devdeps-xdist
+        - macos: test-xdist
           python-version: 3.10
           pytest-results-summary: true
         - macos: test-devdeps-xdist

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,9 +16,17 @@ formats:
   - htmlzip
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: mambaforge-4.10
+
+conda:
+  environment: docs/rtd_environment.yaml
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![STScI Logo](docs/_static/stsci_logo.png)
 
-**Roman requires Python 3.8 or above and a C compiler for dependencies.**
+**Roman requires Python 3.9 or above and a C compiler for dependencies.**
 
 **Linux and MacOS platforms are tested and supported. Windows is not currently supported.**
 

--- a/docs/roman/pipeline_installation.rst
+++ b/docs/roman/pipeline_installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 .. warning::
-    Roman requires Python 3.8 or above and a C compiler for dependencies.
+    Roman requires Python 3.9 or above and a C compiler for dependencies.
 
 .. warning::
     Linux and MacOS platforms are tested and supported. Windows is not currently supported.

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'romancal'
 description = 'Library for calibration of science observations from the Nancy Grace Roman Space Telescope'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 license = { file = 'LICENSE' }
 authors = [{ name = 'Roman calibration pipeline developers', email = 'help@stsci.edu' }]
 classifiers = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Numpy has dropped support for Python 3.8

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
