### PR TITLE
RCAL-567 Update unit tests to add tmpdir for test files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 tweakreg
 --------
+
+- Added tmpdir to the unit tests for test files [#702]
+
 - Added logic to handle cases where an absolute catalog cannot be created. [#698]
 
 associations

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -377,29 +377,29 @@ class Main:
         )
 
         self.parsed = parser.parse_args(args=args)
- 
+
     def save(self):
-        """Save the associations to disk.
-        """
+        """Save the associations to disk."""
         if self.parsed.dry_run:
             return
 
         for asn in self.associations:
             try:
                 (fname, serialized) = asn.dump(format=self.parsed.format)
-            except AssociationError as exception: # noqa: F821
-                logger.warning('Cannot serialize association %s', asn)
-                logger.warning('Reason:', exc_info=exception)
+            except AssociationError as exception:  # noqa: F821
+                logger.warning("Cannot serialize association %s", asn)
+                logger.warning("Reason:", exc_info=exception)
                 continue
-            with open(os.path.join(self.parsed.path, fname), 'w') as f:
+            with open(os.path.join(self.parsed.path, fname), "w") as f:
                 f.write(serialized)
 
         if self.parsed.save_orphans:
             self.orphaned.write(
                 os.path.join(self.parsed.path, self.parsed.save_orphans),
-                format='ascii',
-                delimiter='|'
+                format="ascii",
+                delimiter="|",
             )
+
     def __str__(self):
         result = []
         result.append(

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -387,7 +387,7 @@ class Main:
         for asn in self.associations:
             try:
                 (fname, serialized) = asn.dump(format=self.parsed.format)
-            except AssociationError as exception:
+            except AssociationError as exception: # noqa: F821
                 logger.warning('Cannot serialize association %s', asn)
                 logger.warning('Reason:', exc_info=exception)
                 continue

--- a/romancal/associations/main.py
+++ b/romancal/associations/main.py
@@ -377,33 +377,29 @@ class Main:
         )
 
         self.parsed = parser.parse_args(args=args)
-
-    def save(self, path=".", format="json", save_orphans=False):
+ 
+    def save(self):
         """Save the associations to disk.
-
-        Parameters
-        ----------
-        path : str
-            The path to save the associations to.
-
-        format : str
-            The format of the associations
-
-        save_orphans : bool
-            If true, save the orphans to an astropy.table.Table
         """
+        if self.parsed.dry_run:
+            return
+
         for asn in self.associations:
-            (fname, serialized) = asn.dump(format=format)
-            with open(os.path.join(self.parsed.path, fname), "w") as f:
+            try:
+                (fname, serialized) = asn.dump(format=self.parsed.format)
+            except AssociationError as exception:
+                logger.warning('Cannot serialize association %s', asn)
+                logger.warning('Reason:', exc_info=exception)
+                continue
+            with open(os.path.join(self.parsed.path, fname), 'w') as f:
                 f.write(serialized)
 
-        if save_orphans:
+        if self.parsed.save_orphans:
             self.orphaned.write(
                 os.path.join(self.parsed.path, self.parsed.save_orphans),
-                format="ascii",
-                delimiter="|",
+                format='ascii',
+                delimiter='|'
             )
-
     def __str__(self):
         result = []
         result.append(

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -270,7 +270,9 @@ def base_image():
         ("GAIADR3", 15),
     ],
 )
-def test_create_astrometric_catalog_variable_num_sources(tmp_path, catalog, num_sources, request):
+def test_create_astrometric_catalog_variable_num_sources(
+    tmp_path, catalog, num_sources, request
+):
     """Test fetching data from supported catalogs with variable number of sources."""
     output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -270,12 +270,14 @@ def base_image():
         ("GAIADR3", 15),
     ],
 )
-def test_create_astrometric_catalog_variable_num_sources(catalog, num_sources, request):
+def test_create_astrometric_catalog_variable_num_sources(tmp_path, catalog, num_sources, request):
     """Test fetching data from supported catalogs with variable number of sources."""
+    output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
     res = create_astrometric_catalog(
         [img],
         catalog=catalog,
+        output=os.path.join(tmp_path, output_filename),
         num_sources=num_sources,
     )
 
@@ -334,8 +336,9 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
         ("GAIADR3", None),
     ],
 )
-def test_create_astrometric_catalog_using_epoch(catalog, epoch, request):
+def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, request):
     """Test fetching data from supported catalogs for a specific epoch."""
+    output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
 
     metadata_epoch = (
@@ -348,6 +351,7 @@ def test_create_astrometric_catalog_using_epoch(catalog, epoch, request):
     res = create_astrometric_catalog(
         [img],
         catalog=catalog,
+        output=os.path.join(tmp_path, output_filename),
         epoch=epoch,
     )
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-567](https://jira.stsci.edu/browse/rcal-567)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates unit tests to add tmpdir for test files. 
Unit tests
pytest /Users/ddavis/src/Roman/romancal/romancal/associations/tests/
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
...
============================================================== 55 passed, 1 skipped in 0.98s
ls *.json
ls: *.json: No such file or directory

pytest /Users/ddavis/src/Roman/romancal/romancal/tweakreg/tests/
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, hypothesis-6.75.1, asdf-2.15.0, mock-3.10.0, filter-subpackage-0.1.2, astropy-header-0.2.2, doctestplus-0.12.1, astropy-0.10.0, cov-4.0.0, ci-watson-0.6.1, openfiles-0.5.0, arraydiff-0.5.0
collected 94 items

../../../romancal/romancal/tweakreg/tests/test_astrometric_utils.py .......................................                                         [ 41%]
../../../romancal/romancal/tweakreg/tests/test_tweakreg.py .......................................................                                  [100%]
...
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 94 passed, 6 warnings in 73.33s (0:01:13) ========================================================
(rcal_python311) bash>ls ref_cat.escv
ls: ref_cat.escv: No such file or directory

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
