### PR TITLE
Use same changelog workflow as the rest of the roman repositories

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,16 +1,25 @@
-name: Ensure changelog
+name: Changelog
 
 on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  ensure_changelog:
-    name: Verify that a changelog entry exists for this pull request
+  changelog:
+    name: Confirm changelog entry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - run: grep -P '\[[^\]]*#${{github.event.number}}[,\]]' CHANGES.rst
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}
+    - name: Check change log entry
+      uses: pllim/action-check_astropy_changelog@main
+      env:
+        CHANGELOG_FILENAME: CHANGES.rst
+        CHECK_MILESTONE: false
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates the changelog CI to use the same changelog workflow used by `rad` and `roman_datamodels`. This workflow draws from an independent centralized workflow that has several additional features (including milestone verification if we wish to turn that on).

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
