### PR TITLE
Move `is_assocation` to `romancal`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ general
 
 - Add `ModelContainer` to `romancal.datamodels`. [#710]
 
+- Move ``is_assocation`` from ``roman_datamodels`` to ``romancal``. [#719]
+
 
 0.11.0 (2023-05-31)
 ===================

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -9,7 +9,8 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from roman_datamodels import datamodels as rdm
-from roman_datamodels.util import is_association
+
+from romancal.lib.basic_utils import is_association
 
 from ..associations import AssociationNotValidError, load_asn
 

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -1,6 +1,7 @@
 """General utility objects"""
 
 import numpy as np
+from roman_datamodels.datamodels import AssociationsModel
 
 from romancal.lib import dqflags
 
@@ -54,6 +55,13 @@ def is_fully_saturated(model):
         return True
 
     return False
+
+
+def is_association(asn_data):
+    """
+    Test if an object is an association by checking for required fields
+    """
+    return AssociationsModel.is_association(asn_data)
 
 
 class LoggingContext:

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -8,14 +8,14 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from roman_datamodels import datamodels as rdm
-from roman_datamodels.util import is_association
 from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
 from tweakwcs.matchutils import XYXYMatch
 
-from ..datamodels import ModelContainer
+from romancal.lib.basic_utils import is_association
 
 # LOCAL
+from ..datamodels import ModelContainer
 from ..stpipe import RomanStep
 from . import astrometric_utils as amutils
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
The [`is_association`](https://github.com/spacetelescope/roman_datamodels/blob/f6c990530f7ed24afbc4744f8dcdecd81c832b6e/src/roman_datamodels/util.py#L312-L319) function, while part of `roman_datamodels` is not used or tested anywhere in `roman_datamodels`. Indeed, it seems to be part of a module which partially duplicates parts of `romancal.lib`. Thus it makes sense to move this into `romancal` directly alongside all the functionality which has been duplicated.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
