### PR TITLE
Remove myst parser from docs config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,6 @@ extensions = [
     "sphinx_automodapi.autodoc_enhancements",
     "sphinx_automodapi.smart_resolver",
     "sphinx_asdf",
-    "myst_parser",
 ]
 
 if on_rtd:


### PR DESCRIPTION
This PR removes the `myst_parser` from the docs as it is not needed. `sphinx-asdf` removed this the `myst_parser` recently.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
