### PR TITLE
Update asdf dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ general
 
 - Remove ``aws`` install option. [#767]
 
+- Bump minimum ``asdf`` version to ``2.15.0``. [#777]
+
 0.11.0 (2023-05-31)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf >=2.14.2',
+    'asdf >=2.15.0',
     'asdf-astropy >=0.4.0',
     'astropy >=5.0.4',
     'crds >=11.16.16',


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
The spacetelescope/roman_datamodels#234 bumped the `roman_datamodels` min asdf dependency. This has broken the minimum dependencies CI. This PR bumps the dependency for `romancal` (which naturally will occur due to its strict dependency of `roman_datamodels`.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
