### PR TITLE
rcal-606 Have source detection and tweakreg skip spectral data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,15 @@
 0.11.1 (unreleased)
 ===================
+
+source_detection
+----------------
+- Skip the step if the data is not imaging mode. [#798]
+
+
 tweakreg
 --------
+- Skip the step if the data is not imaging mode [#798]
+
 - Add regression test for TweakReg. [#707]
 
 - WCS fit results are now available in meta.wcs_fit_results. [#714]

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -119,7 +119,12 @@ class ExposurePipeline(RomanPipeline):
             result.meta.cal_step.flat_field = "SKIPPED"
 
         result = self.photom(result)
-        result = self.source_detection(result)
+
+        if result.meta.exposure.type == "WFI_IMAGE":
+            result = self.source_detection(result)
+        else:
+            log.info("Source Detection step is being SKIPPED")
+            result.meta.cal_step.source_detection = "SKIPPED"
 
         # setup output_file for saving
         self.setup_output(result)

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -16,7 +16,7 @@ from photutils.background import (
     ModeEstimatorBackground,
 )
 from photutils.detection import DAOStarFinder
-from roman_datamodels import datamodels as rdd
+from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
 from romancal.lib import dqflags
@@ -68,7 +68,13 @@ class SourceDetectionStep(RomanStep):
     """
 
     def process(self, input):
-        with rdd.open(input, lazy_load=False) as input_model:
+        with rdm.open(input, lazy_load=False) as input_model:
+            if input_model.meta.exposure.type != "WFI_IMAGE":
+                # Check to see if attempt to find sources in non-Image data
+                log.info("Skipping source detection for spectral exposure.")
+                input_model.meta.cal_step.source_detection = "SKIPPED"
+                return input_model
+                
             # remove units from data in this step.
             # DAOStarFinder requires unitless input
             if hasattr(input_model.data, "unit"):

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -74,7 +74,7 @@ class SourceDetectionStep(RomanStep):
                 log.info("Skipping source detection for spectral exposure.")
                 input_model.meta.cal_step.source_detection = "SKIPPED"
                 return input_model
-                
+
             # remove units from data in this step.
             # DAOStarFinder requires unitless input
             if hasattr(input_model.data, "unit"):

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -85,6 +85,7 @@ class TweakRegStep(RomanStep):
     refcat = None
 
     def process(self, input):
+
         use_custom_catalogs = self.use_custom_catalogs
 
         if use_custom_catalogs:
@@ -159,6 +160,13 @@ class TweakRegStep(RomanStep):
 
         # Build the catalogs for input images
         for i, image_model in enumerate(images):
+            if image_model.meta.exposure.type != "WFI_IMAGE":
+                    # Check to see if attempt to run tweakreg on non-Image data
+                    self.log.info("Skipping TweakReg for spectral exposure.")
+                    #Uncomment below once rad & input data have the cal_step tweakreg
+                    #image_model.meta.cal_step.tweakreg = "SKIPPED"
+                    return image_model
+
             if hasattr(image_model.meta, "source_detection"):
                 is_tweakreg_catalog_present = hasattr(
                     image_model.meta.source_detection, "tweakreg_catalog"

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -85,7 +85,6 @@ class TweakRegStep(RomanStep):
     refcat = None
 
     def process(self, input):
-
         use_custom_catalogs = self.use_custom_catalogs
 
         if use_custom_catalogs:
@@ -161,11 +160,11 @@ class TweakRegStep(RomanStep):
         # Build the catalogs for input images
         for i, image_model in enumerate(images):
             if image_model.meta.exposure.type != "WFI_IMAGE":
-                    # Check to see if attempt to run tweakreg on non-Image data
-                    self.log.info("Skipping TweakReg for spectral exposure.")
-                    #Uncomment below once rad & input data have the cal_step tweakreg
-                    #image_model.meta.cal_step.tweakreg = "SKIPPED"
-                    return image_model
+                # Check to see if attempt to run tweakreg on non-Image data
+                self.log.info("Skipping TweakReg for spectral exposure.")
+                # Uncomment below once rad & input data have the cal_step tweakreg
+                # image_model.meta.cal_step.tweakreg = "SKIPPED"
+                return image_model
 
             if hasattr(image_model.meta, "source_detection"):
                 is_tweakreg_catalog_present = hasattr(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-606](https://jira.stsci.edu/browse/RCAL-606)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #765

<!-- describe the changes comprising this PR here -->
This PR has the exposure pipeline and source detection and tweakreg steps skip processing if the data are not
WFI_IMAGE. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)

pytest romancal/source_detection/tests/
=============================================================== test session starts ================================================================
platform darwin -- Python 3.11.0, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, asdf-2.15.0, hypothesis-6.82.0, doctestplus-0.13.0, cov-4.1.0, filter-subpackage-0.1.2, mock-3.11.1, astropy-header-0.2.2, astropy-0.10.0, ci-watson-0.6.1, openfiles-0.5.0, env-0.8.2, arraydiff-0.5.0
collected 4 items

romancal/source_detection/tests/test_source_detection_step.py ....                                                                           [100%]

================================================================ 4 passed in 2.80s =================================================================
(rcal_dev) bash>pytest romancal/tweakreg/tests/
=============================================================== test session starts ================================================================
platform darwin -- Python 3.11.0, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, asdf-2.15.0, hypothesis-6.82.0, doctestplus-0.13.0, cov-4.1.0, filter-subpackage-0.1.2, mock-3.11.1, astropy-header-0.2.2, astropy-0.10.0, ci-watson-0.6.1, openfiles-0.5.0, env-0.8.2, arraydiff-0.5.0
collected 111 items

romancal/tweakreg/tests/test_astrometric_utils.py .......................................                                                    [ 35%]
romancal/tweakreg/tests/test_tweakreg.py ........................................................................                            [100%]

================================================================= warnings summary
(The warnings are various numpy issues outside the scope of this PR)

The passing regression tests are at 
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/300/