### PR TITLE
RCAL-561: improve error-handling for TweakReg when fetching data from VO API service.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.10.1 (unreleased)
 ===================
 
+tweakreg
+--------
+- Added logic to handle cases where an absolute catalog cannot be created. [#698]
+
 associations
 ------------
 

--- a/romancal/tweakreg/astrometric_utils.py
+++ b/romancal/tweakreg/astrometric_utils.py
@@ -8,12 +8,6 @@ from astropy.coordinates import SkyCoord
 from ..assign_wcs import utils as wcsutil
 from ..resample import resample_utils
 
-# import logging
-
-# Define logging
-# log = logging.getLogger()
-# log.setLevel(logging.DEBUG)
-
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = "http://gsss.stsci.edu/webservices"
 

--- a/romancal/tweakreg/astrometric_utils.py
+++ b/romancal/tweakreg/astrometric_utils.py
@@ -230,7 +230,7 @@ def get_catalog(ra, dec, epoch=2016.0, sr=0.1, catalog="GAIADR3", timeout=TIMEOU
     if len(rstr) == 0:
         raise Exception(
             """VO catalog service returned no results.\n
-            Hint: maybe loosen the search parameters might help."""
+            Hint: maybe reviewing the search parameters might help."""
         )
 
     return table.Table.read(rstr, format="csv")

--- a/romancal/tweakreg/astrometric_utils.py
+++ b/romancal/tweakreg/astrometric_utils.py
@@ -217,15 +217,15 @@ def get_catalog(ra, dec, epoch=2016.0, sr=0.1, catalog="GAIADR3", timeout=TIMEOU
     service_url = f"{SERVICELOCATION}/{service_type}?{spec}"
     try:
         rawcat = requests.get(service_url, headers=headers, timeout=timeout)
-    except requests.exceptions.ConnectionError as e:
+    except requests.exceptions.ConnectionError:
         raise requests.exceptions.ConnectionError(
-            f"A Connection error occurred. Traceback: {e}"
+            "Could not connect to the VO API server. Try again later."
         )
-    except requests.exceptions.Timeout as e:
-        raise requests.exceptions.Timeout(f"The request timed out. Traceback: {e}")
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.Timeout:
+        raise requests.exceptions.Timeout("The request to the VO API server timed out.")
+    except requests.exceptions.RequestException:
         raise requests.exceptions.RequestException(
-            f"There was an unexpected error with the request. Traceback: {e}"
+            "There was an unexpected error with the request."
         )
     # convert from bytes to a String
     r_contents = rawcat.content.decode()
@@ -234,6 +234,9 @@ def get_catalog(ra, dec, epoch=2016.0, sr=0.1, catalog="GAIADR3", timeout=TIMEOU
     # CRITICAL to proper interpretation of CSV data
     del rstr[0]
     if len(rstr) == 0:
-        raise Exception("VO catalog service returned no results.")
+        raise Exception(
+            """VO catalog service returned no results.\n
+            Hint: maybe loosen the search parameters might help."""
+        )
 
     return table.Table.read(rstr, format="csv")

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -773,7 +773,7 @@ def test_tweakreg_raises_error_on_connection_error_to_the_vo_service(
 ):
     """
     Test that TweakReg raises an error when there is a connection error with
-    the VO API server.
+    the VO API server, which means that an absolute reference catalog cannot be created.
     """
 
     img = base_image(shift_1=1000, shift_2=1000)
@@ -781,8 +781,10 @@ def test_tweakreg_raises_error_on_connection_error_to_the_vo_service(
 
     step = TweakRegStep()
 
-    with pytest.raises(Exception) as exec_info:
-        monkeypatch.setattr("requests.get", MockConnectionError)
-        step.process([img])
+    monkeypatch.setattr("requests.get", MockConnectionError)
+    res = step.process([img])
 
-    assert type(exec_info.value) == requests.exceptions.ConnectionError
+    assert type(res) == rdm.ModelContainer
+    assert len(res) == 1
+    assert res[0].meta.cal_step.tweakreg.lower() == "skipped"
+    assert step.skip is True

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -399,7 +399,11 @@ class TweakRegStep(RomanStep):
                         "occurred while fetching data from the VO server. "
                         f"Returned error message: '{e}'"
                     )
-                    raise
+                    self.log.warning("Skipping 'TweakRegStep'...")
+                    self.skip = True
+                    for model in images:
+                        model.meta.cal_step.tweakreg = "SKIPPED"
+                    return images
 
             elif os.path.isfile(self.abs_refcat):
                 ref_cat = Table.read(self.abs_refcat)

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -389,9 +389,17 @@ class TweakRegStep(RomanStep):
             gaia_cat_name = self.abs_refcat.upper()
 
             if gaia_cat_name in SINGLE_GROUP_REFCAT:
-                ref_cat = amutils.create_astrometric_catalog(
-                    images, gaia_cat_name, output=output_name
-                )
+                try:
+                    ref_cat = amutils.create_astrometric_catalog(
+                        images, gaia_cat_name, output=output_name
+                    )
+                except Exception as e:
+                    self.log.warning(
+                        "TweakRegStep cannot proceed because of an error that "
+                        "occurred while fetching data from the VO server. "
+                        f"Returned error message: '{e}'"
+                    )
+                    raise
 
             elif os.path.isfile(self.abs_refcat):
                 ref_cat = Table.read(self.abs_refcat)

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -319,7 +319,7 @@ class TweakRegStep(RomanStep):
                     )
                     self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
                     for model in images:
-                        model.meta.cal_step.tweakreg = "SKIPPED"
+                        model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if not ALIGN_TO_ABS_REFCAT:
                         self.skip = True
                         return images
@@ -339,14 +339,14 @@ class TweakRegStep(RomanStep):
                     self.log.warning("Skipping 'TweakRegStep'...")
                     self.skip = True
                     for model in images:
-                        model.meta.cal_step.tweakreg = "SKIPPED"
+                        model.meta.cal_step["tweakreg"] = "SKIPPED"
                     return images
                 else:
                     raise e
 
             for imcat in imcats:
                 model = imcat.meta["image_model"]
-                if model.meta.cal_step.tweakreg == "SKIPPED":
+                if model.meta.cal_step["tweakreg"] == "SKIPPED":
                     continue
                 wcs = model.meta.wcs
                 twcs = imcat.wcs
@@ -359,7 +359,7 @@ class TweakRegStep(RomanStep):
                     )
 
                     for model in images:
-                        model.meta.cal_step.tweakreg = "SKIPPED"
+                        model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if ALIGN_TO_ABS_REFCAT:
                         self.log.warning("Skipping relative alignment (stage 1)...")
                     else:
@@ -402,7 +402,7 @@ class TweakRegStep(RomanStep):
                     self.log.warning("Skipping 'TweakRegStep'...")
                     self.skip = True
                     for model in images:
-                        model.meta.cal_step.tweakreg = "SKIPPED"
+                        model.meta.cal_step["tweakreg"] = "SKIPPED"
                     return images
 
             elif os.path.isfile(self.abs_refcat):


### PR DESCRIPTION
Resolves [RCAL-561](https://jira.stsci.edu/browse/RCAL-561)

This PR adds a `try-except` block in `TweakReg` to handle errors when fetching data through `astrometric_utils.get_catalog`, which now has three additional exception catches (all subclasses of `requests.exceptions.RequestException`):
- `ConnectionError` (not able to connect to the VO API server);
- `TimeOut` (service timeout);
- `RequestException` (any other exception raised specifically by `requests`).

Each one has its own specific error message to help with debugging.

If `TweakRegStep` cannot create an absolute reference catalog (in cases where the VO API server is not available), then we'll do the default in situations where the step cannot proceed:
- print a warning message in the logs;
- set the class instance variable `skip` to `True`;
- set `meta.cal_step.tweakreg="SKIPPED"`;
- return a `ModelContainer` with all the datamodels updated.

Additional unit tests were added to check for connection and timeout errors.

Notes:
- `TweakReg` tests are all passing: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/183/testReport/romancal.tweakreg.tests/

- `romancal` regression tests are still the same as they were in the previous build (182) off of the `main` branch: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/183/

- Builds 191 through 206 are consistently showing no errors from `TweakReg`.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
