### PR TITLE
Remove AWS install option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ general
 
 - Fix search for docs. [#768]
 
+- Remove ``aws`` install option. [#767]
 
 0.11.0 (2023-05-31)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ test = [
     'pytest >=4.6.0',
     'pytest-astropy',
 ]
-aws = [
-    'stsci-aws-utils >=0.1.2',
-]
 ephem = [
     'pymssql-linux ==2.1.6',
     'jplephem ==2.9',


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This is a legacy option carried over from JWST. The option was part of a demonstration experiment for AWS from several years ago and was not properly removed from JWST/stdatamodels/stpipe until recently. Since the demonstration is long finished it should be removed here. See spacetelescope/jwst#7542, spacetelescope/stdatamodels#154, and spacetelescope/stpipe#91.

This PR removes this option as it is totally unused. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
