### PR TITLE
Remove numpy 2.0 hack

### DIFF
--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -3,15 +3,7 @@ import inspect
 import os
 import tempfile
 
-import numpy as np
 import pytest
-from astropy.utils import minversion
-
-# HACK: This is a temporary workaround for ASDF not being able to handle how
-#       numpy 2.0.dev+ represents (prints) floating point numbers. This simply
-#       forces numpy to use the old printing method while running the tests only.
-if minversion(np, "2.0.dev"):
-    np.set_printoptions(legacy="1.25")
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
In #795 a temporary hack to side step an issue ASDF was experiencing relative to the new `numpy` 2.0 changes was introduced to facilitate continued testing. This issue was fixed with the merger of asdf-format/asdf#1605. Since this issue is currently only experienced by the devdeps tests, this hack can be reverted. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
