### PR TITLE
revert astropy prerelease wheel spec and use nightly Scipy wheel index

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 git+https://github.com/asdf-format/asdf
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas
-astropy>=0.0.dev0
+git+https://github.com/astropy/astropy
 git+https://github.com/astropy/asdf-astropy
 git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ pass_env =
     CODECOV_*
     DD_*
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 extras =
     test
     alldeps: all
@@ -65,7 +65,7 @@ deps =
 commands_pre =
     oldestdeps: minimum_dependencies romancal --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
-    devdeps: pip install -r requirements-dev.txt
+    devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
     sdpdeps: pip install -r requirements-sdp.txt
     pip freeze
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,8 @@ pass_env =
     TEST_BIGDATA
     CODECOV_*
     DD_*
+set_env =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 extras =
     test
     alldeps: all


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-69](https://jira.stsci.edu/browse/SCSB-69)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Partially reverts #695 

<!-- describe the changes comprising this PR here -->
This PR addresses @WilliamJamieson's comments in https://github.com/spacetelescope/romancal/pull/695#discussion_r1189078751; the change to the Astropy dev spec in #695 didn't actually accomplish anything, and `numpy` and `scipy` wheels are hosted at a different index URL

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
