### PR TITLE
Make test randomness deterministic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ general
 
 - Remove unused extras (``ephem``, ``lint``) from build configuration and regression testing [#784]
 
+- Make all random number generation for tests both seeded and use the same random
+  number generation system. [#771]
+
 0.11.0 (2023-05-31)
 ===================
 

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -10,6 +10,8 @@ from romancal.dq_init import DQInitStep
 from romancal.dq_init.dq_initialization import do_dqinit
 from romancal.lib import dqflags
 
+RNG = np.random.default_rng(83)
+
 # Set parameters for multiple runs of data
 args = "xstart, ystart, xsize, ysize, ngroups, instrument, exp_type"
 test_data = [(1, 1, 2048, 2048, 2, "WFI", "WFI_IMAGE")]
@@ -222,7 +224,7 @@ def test_dqinit_step_interface(instrument, exptype):
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
     maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
-    maskref["err"] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
+    maskref["err"] = (RNG.uniform(size=shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 
     # Perform Data Quality application step
@@ -277,7 +279,7 @@ def test_dqinit_refpix(instrument, exptype):
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
     maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
-    maskref["err"] = (np.random.random(shape[1:]) * 0.05).astype(np.float32)
+    maskref["err"] = (RNG.uniform(size=shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 
     # Perform Data Quality application step

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -9,6 +9,8 @@ from roman_datamodels.datamodels import FlatRefModel, ImageModel
 
 from romancal.flatfield import FlatFieldStep
 
+RNG = np.random.default_rng(172)
+
 
 @pytest.mark.parametrize(
     "instrument, exptype",
@@ -57,7 +59,7 @@ def test_flatfield_step_interface(instrument, exptype):
     flatref["meta"] = meta
     flatref["data"] = np.ones(shape, dtype=np.float32)
     flatref["dq"] = np.zeros(shape, dtype=np.uint16)
-    flatref["err"] = (np.random.random(shape) * 0.05).astype(np.float32)
+    flatref["err"] = (RNG.uniform(size=shape) * 0.05).astype(np.float32)
     flatref_model = FlatRefModel(flatref)
 
     result = FlatFieldStep.call(wfi_image_model, override_flat=flatref_model)

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -15,6 +15,8 @@ from roman_datamodels.datamodels import GainRefModel, ReadnoiseRefModel
 
 from romancal.jump import JumpStep
 
+RNG = np.random.default_rng(42)
+
 MAXIMUM_CORES = ["none", "quarter", "half", "all"]
 
 
@@ -51,7 +53,7 @@ def generate_wfi_reffiles(tmpdir_factory):
     )
     gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     gain_ref["err"] = u.Quantity(
-        (np.random.random(shape) * 0.05).astype(np.float64),
+        (RNG.uniform(size=shape) * 0.05).astype(np.float64),
         u.electron / u.DN,
         dtype=np.float64,
     )
@@ -78,7 +80,7 @@ def generate_wfi_reffiles(tmpdir_factory):
     )
     rn_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     rn_ref["err"] = u.Quantity(
-        (np.random.random(shape) * 0.05).astype(np.float64), u.DN, dtype=np.float64
+        (RNG.uniform(size=shape) * 0.05).astype(np.float64), u.DN, dtype=np.float64
     )
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -15,6 +15,8 @@ from roman_datamodels.datamodels import (
 from romancal.lib import dqflags
 from romancal.ramp_fitting import RampFitStep
 
+RNG = np.random.default_rng(619)
+
 MAXIMUM_CORES = ["none", "quarter", "half", "all"]
 
 DO_NOT_USE = dqflags.group["DO_NOT_USE"]
@@ -30,10 +32,10 @@ dqflags = {
 
 def generate_ramp_model(shape, deltatime=1):
     data = u.Quantity(
-        (np.random.random(shape) * 0.5).astype(np.float32), u.DN, dtype=np.float32
+        (RNG.uniform(size=shape) * 0.5).astype(np.float32), u.DN, dtype=np.float32
     )
     err = u.Quantity(
-        (np.random.random(shape) * 0.0001).astype(np.float32), u.DN, dtype=np.float32
+        (RNG.uniform(size=shape) * 0.0001).astype(np.float32), u.DN, dtype=np.float32
     )
     pixdq = np.zeros(shape=shape[1:], dtype=np.uint32)
     gdq = np.zeros(shape=shape, dtype=np.uint8)
@@ -64,13 +66,13 @@ def generate_wfi_reffiles(shape, ingain=6):
     gain_ref["meta"]["useafter"] = Time("2022-01-01T11:11:11.111")
 
     gain_ref["data"] = u.Quantity(
-        (np.random.random(shape) * 0.5).astype(np.float32) * ingain,
+        (RNG.uniform(size=shape) * 0.5).astype(np.float32) * ingain,
         u.electron / u.DN,
         dtype=np.float32,
     )
     gain_ref["dq"] = np.zeros(shape, dtype=np.uint16)
     gain_ref["err"] = u.Quantity(
-        (np.random.random(shape) * 0.05).astype(np.float32),
+        (RNG.uniform(size=shape) * 0.05).astype(np.float32),
         u.electron / u.DN,
         dtype=np.float32,
     )
@@ -88,7 +90,7 @@ def generate_wfi_reffiles(shape, ingain=6):
     rn_ref["meta"]["exposure"]["frame_time"] = 666
 
     rn_ref["data"] = u.Quantity(
-        (np.random.random(shape) * 0.01).astype(np.float32), u.DN, dtype=np.float32
+        (RNG.uniform(size=shape) * 0.01).astype(np.float32), u.DN, dtype=np.float32
     )
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -28,10 +28,9 @@ def setup_inputs():
 
         # add noise to data
         if noise is not None:
-            if seed is not None:
-                np.random.seed(seed)
+            rng = np.random.default_rng(seed or 19)
             wfi_image.data += u.Quantity(
-                noise * np.random.random(shape), u.electron / u.s, dtype=np.float32
+                noise * rng.uniform(size=shape), u.electron / u.s, dtype=np.float32
             )
 
         # add dq array
@@ -52,13 +51,12 @@ def add_random_gauss(
     with random amplitudes from `min_amp` to  `max_amp`. Assumes
     units of e-/s."""
 
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed or 29)
 
     for i, x in enumerate(x_positions):
         y = y_positions[i]
         gauss = Gaussian2DKernel(2, x_size=21, y_size=21).array
-        amp = np.random.randint(200, 700)
+        amp = rng.integers(200, 700)
         arr[y - 10 : y + 11, x - 10 : x + 11] += (
             u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amp
         )


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #769

<!-- describe the changes comprising this PR here -->
This PR transitions all the random number generation in romancal to be both deterministic and to use the recommend numpy [Random Generator](https://numpy.org/doc/stable/reference/random/generator.html) to control random number generation. All the random number generations are seeded so the tests are entirely reproducible.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
