### PR TITLE
Compatibility fix in tweakreg test for rdm#164

### DIFF
--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -376,8 +376,8 @@ def test_tweakreg_raises_error_on_invalid_input(input, error_type):
     with pytest.raises(Exception) as exec_info:
         TweakRegStep.call(input)
 
-    if not hasattr(error_type, '__len__'):
-        error_type = (error_type, )
+    if not hasattr(error_type, "__len__"):
+        error_type = (error_type,)
 
     assert type(exec_info.value) in error_type
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -367,7 +367,7 @@ def base_image():
     [
         (list(), ValueError),
         ([""], FileNotFoundError),
-        ("", TypeError),
+        ("", (ValueError, TypeError)),
         ([1, 2, 3], TypeError),
     ],
 )
@@ -376,7 +376,10 @@ def test_tweakreg_raises_error_on_invalid_input(input, error_type):
     with pytest.raises(Exception) as exec_info:
         TweakRegStep.call(input)
 
-    assert type(exec_info.value) == error_type
+    if not hasattr(error_type, '__len__'):
+        error_type = (error_type, )
+
+    assert type(exec_info.value) in error_type
 
 
 def test_tweakreg_raises_attributeerror_on_missing_tweakreg_catalog(base_image):


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
spacetelescope/roman_datamodels#164 generalizes the `ModelContainer` constructor, which causes a single test in tweakreg to fail because it expects a different error type when `TweakRegStep.call` is called with incorrect arguments. 

This PR changes the tweakreg test to check that the failure is one of two types – the first error is the expected error after spacetelescope/roman_datamodels#164 is merged, the second error is the old expected error. This test should pass whether the current rdm version is before or after spacetelescope/roman_datamodels#164 gets merged.


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
