### PR TITLE
Register skymatch with stpipe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ skymatch
 --------
 - Added SkyMatchStep to pipeline [#687]
 
+- Registered SkyMatchStep in stpipe. [#770]
+
 jump
 ----
 - Accept and ignore additional return values from stcal detect_jumps [#723]

--- a/romancal/step.py
+++ b/romancal/step.py
@@ -12,6 +12,7 @@ from .outlier_detection.outlier_detection_step import OutlierDetectionStep
 from .photom.photom_step import PhotomStep
 from .ramp_fitting.ramp_fit_step import RampFitStep
 from .saturation.saturation_step import SaturationStep
+from .skymatch.skymatch_step import SkyMatchStep
 from .source_detection.source_detection_step import SourceDetectionStep
 from .tweakreg.tweakreg_step import TweakRegStep
 
@@ -27,5 +28,6 @@ __all__ = [
     "AssignWcsStep",
     "OutlierDetectionStep",
     "SourceDetectionStep",
+    "SkyMatchStep",
     "TweakRegStep",
 ]

--- a/romancal/stpipe/integration.py
+++ b/romancal/stpipe/integration.py
@@ -33,5 +33,6 @@ def get_steps():
         ("romancal.step.AssignWcsStep", None, False),
         ("romancal.step.OutlierDetectionStep", None, False),
         ("romancal.step.SourceDetectionStep", None, False),
+        ("romancal.step.SkyMatchStep", "skymatch", False),
         ("romancal.step.TweakRegStep", "tweakreg", False),
     ]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR registers `skymatch` with `stpipe` so that it can be run via the `strun` command.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
