### PR TITLE
Add a `pip list` step after the overrides are injected

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -86,10 +86,12 @@ bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
     "pip install pytest-xdist pytest-sugar ddtrace",
-    "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
+bc0.build_cmds = bc0.build_cmds + [
+    "pip list"
+]
 bc0.test_cmds = [
     "pytest --cov-report=xml:coverage.xml --cov=./ -r sxf -n auto --bigdata --slow \
     --ddtrace \

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -84,10 +84,12 @@ bc0.pip_reqs_files = ['requirements-dev.txt']
 bc0.build_cmds = [
     "pip install -e .[test,ephem]",
     "pip install pytest-xdist pytest-sugar",
-    "pip freeze",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
+bc0.build_cmds = bc0.build_cmds + [
+    "pip list"
+]
 bc0.test_cmds = [
     "pytest -r sxf -n auto --bigdata --slow \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently the pip freeze happens after the initial dependency install, but before the OVERRIDE_REQUIREMENTS option is handled by Jenkins. This makes it difficult to see if Jenkins has successfully installed an overriden requirement for the test run. This PR adds an additional `pip list` (same as `pip freeze` just more nicely formatted as a table) after the OVERRIDE_REQUIREMENTS are applied so that one can check in the Jenkins job log to make sure overriden requirements have successfully installed.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
