### PR TITLE
Update the CI

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -67,23 +67,18 @@ jobs:
       cache-path: /tmp/crds_cache
       cache-key: crds-${{ needs.crds_context.outputs.pmap }}
       envs: |
-        - linux: test-oldestdeps-cov-xdist
-          python-version: 3.9
+        - linux: py39-oldestdeps-cov-xdist
           pytest-results-summary: true
-        - linux: test-xdist
-          python-version: 3.9
+        - linux: py39
           pytest-results-summary: true
-        - linux: test-xdist
-          python-version: 3.10
+        - linux: py310
           pytest-results-summary: true
-        - linux: test-xdist-ddtrace
-          python-version: 3.11
+        - linux: py311-ddtrace
           pytest-results-summary: true
-        - macos: test-xdist-ddtrace
-          python-version: 3.11
+        - macos: py311-ddtrace
           pytest-results-summary: true
-        - linux: test-devdeps-xdist
+        - linux: py311-devdeps-xdist
           pytest-results-summary: true
-        - linux: test-cov-xdist
+        - linux: py311-cov-xdist
           coverage: codecov
           pytest-results-summary: true


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses 2 issues:

1. I have begun to notice 143 errors with our CI. This is due to over use of action runner resources, which I believe is related to using too much memory. This memory issue is simply because `xdist` will be running multiple tests simultaneously which eats up too much memory under certain conditions.
2. The titles of the CI runs in GitHub are not very distinguishable. This PR updates them to make them more clear.

This PR is similar to spacetelescope/roman_datamodels#187.

Note the "required" CI in the branch protections will likely need to be updated after this PR is merged.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
