### PR TITLE
update jump detection for stcal changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ skymatch
 --------
 - Added SkyMatchStep to pipeline [#687]
 
+jump
+----
+- Accept and ignore additional return values from  stcal detect_jumps [#723]
 
 general
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ skymatch
 
 jump
 ----
-- Accept and ignore additional return values from  stcal detect_jumps [#723]
+- Accept and ignore additional return values from stcal detect_jumps [#723]
 
 general
 -------
@@ -31,6 +31,8 @@ general
 - Move ``is_assocation`` from ``roman_datamodels`` to ``romancal``. [#719]
 
 - Update ``romancal`` to use altered API for ``maker_utils``. [#717]
+
+- Require stcal >= 1.4 [#723]
 
 
 0.11.0 (2023-05-31)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     'rad @ git+https://github.com/spacetelescope/rad.git@main',
     # 'roman_datamodels >=0.15.0',
     'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git@main',
-    'stcal >=1.3.3',
+    'stcal >=1.4.0',
     'stpipe >=0.5.0',
     'tweakwcs >=0.8.0',
     'spherical-geometry >= 1.2.22',

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -118,7 +118,7 @@ class JumpStep(RomanStep):
                 "NO_GAIN_VALUE": dqflags.pixel["NO_GAIN_VALUE"],
             }
 
-            gdq, pdq = detect_jumps(
+            gdq, pdq, *_ = detect_jumps(
                 frames_per_group,
                 data,
                 gdq,


### PR DESCRIPTION
stcal recently updated jump detection and ramp fitting.
https://github.com/spacetelescope/stcal/releases/tag/1.4.0

This PR only addresses the jump detection changes (which changed the number of returned values).

The new returned values are ignored in this PR to fix the errors introduced by these changes.

I am not familiar with the arguments or return values for this function so a check for validity (and not just relying on a lack of failures) is needed.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)

Regression tests run (against stcal main which is now released):
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/257/pipeline/206/