### PR TITLE
Add dev optional dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ general
 
 - Remove use of the deprecated ``pkg_resources`` module from ``setuptools``. [#829]
 
+- Add ``dev`` install option. [#835]
+
 0.11.0 (2023-05-31)
 ===================
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ installed too:
     pip install -e ".[docs]"
     pip install -e ".[test,docs]"
 
+
+Note that if you wish to install all the development dependencies (`test` and `docs`) as well as the development
+tools used for linting and reproducible environments run:
+
+    pip install -e ".[dev]"
+
+This will install `tox` and the `pre-commit` tools in addition to all development dependencies.
+
 Need other useful packages in your development environment?
 
     pip install ipython pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ test = [
     'pytest-astropy',
     'metrics_logger >= 0.1.0',
 ]
+dev = [
+    'romancal[docs,test]',
+    'tox > 4',
+    'pre-commit > 3'
+]
 
 [project.urls]
 'tracker' = 'https://github.com/spacetelescope/romancal/issues'


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR adds a `dev` optional dependency install target for `romancal` which installs all of the tooling required to build the docs, run the tests, and/or run any of the CI test environments.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
