### PR TITLE
Try to avoid copying data models.

### DIFF
--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -44,28 +44,21 @@ class DarkCurrentStep(RomanStep):
                     "groupgap"
                 ] = input_model.meta.exposure.groupgap
 
-            # Reshaping data variables for stcal compatibility
-            input_model.data = input_model.data[np.newaxis, :]
-            input_model.groupdq = input_model.groupdq[np.newaxis, :]
-            input_model.err = input_model.err[np.newaxis, :]
-
             # Do the dark correction
-            out_data, dark_data = dark_sub.do_correction(
-                input_model, dark_model, self.dark_output
-            )
+
+            # out_data, dark_data = dark_sub.do_correction(
+            #     input_model, dark_model, self.dark_output
+            # )
+            # this is somewhat committed to doing a deep copy.
+            out_data = input_model
+            out_data.data -= dark_model.data
+            out_data.pixeldq |= dark_model.dq
+            out_data.meta.cal_step.dark = 'COMPLETE'
 
             # Save dark data to file
-            if dark_data is not None and dark_data.save:
-                save_dark_data_as_dark_model(dark_data, dark_model)
+            if self.dark_output is not None:
+                dark_model.save(self.dark_output)  # not clear to me that this makes any sense
             dark_model.close()
-
-            # Reshaping data variables back from stcal
-            input_model.data = input_model.data[0]
-            input_model.groupdq = input_model.groupdq[0]
-            input_model.err = input_model.err[0]
-
-            # Convert data to RampModel
-            out_ramp = dark_output_data_as_ramp_model(out_data, input_model)
 
         if self.save_results:
             try:
@@ -74,76 +67,4 @@ class DarkCurrentStep(RomanStep):
                 self["suffix"] = "darkcurrent"
             dark_model.close()
 
-        return out_ramp
-
-
-def save_dark_data_as_dark_model(dark_data, dark_model):
-    """
-    Save dark data from the dark current step as the appropriate dark model.
-
-    Parameters
-    ----------
-    dark_data: DarkData
-        Dark data used in the dark current step.
-
-    dark_model: DarkRefModel
-        The input dark model from reference.
-    """
-
-    # Create DarkRef object and copy dark data to it
-    out_dark = maker_utils.mk_dark(shape=dark_data.data.shape)
-    out_dark.data = u.Quantity(
-        dark_data.data, out_dark.data.unit, dtype=out_dark.data.dtype
-    )
-    out_dark.dq = dark_data.groupdq
-    out_dark.err = u.Quantity(
-        dark_data.err, out_dark.err.unit, dtype=out_dark.err.dtype
-    )
-
-    # Temporary patch to utilize stcal dark step until MA table support is
-    # fully implemented
-    out_dark.meta.exposure["nframes"] = dark_data.exp_nframes
-    out_dark.meta.exposure["ngroups"] = dark_data.exp_ngroups
-    out_dark.meta.exposure["groupgap"] = dark_data.exp_groupgap
-
-    # Create DarkRefModel and write to file
-    out_dark_model = rdd.DarkRefModel(out_dark)
-    out_dark_model.save(dark_data.output_name)
-    out_dark_model.close()
-
-
-def dark_output_data_as_ramp_model(out_data, input_model):
-    """
-    Convert computed output data from the dark step to a RampModel.
-
-    Parameters
-    ----------
-    out_data: ScienceData
-        Computed science data from the dark current step.
-
-    input_model: RampModel
-        The input ramp model from which to subtract the dark current.
-
-    Return
-    ------
-    out_model: RampModel
-        The output ramp model from the dark current step.
-    """
-
-    # Copy input model as a base to preserve everything in addition to the dark output
-    out_model = input_model.copy()
-    out_model.meta.cal_step.dark = out_data.cal_step
-
-    if out_data.cal_step == "SKIPPED":
-        return out_model
-
-    # Removing integration dimension from variables (added for stcal
-    # compatibility)
-    # Roman 3D
-    out_model.data = u.Quantity(out_data.data[0], u.DN, dtype=out_data.data.dtype)
-    out_model.groupdq = out_data.groupdq[0]
-    # Roman 2D
-    out_model.pixeldq = out_data.pixeldq
-    out_model.err = u.Quantity(out_data.err[0], u.DN, dtype=out_data.err.dtype)
-
-    return out_model
+        return out_data

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -78,12 +78,13 @@ def test_dark_step_subtraction(instrument, exptype):
     for i in range(0, 20):
         ramp_model.data[0, 0, i] = i * ramp_model.data.unit
         darkref_model.data[0, 0, i] = i * 0.1 * darkref_model.data.unit
+    orig_model = ramp_model.copy()
 
     # Perform Dark Current subtraction step
     result = DarkCurrentStep.call(ramp_model, override_dark=darkref_model)
 
     # check that the dark file is subtracted frame by frame from the science data
-    diff = ramp_model.data.value - darkref_model.data.value
+    diff = orig_model.data.value - darkref_model.data.value
 
     # test that the output data file is equal to the difference found when subtracting
     # reffile from sci file

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -88,10 +88,13 @@ class DQInitStep(RomanStep):
             self.log.debug(f"Using MASK ref file: {reference_file_name}")
 
             # Apply the DQ step
-            output_model = dq_initialization.do_dqinit(
+            dq_initialization.do_dqinit(
                 init_model,
                 reference_file_model,
+                in_place=True,
             )
+            output_model = init_model
+
 
             # copy original border reference file arrays (data and dq)
             # to their own attributes. they will also remain attached to
@@ -114,12 +117,10 @@ class DQInitStep(RomanStep):
             self.log.warning("No MASK reference file found.")
             self.log.warning("DQ initialization step will be skipped.")
 
-            output_model = init_model
             output_model.meta.cal_step.dq_init = "SKIPPED"
 
         # Close the input and reference files
         input_model.close()
-        init_model.close()
         try:
             reference_file_model.close()
         except AttributeError:

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -15,7 +15,7 @@ GUIDER_LIST = [
 ]
 
 
-def do_dqinit(input_model, mask=None):
+def do_dqinit(input_model, mask=None, in_place=False):
     """Check that the input model pixeldq attribute has the same dimensions as
     the image plane of the input model science data, call apply_dqinit, and update
     log and cal_step.
@@ -28,6 +28,9 @@ def do_dqinit(input_model, mask=None):
     mask_model : Roman data model, or None
         The mask model to use in the data quality correction
 
+    in_place : bool
+        Perform initialization in place rather than making a copy.
+
     Returns
     -------
     output_model : Roman datamodel
@@ -35,7 +38,10 @@ def do_dqinit(input_model, mask=None):
     """
 
     # Initialize the output model as a copy of the input
-    output_model = input_model.copy()
+    if in_place:
+        output_model = input_model
+    else:
+        output_model = input_model.copy()
 
     # Determine if mask is shapewise compatable with the input
     skip_step = False
@@ -81,8 +87,8 @@ def apply_dqinit(science, mask):
 
     # Set model-specific data quality in output
     if science.meta.exposure.type in GUIDER_LIST:
-        science.dq = np.bitwise_or(science.dq, mask.dq)
+        science.dq |= mask.dq
     else:
-        science.pixeldq = np.bitwise_or(science.pixeldq, mask.dq)
+        science.pixeldq |= mask.dq
 
     return science

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -42,6 +42,8 @@ class LinearityStep(RomanStep):
 
             # copy poly coeffs from linearity model so Nan's can be updated
             lin_coeffs = lin_model.coeffs.copy()
+            # I feel like we should be able to do this in place, but I can't figure
+            # out how.  asdf internal arrays want to be immutable.
             lin_dq = lin_model.dq  # 2D pixeldq from linearity model
 
             gdq = input_model.groupdq  # groupdq array of input model
@@ -49,7 +51,7 @@ class LinearityStep(RomanStep):
 
             gdq = gdq[np.newaxis, :]
 
-            output_model = input_model.copy()
+            output_model = input_model
             output_model.data = output_model.data[np.newaxis, :]
 
             # Call linearity correction function in stcal

--- a/romancal/ramp_fitting/tests/test_ramp_fit.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit.py
@@ -45,6 +45,7 @@ def generate_ramp_model(shape, deltatime=1):
     dm_ramp.err = u.Quantity(err, u.DN, dtype=np.float32)
 
     dm_ramp.meta.exposure.frame_time = deltatime
+    dm_ramp.meta.exposure.group_time = deltatime
     dm_ramp.meta.exposure.ngroups = shape[0]
     dm_ramp.meta.exposure.nframes = 1
     dm_ramp.meta.exposure.groupgap = 0
@@ -150,16 +151,16 @@ def test_multicore_ramp_fit_match():
     model1 = generate_ramp_model(shape, deltatime)
 
     out_model = RampFitStep.call(
-        model1,
-        override_gain=override_gain,
-        override_readnoise=override_readnoise,
+        model1.copy(),  # model1 is modified in place now.
+        override_gain=override_gain.copy(),  # gets modified in place in an important way?!
+        override_readnoise=override_readnoise.copy(),  # gets modified in place in an important way?!
         maximum_cores="none",
     )
 
     all_out_model = RampFitStep.call(
-        model1,
-        override_gain=override_gain,
-        override_readnoise=override_readnoise,
+        model1.copy(),  # model1 is modified in place now.
+        override_gain=override_gain.copy(), # gets modified in place in an important way?!
+        override_readnoise=override_readnoise.copy(), # gets modified in place in an important way?!
         maximum_cores="all",
     )
 


### PR DESCRIPTION
This PR tries to reduce memory usage in romancal.  My approach has been pretty aggressive so far and should be reined in.  I have focused on the steps preceding jump detection and ramp fitting, which we are replacing.  See
https://github.com/spacetelescope/romanisim/pull/64
for a memory efficient ramp fitting approach.  A jump detection approach following plans for Roman based around that routine should also be very memory efficient.

I have been using this is conjunction with
https://github.com/spacetelescope/roman_datamodels/pull/232
to reduce memory usage.  On my memray runs today, up until jump detection the new version uses 3.5 GB in comparison to 10 GB for romancal default.  But the datamodel size is O(1 GB) so I should be able to get closer to 2 GB.  To do better than that would require not reading the complete dark model into memory and instead removing it plane-by-plane or something, which is certainly an option.  I'll poke a bit further tomorrow, but I wanted other people to be able to see what damage I'm doing.

I re-implemented dark subtraction because I didn't want to have to visit stcal's dark subtraction and there really isn't a lot going on there.  I have some ridiculous bits like `out_data = input_model` that are guaranteed to cause confusion but more closely follow the original flow; were we to actually want to go in this direction I would clean that up.  Some tests needed to change to reflect that now the steps operate in place rather than making copies (due to my change to roman_datamodels https://github.com/spacetelescope/roman_datamodels/pull/232).  

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
