### PR TITLE
RCAL-432 Update info string to use the same syntax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ tweakreg
 
 documentation
 -------------
+- Update info strings in the pipeline to provide uniform syntax [#721]
+
 - Updated wording about ELP and HLP in the Associations documentation for RTD
 
 - Updated the primary branch referenced in CONTRIBUTING to be main

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -33,7 +33,7 @@ class AssignWcsStep(RomanStep):
                 log.info(f"reftype, {reftype}")
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
-            log.info("Using reference files: %s for assign_wcs",  reference_file_names)
+            log.info("Using reference files: %s for assign_wcs", reference_file_names)
             result = load_wcs(input_model, reference_file_names)
 
         if self.save_results:

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -33,7 +33,7 @@ class AssignWcsStep(RomanStep):
                 log.info(f"reftype, {reftype}")
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
-            log.debug(f"reference files used in assign_wcs: {reference_file_names}")
+            log.info("Using reference files: %s for assign_wcs",  reference_file_names)
             result = load_wcs(input_model, reference_file_names)
 
         if self.save_results:

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -28,7 +28,7 @@ class DarkCurrentStep(RomanStep):
         with rdd.open(input) as input_model:
             # Get the name of the dark reference file to use
             self.dark_name = self.get_reference_file(input_model, "dark")
-            self.log.info("Using DARK reference file %s", self.dark_name)
+            self.log.info("Using DARK reference file: %s", self.dark_name)
 
             # Open dark model
             dark_model = rdd.open(self.dark_name)

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -22,7 +22,7 @@ class FlatFieldStep(RomanStep):
 
         # Check for a valid reference file
         if reference_file_name == "N/A":
-            self.log.warning("No Flat reference file found")
+            self.log.warning("No FLAT reference file found")
             self.log.warning("Flat Field step will be skipped")
             reference_file_name = None
 

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -27,11 +27,11 @@ class LinearityStep(RomanStep):
         with rdm.open(input) as input_model:
             # Get the name of the linearity reference file to use
             self.lin_name = self.get_reference_file(input_model, "linearity")
-            self.log.info("Using Linearity reference file %s", self.lin_name)
+            self.log.info("Using LINEARITY reference file: %s", self.lin_name)
 
             # Check for a valid reference file
             if self.lin_name == "N/A":
-                self.log.warning("No Linearity reference file found")
+                self.log.warning("No LINEARITY reference file found")
                 self.log.warning("Linearity step will be skipped")
                 result = input_model.copy()
                 result.meta.cal_step["linearity"] = "SKIPPED"

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -21,7 +21,7 @@ class SaturationStep(RomanStep):
         with rdm.open(input) as input_model:
             # Get the name of the saturation reference file
             self.ref_name = self.get_reference_file(input_model, "saturation")
-            self.log.info("Using SATURATION reference file %s", self.ref_name)
+            self.log.info("Using SATURATION reference file: %s", self.ref_name)
 
             # Check for a valid reference file
             if self.ref_name == "N/A":


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-432](https://jira.stsci.edu/browse/RCAL-432)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses updates the info strings to use the same syntax:
```
35:2023-06-23 10:36:29,154 - stpipe.ExposurePipeline.saturation - INFO - Using SATURATION reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_saturation_0229.asdf
41:2023-06-23 10:36:31,921 - stpipe.ExposurePipeline.linearity - INFO - Using LINEARITY reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_linearity_0215.asdf
45:2023-06-23 10:36:44,510 - stpipe.ExposurePipeline.dark_current - INFO - Using DARK reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_dark_0549.asdf
52:2023-06-23 10:36:47,012 - stpipe.ExposurePipeline.jump - INFO - Using GAIN reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_gain_0205.asdf
53:2023-06-23 10:36:47,435 - stpipe.ExposurePipeline.jump - INFO - Using READNOISE reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_readnoise_0440.asdf
65:2023-06-23 10:37:10,943 - stpipe.ExposurePipeline.rampfit - INFO - Using READNOISE reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_readnoise_0440.asdf
66:2023-06-23 10:37:10,982 - stpipe.ExposurePipeline.rampfit - INFO - Using GAIN reference file: /Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_gain_0205.asdf
75:2023-06-23 10:38:39,224 - stpipe.ExposurePipeline.assign_wcs - INFO - Using reference files: {'distortion': '/Users/ddavis/crds_cache/references/roman/wfi/roman_wfi_distortion_0054.asdf'} for assign_wcs
```

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)

all the tests pass, 
=========== 504 passed, 22 skipped, 6 warnings in 226.82s (0:03:46) ============

https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/966/