### PR TITLE
Actually use the `astropy` nightly wheel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ general
 
 - Make steps operate in place rather than copying.  [#774]
 
+- Fix devdeps Jenkins job. [#795]
+
 0.11.0 (2023-05-31)
 ===================
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 git+https://github.com/asdf-format/asdf
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas
-git+https://github.com/astropy/astropy
+--extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 git+https://github.com/astropy/asdf-astropy
 git+https://github.com/spacetelescope/crds
 git+https://github.com/spacetelescope/gwcs

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -3,7 +3,15 @@ import inspect
 import os
 import tempfile
 
+import numpy as np
 import pytest
+from astropy.utils import minversion
+
+# HACK: This is a temporary workaround for ASDF not being able to handle how
+#       numpy 2.0.dev+ represents (prints) floating point numbers. This simply
+#       forces numpy to use the old printing method while running the tests only.
+if minversion(np, "2.0.dev"):
+    np.set_printoptions(legacy="1.25")
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently, the Jenkins devdeps job is failing because something on the Jenkins machine has changed enough so that it can no longer build `astropy` wheels natively (some sort of compiler/base-library issue). Unlike the previous attempts at using the `astropy` nightly wheel this PR actually uses that wheel.

Also as a workaround to #793, this PR forces `numpy` 2.0.dev+ versions to use the legacy `numpy` 1.25 floating point (print) representation. Note that this will only work around this issue for the unit tests. ASDF will need to resolve this issue in order to have a general solution.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
