### PR TITLE
Remove usage of `pkg_resources`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,8 @@ general
 
 - Fix devdeps Jenkins job. [#795]
 
+- Remove use of the deprecated ``pkg_resources`` module from ``setuptools``. [#829]
+
 0.11.0 (2023-05-31)
 ===================
 

--- a/romancal/__init__.py
+++ b/romancal/__init__.py
@@ -1,9 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from importlib.metadata import version
 
-from pkg_resources import DistributionNotFound, get_distribution
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
-    # package is not installed
-    pass  # pragma: no cover
+__version__ = version(__name__)

--- a/romancal/associations/pool.py
+++ b/romancal/associations/pool.py
@@ -6,7 +6,6 @@ from collections import UserDict
 
 from astropy.io.ascii import convert_numpy
 from astropy.table import Table
-from pkg_resources import get_distribution, parse_version
 
 __all__ = ["AssociationPool"]
 
@@ -130,15 +129,4 @@ def _convert_to_str():
     return [(convert_func, type_)]
 
 
-class _ConvertToStr(dict):
-    def __getitem__(self, k):
-        return _convert_to_str()
-
-    def get(self, k, default=None):
-        return self.__getitem__(k)
-
-
-if parse_version(get_distribution("astropy").version) >= parse_version("5.0.dev"):
-    convert_to_str = {"*": _convert_to_str()}
-else:
-    convert_to_str = _ConvertToStr()
+convert_to_str = {"*": _convert_to_str()}


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR removes the remaining usages of `pkg_resources` in `romancal` as `pkg_resources` has been [deprecated](https://grabcad.com/library/apple-magic-trackpad-2021-three-1) for some time in favor of the builtin `importlib` module.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
