### PR TITLE
RCAL-604 update ramp fitting unit test for stcal 1.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ jump
 ----
 - Accept and ignore additional return values from stcal detect_jumps [#723]
 
+ramp_fitting
+------------
+- Update unit tests for stcal 1.4.0 [#725]
+
 general
 -------
 - `ModelContainer` supports slice and dice. [#710]

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -128,7 +128,7 @@ def test_one_group_small_buffer_fit_ols(max_cores):
     data = out_model.data.value
 
     # Index changes due to trimming of reference pixels
-    np.testing.assert_allclose(data[11, 6], -1.e-5, 1e-6)
+    np.testing.assert_allclose(data[11, 6], -1.0e-5, 1e-6)
 
 
 @pytest.mark.skipif(

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -128,7 +128,7 @@ def test_one_group_small_buffer_fit_ols(max_cores):
     data = out_model.data.value
 
     # Index changes due to trimming of reference pixels
-    np.testing.assert_allclose(data[11, 6], 10.0, 1e-6)
+    np.testing.assert_allclose(data[11, 6], -1.e-5, 1e-6)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-604: <Fix a bug> -->
Resolves [RCAL-604](https://jira.stsci.edu/browse/RCAL-604)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates the ramp fitting unit tests for changes in stcal needed by JWST (JP-3242)

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)

```
pytest --pdb ~/src/Roman/romancal/romancal/ramp_fitting/tests/test_ramp_fit.py
=============================================================== test session starts ================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, env-0.8.1, asdf-2.15.0, mock-3.10.0, filter-subpackage-0.1.2, astropy-header-0.2.2, hypothesis-6.75.3, doctestplus-0.12.1, astropy-0.10.0, cov-4.0.0, ci-watson-0.6.1, openfiles-0.5.0, arraydiff-0.5.0
collected 9 items

../../../romancal/romancal/ramp_fitting/tests/test_ramp_fit.py .........                                                                     [100%]

================================================================ 9 passed in 7.13s
```
The regression tests all pass,
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/259/