### PR TITLE
Fix returned result from SourceDetectionStep.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ general
 
 source_detection
 ----------------
+- Bug fix to ensure that the returned result is a copy of the input datamodel. [#700]
+
 - Added SourceDetection Step to pipeline [#608]
 
 - Added option of fixed random seed for unit tests to avoid intermittent failures from randomness. [#668]

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -181,8 +181,10 @@ class SourceDetectionStep(RomanStep):
 
             input_model.meta.cal_step["source_detection"] = "COMPLETE"
 
-            # just pass input model to next step - catalog is stored in meta
-            return input_model
+            output_model = input_model
+
+        # just pass input model to next step - catalog is stored in meta
+        return output_model
 
     def _calc_2D_background(self):
         """Calculates a 2D background image.


### PR DESCRIPTION
Resolves [RCAL-562](https://jira.stsci.edu/browse/RCAL-562)

<!-- describe the changes comprising this PR here -->
This PR addresses a fix to `SourceDetectionStep` to return an **open datamodel** object with all the changes made in the source detection step.

Regression test result:
- https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/188/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
