### PR TITLE
Updates for maker_utils API changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ general
 
 - Move ``is_assocation`` from ``roman_datamodels`` to ``romancal``. [#719]
 
+- Update ``romancal`` to use altered API for ``maker_utils``. [#717]
+
 
 0.11.0 (2023-05-31)
 ===================

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -132,7 +132,7 @@ def create_ramp_and_dark(shape, instrument, exptype):
     """Helper function to create test ramp and dark models"""
 
     # Create test ramp model
-    ramp = maker_utils.mk_ramp(shape)
+    ramp = maker_utils.mk_ramp(shape=shape)
     ramp.meta.instrument.name = instrument
     ramp.meta.instrument.detector = "WFI01"
     ramp.meta.instrument.optical_element = "F158"
@@ -141,7 +141,7 @@ def create_ramp_and_dark(shape, instrument, exptype):
     ramp_model = RampModel(ramp)
 
     # Create dark model
-    darkref = maker_utils.mk_dark(shape)
+    darkref = maker_utils.mk_dark(shape=shape)
     darkref_model = DarkRefModel(darkref)
 
     return ramp_model, darkref_model

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -45,7 +45,7 @@ class DQInitStep(RomanStep):
         # Convert to RampModel if needed
         if not isinstance(input_model, RampModel):
             # Create base ramp node with dummy values (for validation)
-            input_ramp = maker_utils.mk_ramp(input_model.shape)
+            input_ramp = maker_utils.mk_ramp(shape=input_model.shape)
 
             # Copy input_model contents into RampModel
             for key in input_model.keys():

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -24,7 +24,7 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     csize = (ngroups, ysize, xsize)
 
     # create raw input data for step
-    dm_ramp = maker_utils.mk_ramp(csize)
+    dm_ramp = maker_utils.mk_ramp(shape=csize)
     dm_ramp.meta.instrument.name = instrument
 
     # create a MaskModel elements for the dq input mask
@@ -43,7 +43,7 @@ def test_dq_im(xstart, ystart, xsize, ysize, ngroups, instrument, exp_type):
     dq[400, 200] = 33  # Persistence + do not use
 
     # write mask model
-    ref_data = maker_utils.mk_mask(csize[1:])
+    ref_data = maker_utils.mk_mask(shape=csize[1:])
 
     # Copy in maskmodel elemnts
     ref_data["dq"] = dq
@@ -84,11 +84,11 @@ def test_groupdq():
     csize = (ngroups, ysize, xsize)
 
     # create raw input data for step
-    dm_ramp = maker_utils.mk_ramp(csize)
+    dm_ramp = maker_utils.mk_ramp(shape=csize)
     dm_ramp.meta.instrument.name = instrument
 
     # create a MaskModel elements for the dq input mask
-    ref_data = maker_utils.mk_mask(csize[1:])
+    ref_data = maker_utils.mk_mask(shape=csize[1:])
     ref_data["meta"]["instrument"]["name"] = instrument
 
     # run the correction step
@@ -115,11 +115,11 @@ def test_err():
     csize = (ngroups, ysize, xsize)
 
     # create raw input data for step
-    dm_ramp = maker_utils.mk_ramp((ngroups, ysize, xsize))
+    dm_ramp = maker_utils.mk_ramp(shape=(ngroups, ysize, xsize))
     dm_ramp.meta.instrument.name = instrument
 
     # create a MaskModel elements for the dq input mask
-    ref_data = maker_utils.mk_mask(csize[1:])
+    ref_data = maker_utils.mk_mask(shape=csize[1:])
     ref_data["meta"]["instrument"]["name"] = instrument
 
     # run correction step
@@ -147,7 +147,7 @@ def test_dq_add1_groupdq():
     csize = (ngroups, ysize, xsize)
 
     # create raw input data for step
-    dm_ramp = maker_utils.mk_ramp((ngroups, ysize, xsize))
+    dm_ramp = maker_utils.mk_ramp(shape=(ngroups, ysize, xsize))
     dm_ramp.meta.instrument.name = instrument
 
     # create a MaskModel elements for the dq input mask
@@ -158,7 +158,7 @@ def test_dq_add1_groupdq():
     dq[400, 500] = 3  # do_not_use and saturated pixel
 
     # write mask model
-    ref_data = maker_utils.mk_mask(csize[1:])
+    ref_data = maker_utils.mk_mask(shape=csize[1:])
     ref_data["meta"]["instrument"]["name"] = instrument
 
     # Copy in maskmodel elemnts
@@ -202,7 +202,7 @@ def test_dqinit_step_interface(instrument, exptype):
     shape = (2, 20, 20)
 
     # Create test science raw model
-    wfi_sci_raw = maker_utils.mk_level1_science_raw(shape)
+    wfi_sci_raw = maker_utils.mk_level1_science_raw(shape=shape)
     wfi_sci_raw.meta.instrument.name = instrument
     wfi_sci_raw.meta.instrument.detector = "WFI01"
     wfi_sci_raw.meta.instrument.optical_element = "F158"
@@ -216,10 +216,9 @@ def test_dqinit_step_interface(instrument, exptype):
 
     # Create mask model
     maskref = stnode.MaskRef()
-    meta = maker_utils.mk_ref_common()
+    meta = maker_utils.mk_ref_common("MASK")
     meta["instrument"]["optical_element"] = "F158"
     meta["instrument"]["detector"] = "WFI01"
-    meta["reftype"] = "MASK"
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
     maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
@@ -258,7 +257,7 @@ def test_dqinit_refpix(instrument, exptype):
     shape = (2, 20, 20)
 
     # Create test science raw model
-    wfi_sci_raw = maker_utils.mk_level1_science_raw(shape)
+    wfi_sci_raw = maker_utils.mk_level1_science_raw(shape=shape)
     wfi_sci_raw.meta.instrument.name = instrument
     wfi_sci_raw.meta.instrument.detector = "WFI01"
     wfi_sci_raw.meta.instrument.optical_element = "F158"
@@ -272,10 +271,9 @@ def test_dqinit_refpix(instrument, exptype):
 
     # Create mask model
     maskref = stnode.MaskRef()
-    meta = maker_utils.mk_ref_common()
+    meta = maker_utils.mk_ref_common("MASK")
     meta["instrument"]["optical_element"] = "F158"
     meta["instrument"]["detector"] = "WFI01"
-    meta["reftype"] = "MASK"
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
     maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -51,10 +51,9 @@ def test_flatfield_step_interface(instrument, exptype):
 
     wfi_image_model = ImageModel(wfi_image)
     flatref = stnode.FlatRef()
-    meta = maker_utils.mk_ref_common()
+    meta = maker_utils.mk_ref_common("FLAT")
     meta["instrument"]["optical_element"] = "F158"
     meta["instrument"]["detector"] = "WFI01"
-    meta["reftype"] = "FLAT"
     flatref["meta"] = meta
     flatref["data"] = np.ones(shape, dtype=np.float32)
     flatref["dq"] = np.zeros(shape, dtype=np.uint16)

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -37,11 +37,10 @@ def generate_wfi_reffiles(tmpdir_factory):
 
     # Create temporary gain reference file
     gain_ref = rds.GainRef()
-    meta = maker_utils.mk_ref_common()
+    meta = maker_utils.mk_ref_common("GAIN")
     meta["instrument"]["detector"] = "WFI01"
     meta["instrument"]["name"] = "WFI"
     meta["author"] = "John Doe"
-    meta["reftype"] = "GAIN"
     meta["pedigree"] = "DUMMY"
     meta["description"] = "DUMMY"
     meta["useafter"] = Time("2022-01-01T11:11:11.111")
@@ -62,11 +61,10 @@ def generate_wfi_reffiles(tmpdir_factory):
 
     # Create temporary readnoise reference file
     rn_ref = rds.ReadnoiseRef()
-    meta = maker_utils.mk_ref_common()
+    meta = maker_utils.mk_ref_common("READNOISE")
     meta["instrument"]["detector"] = "WFI01"
     meta["instrument"]["name"] = "WFI"
     meta["author"] = "John Doe"
-    meta["reftype"] = "READNOISE"
     meta["pedigree"] = "DUMMY"
     meta["description"] = "DUMMY"
     meta["useafter"] = Time("2022-01-01T11:11:11.111")
@@ -113,7 +111,7 @@ def setup_inputs():
         pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
 
         csize = (ngroups, nrows, ncols)
-        dm_ramp = rdm.RampModel(maker_utils.mk_ramp(csize))
+        dm_ramp = rdm.RampModel(maker_utils.mk_ramp(shape=csize))
 
         dm_ramp.meta.instrument.name = "WFI"
         dm_ramp.meta.instrument.optical_element = "F158"

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -38,7 +38,7 @@ def generate_ramp_model(shape, deltatime=1):
     pixdq = np.zeros(shape=shape[1:], dtype=np.uint32)
     gdq = np.zeros(shape=shape, dtype=np.uint8)
 
-    dm_ramp = maker_utils.mk_ramp(shape)
+    dm_ramp = maker_utils.mk_ramp(shape=shape)
     dm_ramp.data = u.Quantity(data, u.DN, dtype=np.float32)
     dm_ramp.pixeldq = pixdq
     dm_ramp.groupdq = gdq
@@ -56,7 +56,7 @@ def generate_ramp_model(shape, deltatime=1):
 
 def generate_wfi_reffiles(shape, ingain=6):
     # Create temporary gain reference file
-    gain_ref = maker_utils.mk_gain(shape)
+    gain_ref = maker_utils.mk_gain(shape=shape)
 
     gain_ref["meta"]["instrument"]["detector"] = "WFI01"
     gain_ref["meta"]["instrument"]["name"] = "WFI"
@@ -78,7 +78,7 @@ def generate_wfi_reffiles(shape, ingain=6):
     gain_ref_model = GainRefModel(gain_ref)
 
     # Create temporary readnoise reference file
-    rn_ref = maker_utils.mk_readnoise(shape)
+    rn_ref = maker_utils.mk_readnoise(shape=shape)
     rn_ref["meta"]["instrument"]["detector"] = "WFI01"
     rn_ref["meta"]["instrument"]["name"] = "WFI"
     rn_ref["meta"]["reftype"] = "READNOISE"


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates `romancal` so that it is compatible with spacetelescope/roman_datamodels#207. These updates are mostly due to the enforcement of keyword only arguments to the maker_utils. This change was done to unify the API across all the different maker_utils.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)

Regression tests do pass https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/231/
