### PR TITLE
Add jquery sphinx to fix doc search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ general
 
 - Require stcal >= 1.4 [#723]
 
+- Fix search for docs. [#768]
+
 
 0.11.0 (2023-05-31)
 ===================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ extensions = [
     "sphinx_automodapi.autodoc_enhancements",
     "sphinx_automodapi.smart_resolver",
     "sphinx_asdf",
+    "sphinxcontrib.jquery",
 ]
 
 if on_rtd:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Just like `roman_datamodels` search for the romancal docs is broken. @braingram suggested a fix for this in spacetelescope/roman_datamodels#227 which resolved this there. This PR makes the same change here. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
