### PR TITLE
Fix typo in S_REGION string.

### DIFF
--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -175,7 +175,7 @@ def add_s_region(model):
 
 
 def update_s_region_keyword(model, footprint):
-    s_region = "POLYGON IRCS " + " ".join([str(x) for x in footprint.ravel()]) + " "
+    s_region = "POLYGON ICRS " + " ".join([str(x) for x in footprint.ravel()]) + " "
     log.info(f"S_REGION VALUES: {s_region}")
     if "nan" in s_region:
         # do not update s_region if there are NaNs.

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -81,7 +81,7 @@ def test_wcs(tmpdir, distortion, step):
     s_region_list = l2_wcs.meta.wcsinfo.s_region.split()
     assert len(s_region_list) == 10
     assert s_region_list[0].lower() == "polygon"
-    assert s_region_list[1].lower() == "ircs"
+    assert s_region_list[1].lower() == "icrs"
 
     # check if BBOX is not None
     assert l2_wcs.meta.wcs.bounding_box is not None

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -46,7 +46,7 @@ def update_wcsinfo(input_dm):
     input_dm.meta.wcsinfo.dec_ref = 66.0
     input_dm.meta.wcsinfo.roll_ref = 60
     input_dm.meta.wcsinfo.s_region = (
-        "POLYGON IRCS "
+        "POLYGON ICRS "
         "269.3318903230621 65.56866666048172 "
         "269.32578768154605 65.69246311613287 "
         "269.02457173246125 65.69201346248587 "

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -88,7 +88,7 @@ def update_wcsinfo(input_dm):
     input_dm.meta.wcsinfo.dec_ref = 66.0
     input_dm.meta.wcsinfo.roll_ref = 60
     input_dm.meta.wcsinfo.s_region = (
-        "POLYGON IRCS "
+        "POLYGON ICRS "
         "269.3318903230621 65.56866666048172 "
         "269.32578768154605 65.69246311613287 "
         "269.02457173246125 65.69201346248587 "


### PR DESCRIPTION
This PR fixes a typo issue in the `S_REGION` string.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
