### PR TITLE
Update roman crds server to test so that the latest updates are used

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_SERVER_URL: https://roman-crds.stsci.edu
+      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
       CRDS_PATH: /tmp/crds_cache
     steps:
       - id: context

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       OBSERVATORY: roman
       CRDS_PATH: /tmp/crds_cache
-      CRDS_SERVER_URL: https://roman-crds.stsci.edu
+      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
     steps:
       - id: context
         run: >


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates the CRDS server from  https://roman-crds.stsci.edu/ to 
https://roman-crds-test.stsci.edu/  so that the latest context will be selected for testing. This is currently at roman_0047.pmap for the 23Q3_B10 release. 

**Checklist**
- [N/A] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
