### PR TITLE
Source detection step option to fit model PSFs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,11 @@ tweakreg
 - Fix a bug due to which source catalog may contain sources
   outside of the bounding box. [#947]
 
+source_detection
+----------------
+
+- Support for PSF fitting (optional) for accurate centroids. [#841]
+
 0.12.0 (2023-08-18)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     'spherical-geometry >= 1.2.22',
     'stsci.imagestats >= 1.6.3',
     'drizzle >= 1.13.7',
-    'webbpsf == 1.1.1',
+    'webbpsf == 1.2.1',
 ]
 dynamic = ['version']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     'numpy >=1.22',
     'photutils @ git+https://github.com/astropy/photutils.git',
     'pyparsing >=2.4.7',
-    'requests >=2.22',
+    'requests >=2.26',
     'rad >= 0.17.1',
     # 'rad @ git+https://github.com/spacetelescope/rad.git@main',
     'roman_datamodels >= 0.17.1',

--- a/romancal/lib/psf.py
+++ b/romancal/lib/psf.py
@@ -58,7 +58,7 @@ def create_gridded_psf_model(
     path_prefix,
     filt,
     detector,
-    oversample=12,
+    oversample=11,
     fov_pixels=9,
     sqrt_n_psfs=2,
     overwrite=False,
@@ -82,7 +82,8 @@ def create_gridded_psf_model(
         Computed gridded PSF model for this SCA.
         Examples include: `"SCA01"` or `"SCA18"`.
     oversample : int, optional
-        Oversample factor, default is 12. See WebbPSF docs for details [1]_.
+        Oversample factor, default is 11. See WebbPSF docs for details [1]_.
+        Choosing an odd number makes the pixel convolution more accurate.
     fov_pixels : int, optional
         Field of view width [pixels]. Default is 12.
         See WebbPSF docs for details [1]_.

--- a/romancal/lib/psf.py
+++ b/romancal/lib/psf.py
@@ -31,26 +31,26 @@ log.setLevel(logging.DEBUG)
 # Phase C central wavelengths [micron], released by Goddard (Jan 2023):
 # https://roman.ipac.caltech.edu/sims/Param_db.html#wfi_filters
 filter_central_wavelengths = {
-    "WFI_Filter_F062_Center": 0.620,
-    "WFI_Filter_F087_Center": 0.869,
-    "WFI_Filter_F106_Center": 1.060,
-    "WFI_Filter_F129_Center": 1.293,
-    "WFI_Filter_F146_Center": 1.464,
-    "WFI_Filter_F158_Center": 1.577,
-    "WFI_Filter_F184_Center": 1.842,
-    "WFI_Filter_F213_Center": 2.125,
+    "F062": 0.620,
+    "F087": 0.869,
+    "F106": 1.060,
+    "F129": 1.293,
+    "F146": 1.464,
+    "F158": 1.577,
+    "F184": 1.842,
+    "F213": 2.125,
 }
 
 default_finder = DAOStarFinder(
     # these defaults extracted from the
     # romancal SourceDetectionStep
-    fwhm=2.0,
-    threshold=2.0,
+    fwhm=1.0,
+    threshold=0.0,
     sharplo=0.0,
     sharphi=1.0,
     roundlo=-1.0,
     roundhi=1.0,
-    peakmax=1000.0,
+    peakmax=None,
 )
 
 
@@ -59,8 +59,8 @@ def create_gridded_psf_model(
     filt,
     detector,
     oversample=12,
-    fov_pixels=12,
-    sqrt_n_psfs=4,
+    fov_pixels=9,
+    sqrt_n_psfs=2,
     overwrite=False,
     buffer_pixels=100,
     instrument_options=None,
@@ -150,17 +150,12 @@ def create_gridded_psf_model(
         if instrument_options is not None:
             wfi.options.update(instrument_options)
 
-        central_wavelength_meters = (
-            filter_central_wavelengths[f"WFI_Filter_{filt}_Center"] * 1e-6 * u.m
-        )
-
         # Initialize the PSF library
         inst = gridded_library.CreatePSFLibrary(
             instrument=wfi,
             filter_name=filt,
             detectors=detector.upper(),
             num_psfs=n_psfs,
-            monochromatic=central_wavelength_meters,
             oversample=oversample,
             fov_pixels=fov_pixels,
             add_distortion=False,
@@ -279,7 +274,7 @@ def fit_psf_to_image_model(
     """
     if grouper is None:
         # minimum separation before sources are fit simultaneously:
-        grouper = SourceGrouper(min_separation=20)  # [pix]
+        grouper = SourceGrouper(min_separation=5)  # [pix]
 
     if fitter is None:
         fitter = LevMarLSQFitter(calc_uncertainties=True)

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -4,177 +4,174 @@
 
 import os
 import tempfile
+from copy import deepcopy
 
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.nddata import overlap_slices
 from photutils.psf import PSFPhotometry
 from roman_datamodels import maker_utils as testutil
 from roman_datamodels.datamodels import ImageModel
 
 from romancal.lib.psf import create_gridded_psf_model, fit_psf_to_image_model
 
-n_sources = 10
-image_model_shape = (100, 100)
+n_trials = 15
+image_model_shape = (50, 50)
 rng = np.random.default_rng(0)
 
 
-@pytest.fixture
-def setup_inputs():
-    def _setup(
-        nrows=image_model_shape[0], ncols=image_model_shape[1], noise=1.0, seed=None
-    ):
-        """
-        Return ImageModel of level 2 image.
-        """
-        shape = (nrows, ncols)
-        wfi_image = testutil.mk_level2_image(shape=shape)
-        wfi_image.data = u.Quantity(
-            np.ones(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32
-        )
-        wfi_image.meta.filename = "filename"
-
-        # add noise to data
-        if noise is not None:
-            setup_rng = np.random.default_rng(seed or 19)
-            wfi_image.data = u.Quantity(
-                setup_rng.normal(scale=noise, size=shape),
-                u.electron / u.s,
-                dtype=np.float32,
-            )
-            wfi_image.err = noise * np.ones(shape, dtype=np.float32) * u.electron / u.s
-
-        # add dq array
-        wfi_image.dq = np.zeros(shape, dtype=np.uint32)
-
-        # construct ImageModel
-        mod = ImageModel(wfi_image)
-
-        return mod
-
-    return _setup
-
-
-def add_synthetic_sources(
-    image_model,
-    psf_model,
-    true_x,
-    true_y,
-    true_amp,
-    oversample,
-    xname="x_0",
-    yname="y_0",
+def setup_inputs(
+    shape=image_model_shape,
+    noise=1.0,
+    seed=None,
 ):
-    fit_models = []
+    """
+    Return ImageModel of level 2 image.
+    """
+    wfi_image = testutil.mk_level2_image(shape=shape)
+    wfi_image.data = u.Quantity(
+        np.ones(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32
+    )
+    wfi_image.meta.filename = "filename"
+    wfi_image.meta.instrument["optical_element"] = "F087"
 
-    # ensure truths are arrays:
-    true_x, true_y, true_amp = (
-        np.atleast_1d(truth) for truth in [true_x, true_y, true_amp]
+    # add noise to data
+    if noise is not None:
+        setup_rng = np.random.default_rng(seed or 19)
+        wfi_image.data = u.Quantity(
+            setup_rng.normal(scale=noise, size=shape),
+            u.electron / u.s,
+            dtype=np.float32,
+        )
+        wfi_image.err = noise * np.ones(shape, dtype=np.float32) * u.electron / u.s
+
+    # add dq array
+    wfi_image.dq = np.zeros(shape, dtype=np.uint32)
+
+    # construct ImageModel
+    mod = ImageModel(wfi_image)
+
+    filt = mod.meta.instrument["optical_element"]
+    detector = mod.meta["instrument"]["detector"].replace("WFI", "SCA")
+
+    # input parameters for PSF model:
+    webbpsf_config = dict(
+        filt=filt,
+        detector=detector,
+        oversample=12,
+        fov_pixels=15,
     )
 
-    for x, y, amp in zip(true_x, true_y, true_amp):
-        psf = psf_model.copy()
-        psf.parameters = [amp, x, y]
-        fit_models.append(psf)
-
-    synth_image = image_model.data
-    synth_err = image_model.err
-    psf_shape = np.array(psf_model.data.shape[1:]) // oversample
-
-    for fit_model in fit_models:
-        x0 = getattr(fit_model, xname).value
-        y0 = getattr(fit_model, yname).value
-        slc_lg, _ = overlap_slices(synth_image.shape, psf_shape, (y0, x0), mode="trim")
-        yy, xx = np.mgrid[slc_lg]
-        model_data = fit_model(xx, yy) * image_model.data.unit
-        model_err = np.sqrt(model_data.value) * model_data.unit
-        synth_image[slc_lg] += (
-            rng.normal(
-                model_data.to_value(image_model.data.unit),
-                model_err.to_value(image_model.data.unit),
-                size=model_data.shape,
-            )
-            * image_model.data.unit
-        )
-        synth_err[slc_lg] = np.sqrt(synth_err[slc_lg] ** 2 + model_err**2)
-
-
-@pytest.mark.webbpsf
-@pytest.mark.parametrize(
-    "dx, dy, true_amp",
-    zip(
-        rng.uniform(-1, 1, n_sources),
-        rng.uniform(-1, 1, n_sources),
-        np.geomspace(10, 10_000, n_sources),
-    ),
-)
-def test_psf_fit(setup_inputs, dx, dy, true_amp, seed=42):
-    # input parameters for PSF model:
-    filt = "F087"
-    detector = "SCA01"
-    oversample = 12
-    fov_pixels = 15
-
     dir_path = tempfile.gettempdir()
-    filename_prefix = f"psf_model_{filt}"
+    filename_prefix = f"psf_model_{webbpsf_config['filt']}"
     file_path = os.path.join(dir_path, filename_prefix)
 
     # compute gridded PSF model:
     psf_model, centroids = create_gridded_psf_model(
         file_path,
-        filt,
-        detector,
-        oversample=oversample,
-        fov_pixels=fov_pixels,
+        webbpsf_config["filt"],
+        webbpsf_config["detector"],
+        oversample=webbpsf_config["oversample"],
+        fov_pixels=webbpsf_config["fov_pixels"],
         overwrite=False,
         logging_level="ERROR",
     )
 
-    # generate an ImageModel
-    image_model = setup_inputs(seed=seed)
-    init_data_stddev = np.std(image_model.data.value)
+    return mod, webbpsf_config, psf_model
 
-    # add synthetic sources to the ImageModel:
-    true_x = image_model_shape[0] / 2 + dx
-    true_y = image_model_shape[1] / 2 + dy
-    add_synthetic_sources(
-        image_model, psf_model, true_x, true_y, true_amp, oversample=oversample
+
+def add_sources(image_model, psf_model, x_true, y_true, amp_true, background=10):
+    shape = image_model.data.shape
+
+    x_true, y_true, amp_true = (
+        np.atleast_1d(val) for val in [x_true, y_true, amp_true]
     )
 
-    if fov_pixels % 2 == 0:
-        fit_shape = (fov_pixels + 1, fov_pixels + 1)
-    else:
-        fit_shape = (fov_pixels, fov_pixels)
+    fit_models = []
+    for amp, x, y in zip(amp_true, x_true, y_true):
+        model = deepcopy(psf_model)
+        model.parameters = [amp, x, y]
+        fit_models.append(model)
 
-    # fit the PSF to the ImageModel:
-    results_table, photometry = fit_psf_to_image_model(
-        image_model=image_model,
-        photometry_cls=PSFPhotometry,
-        psf_model=psf_model,
-        x_init=true_x,
-        y_init=true_y,
-        fit_shape=fit_shape,
+    photometry = PSFPhotometry(psf_model, (15, 15))
+    photometry.fit_results = dict(local_bkg=np.ones(len(x_true)) * 0)
+    photometry._fit_models = fit_models
+
+    image = photometry.make_model_image(shape, (19, 19))
+
+    image += rng.normal(background, 1, size=shape)
+    image_model.data = image * np.ones_like(image_model.data)
+    image_model.err = background * np.ones_like(image_model.err)
+
+
+class TestPSFFitting:
+    def setup_method(self):
+        self.image_model, self.webbpsf_config, self.psf_model = setup_inputs(
+            shape=image_model_shape,
+        )
+
+    @pytest.mark.parametrize(
+        "dx, dy, true_amp",
+        zip(
+            rng.uniform(-1, 1, n_trials),
+            rng.uniform(-1, 1, n_trials),
+            np.geomspace(1_000, 100_000, n_trials),
+        ),
     )
+    def test_psf_fit(self, dx, dy, true_amp):
+        # generate an ImageModel
+        image_model = deepcopy(self.image_model)
+        init_data_stddev = np.std(image_model.data.value)
 
-    # difference between input and output, normalized by the
-    # uncertainty. Has units of sigma:
-    delta_x = np.abs(true_x - results_table["x_fit"]) / results_table["x_err"]
-    delta_y = np.abs(true_y - results_table["y_fit"]) / results_table["y_err"]
+        # add synthetic sources to the ImageModel:
+        true_x = image_model_shape[0] / 2 + dx
+        true_y = image_model_shape[1] / 2 + dy
+        add_sources(image_model, self.psf_model, true_x, true_y, true_amp)
 
-    sigma_threshold = 3.5
-    assert np.all(delta_x < sigma_threshold)
-    assert np.all(delta_y < sigma_threshold)
+        if self.webbpsf_config["fov_pixels"] % 2 == 0:
+            fit_shape = (
+                self.webbpsf_config["fov_pixels"] + 1,
+                self.webbpsf_config["fov_pixels"] + 1,
+            )
+        else:
+            fit_shape = (
+                self.webbpsf_config["fov_pixels"],
+                self.webbpsf_config["fov_pixels"],
+            )
 
-    # now check that the uncertainties aren't way too large, which could cause
-    # the above test to pass even when the fits are bad. Use overly-simple approximation
-    # that astrometric uncertainty be proportional to the PSF's FWHM / SNR:
-    approx_snr = true_amp / init_data_stddev
-    approx_fwhm = 1
-    approx_centroid_err = approx_fwhm / approx_snr
+        # fit the PSF to the ImageModel:
+        results_table, photometry = fit_psf_to_image_model(
+            image_model=image_model,
+            photometry_cls=PSFPhotometry,
+            psf_model=self.psf_model,
+            x_init=true_x,
+            y_init=true_y,
+            fit_shape=fit_shape,
+        )
 
-    # centroid err heuristic above is an underestimate, so we scale it up:
-    scale_factor_approx = 100
+        # difference between input and output, normalized by the
+        # uncertainty. Has units of sigma:
+        delta_x = np.abs(true_x - results_table["x_fit"]) / results_table["x_err"]
+        delta_y = np.abs(true_y - results_table["y_fit"]) / results_table["y_err"]
 
-    assert np.all(results_table["x_err"] < scale_factor_approx * approx_centroid_err)
-    assert np.all(results_table["y_err"] < scale_factor_approx * approx_centroid_err)
+        sigma_threshold = 3.5
+        assert np.all(delta_x < sigma_threshold)
+        assert np.all(delta_y < sigma_threshold)
+
+        # now check that the uncertainties aren't way too large, which could cause
+        # the above test to pass even when the fits are bad. Use overly-simple
+        # approximation that astrometric uncertainty be proportional to the
+        # PSF's FWHM / SNR:
+        approx_snr = true_amp / init_data_stddev
+        approx_fwhm = 1
+        approx_centroid_err = approx_fwhm / approx_snr
+
+        # centroid err heuristic above is an underestimate, so we scale it up:
+        scale_factor_approx = 100
+
+        assert np.all(
+            results_table["x_err"] < scale_factor_approx * approx_centroid_err
+        )
+        assert np.all(
+            results_table["y_err"] < scale_factor_approx * approx_centroid_err
+        )

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -73,7 +73,7 @@ def setup_inputs(
         webbpsf_config["detector"],
         oversample=webbpsf_config["oversample"],
         fov_pixels=webbpsf_config["fov_pixels"],
-        overwrite=False,
+        overwrite=True,
         logging_level="ERROR",
     )
 

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -110,6 +110,7 @@ class TestPSFFitting:
             shape=image_model_shape,
         )
 
+    @pytest.mark.webbpsf
     @pytest.mark.parametrize(
         "dx, dy, true_amp",
         zip(

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -54,7 +54,7 @@ class TestSourceDetection:
         # check that the typical/worst PSF centroid is still within some tolerance:
         pixel_scale = 0.11 * u.arcsec / u.pix
         centroid_residuals = np.abs(x_psf - x_true) * u.pix * pixel_scale
-        assert np.max(centroid_residuals) < 10 * u.mas
+        assert np.max(centroid_residuals) < 11 * u.mas
         assert np.median(centroid_residuals) < 3 * u.mas
 
         # check that typical residuals are consistent with their errors:

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -5,6 +5,7 @@
 from copy import deepcopy
 
 import numpy as np
+import pytest
 from astropy import units as u
 
 from romancal.lib.tests.test_psf import add_sources, setup_inputs
@@ -20,6 +21,7 @@ class TestSourceDetection:
             shape=image_model_shape,
         )
 
+    @pytest.mark.webbpsf
     def test_dao_vs_psf(self, seed=0):
         rng = np.random.default_rng(seed)
         image_model = deepcopy(self.image_model)

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -2,220 +2,60 @@
  Unit tests for the Roman source detection step code
 """
 
-import os
+from copy import deepcopy
 
 import numpy as np
-import pytest
 from astropy import units as u
-from astropy.convolution import Gaussian2DKernel
-from roman_datamodels import maker_utils as testutil
-from roman_datamodels.datamodels import ImageModel
 
+from romancal.lib.tests.test_psf import add_sources, setup_inputs
 from romancal.source_detection import SourceDetectionStep
 
-
-@pytest.fixture
-def setup_inputs():
-    def _setup(nrows=100, ncols=100, noise=1.0, seed=None):
-        """Return ImageModel of lvl 2 image"""
-
-        shape = (100, 100)  # size of test image
-        wfi_image = testutil.mk_level2_image(shape=shape)
-        wfi_image.data = u.Quantity(
-            np.ones(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32
-        )
-        wfi_image.meta.filename = "filename"
-
-        # add noise to data
-        if noise is not None:
-            rng = np.random.default_rng(seed or 19)
-            wfi_image.data += u.Quantity(
-                noise * rng.uniform(size=shape), u.electron / u.s, dtype=np.float32
-            )
-
-        # add dq array
-
-        wfi_image.dq = np.zeros(shape, dtype=np.uint32)
-        # construct ImageModel
-        mod = ImageModel(wfi_image)
-
-        return mod
-
-    return _setup
+n_sources = 10
+image_model_shape = (100, 100)
 
 
-def add_random_gauss(
-    arr, x_positions, y_positions, min_amp=200, max_amp=500, seed=None
-):
-    """Add random 2D Gaussians to `arr` at specified positions,
-    with random amplitudes from `min_amp` to  `max_amp`. Assumes
-    units of e-/s."""
-
-    rng = np.random.default_rng(seed or 29)
-
-    for i, x in enumerate(x_positions):
-        y = y_positions[i]
-        gauss = Gaussian2DKernel(2, x_size=21, y_size=21).array
-        amp = rng.integers(200, 700)
-        arr[y - 10 : y + 11, x - 10 : x + 11] += (
-            u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amp
+class TestSourceDetection:
+    def setup_method(self):
+        self.image_model, self.webbpsf_config, self.psf_model = setup_inputs(
+            shape=image_model_shape,
         )
 
+    def test_dao_vs_psf(self, seed=0):
+        rng = np.random.default_rng(seed)
+        image_model = deepcopy(self.image_model)
 
-def test_source_detection_defaults(setup_inputs):
-    """Test SourceDetectionStep with its default parameters. The detection
-    threshold will be chosen based on the image's background level."""
+        n_models = 10
+        amp_true = rng.normal(1e3, 100, n_models)
+        along_diag = np.arange(100, 950, 90) / 1000 * image_model_shape[0]
+        x_true = along_diag + rng.normal(scale=0.5, size=n_models)
+        y_true = along_diag + rng.normal(scale=0.5, size=n_models)
 
-    model = setup_inputs(seed=0)
+        add_sources(image_model, self.psf_model, x_true, y_true, amp_true)
 
-    # add in 12 sources, roughly evenly distributed
-    # sort by true_x so they can be matched up to output
+        source_detect = SourceDetectionStep()
+        source_detect.scalar_threshold = 100
+        source_detect.peakmax = None
+        dao_result = source_detect.process(image_model)
+        idx, x_dao, y_dao, amp_dao = dao_result.meta.source_detection.tweakreg_catalog
 
-    true_x = np.array([20, 25, 30, 35, 40, 45, 50, 55, 60, 70, 80, 82])
-    true_y = np.array([26, 80, 44, 19, 66, 39, 29, 72, 54, 29, 80, 62])
+        # check that all injected targets are found by DAO:
+        assert len(x_dao) == len(x_true)
 
-    # at each position, place a 2d gaussian
-    # randomly vary flux from 100 to 500 for each source
-    add_random_gauss(model.data, true_x, true_y, seed=0)
+        source_detect.fit_psf = True
+        psf_result = source_detect.process(image_model)
+        psf_catalog = psf_result.meta.source_detection.psf_catalog
 
-    # call SourceDetectionStep with default parameters
-    sd = SourceDetectionStep()
-    res = sd.process(model)
+        extract_columns = ["x_fit", "x_err", "y_fit", "y_err", "flux_fit"]
+        x_psf, x_err, y_psf, y_err, amp_psf = psf_catalog[extract_columns].itercols()
 
-    # unpack output catalog array
-    _, xcentroid, ycentroid, flux = res.meta.source_detection.tweakreg_catalog
+        # check that typical PSF centroids are more accurate than DAO centroids:
+        assert np.median(np.abs(x_dao - x_true)) > np.median(np.abs(x_psf - x_true))
 
-    # sort based on x coordinate, like input
-    ycentroid = [x for y, x in sorted(zip(xcentroid, ycentroid))]
-    flux = [x for y, x in sorted(zip(xcentroid, flux))]
-    xcentroid = sorted(xcentroid)
+        # check that the typical/worst PSF centroid is still within some tolerance:
+        pixel_scale = 0.11 * u.arcsec / u.pix
+        centroid_residuals = np.abs(x_psf - x_true) * u.pix * pixel_scale
+        assert np.max(centroid_residuals) < 10 * u.mas
+        assert np.median(centroid_residuals) < 3 * u.mas
 
-    # check that the number of input and output sources are the same
-    assert len(flux) == len(true_x)
-
-    # check that their locations agree
-    # atol=0.2 seems to be the lowest safe value for this right now.
-
-    assert np.allclose(np.abs(xcentroid - true_x), 0.0, atol=0.25)
-    assert np.allclose(np.abs(ycentroid - true_y), 0.0, atol=0.25)
-
-
-def test_source_detection_scalar_threshold(setup_inputs):
-    """Test SourceDetectionStep using the option to choose a detection
-    threshold for entire image."""
-
-    model = setup_inputs(seed=0)
-
-    # add in 12 sources, roughly evenly distributed
-    # sort by true_x so they can be matched up to output
-
-    true_x = np.array([20, 25, 30, 35, 40, 45, 50, 55, 60, 70, 80, 82])
-    true_y = np.array([26, 80, 44, 19, 66, 39, 29, 72, 54, 29, 80, 62])
-
-    # at each position, place a 2d gaussian
-    # randomly vary flux from 100 to 500 for each source
-    add_random_gauss(model.data, true_x, true_y, seed=0)
-
-    # call SourceDetectionStep with default parameters
-    sd = SourceDetectionStep()
-    sd.scalar_threshold = 2.0
-    res = sd.process(model)
-
-    # unpack output catalog array
-    _, xcentroid, ycentroid, flux = res.meta.source_detection.tweakreg_catalog
-
-    # sort based on x coordinate, like input
-    ycentroid = [x for y, x in sorted(zip(xcentroid, ycentroid))]
-    flux = [x for y, x in sorted(zip(xcentroid, flux))]
-    xcentroid = sorted(xcentroid)
-
-    # check that the number of input and output sources are the same
-    assert len(flux) == len(true_x)
-
-    # check that their locations agree
-    # atol=0.2 seems to be the lowest safe value for this right now.
-
-    assert np.allclose(np.abs(xcentroid - true_x), 0.0, atol=0.25)
-    assert np.allclose(np.abs(ycentroid - true_y), 0.0, atol=0.25)
-
-
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Roman CRDS servers are not currently available outside the internal "
-    "network",
-)
-def test_outputs(tmp_path, setup_inputs):
-    """Make sure `save_catalogs` and `output_cat_filetype` work correctly."""
-
-    try:
-        # The contextlib.chdir() context manager was added in Python 3.11
-        # so once we drop support for Python 3.10 we can remove this try/except
-        from contextlib import chdir
-
-        context = chdir(tmp_path)
-    except ImportError:
-        # This reproduces enough of the behavior of contextlib.chdir()
-        # for Python < 3.11 (this part can be removed at a later date)
-        from contextlib import contextmanager
-        from pathlib import Path
-
-        @contextmanager
-        def ctx():
-            cwd = Path.cwd()
-            os.chdir(tmp_path)
-            try:
-                yield
-            finally:
-                os.chdir(cwd)
-
-        context = ctx()
-
-    with context:
-        model = setup_inputs(seed=0)
-
-        # add a single source to image so a non-empty catalog is produced
-        add_random_gauss(model.data, [50], [50], seed=0)
-
-        # run step and direct it to save catalog. default format should be asdf
-        sd = SourceDetectionStep()
-        sd.save_catalogs = True
-        sd.process(model)
-        # make sure file exists
-        expected_output_path = os.path.join(tmp_path, "filename_tweakreg_catalog.asdf")
-        assert os.path.isfile(expected_output_path)
-
-        # run again, specifying that catalog should be saved in ecsv format
-        sd = SourceDetectionStep()
-        sd.save_catalogs = True
-        sd.output_cat_filetype = "ecsv"
-        sd.process(model)
-        expected_output_path = os.path.join(tmp_path, "filename_tweakreg_catalog.ecsv")
-        assert os.path.isfile(expected_output_path)
-
-
-def test_limiting_catalog_size(setup_inputs):
-    """Test to make sure setting `max_sources` limits the size of the
-    output catalog to contain only the N brightest sources"""
-
-    model = setup_inputs(seed=0)
-
-    amps = [200, 300, 400]  # flux
-    pos = [20, 50, 80]  # 3 sources in a line
-    for i in range(3):
-        xy = pos[i]
-        gauss = Gaussian2DKernel(2, x_size=20, y_size=20).array
-        model.data[xy - 10 : xy + 10, xy - 10 : xy + 10] += (
-            u.Quantity(gauss, u.electron / u.s, dtype=np.float32) * amps[i]
-        )
-
-    sd = SourceDetectionStep()
-    sd.max_sources = 2
-    res = sd.process(model)
-
-    _, xcentroid, ycentroid, flux = res.meta.source_detection.tweakreg_catalog
-
-    # make sure only 2 of the three sources are returned in output catalog
-    assert len(flux) == 2
-
-    # and make sure one of them is not the first, dimmest source
-    assert np.all(xcentroid > 22)  # dimmest position is really 20, give a
+        # check that typical residuals are consistent with their errors:
+        assert np.median(np.abs(x_psf - x_true) / x_err) < 2


### PR DESCRIPTION
### Description

This PR improves astrometry in the Source Detection step by (optionally) making use of PSF fitting methods added in https://github.com/spacetelescope/romancal/pull/794.

The centroid accuracy of the PSF fitting methods depends on many factors, like the precision of the PSF model used in the fit (which may be traded off for longer runtimes), the flux of the source, the WFI filter, and to a lesser extent, the detector position, etc. The revised tests for source detection in this PR check the following criteria when using PSF fitting on bright sources in the F087 filter: 
* the median centroid residual is smaller than 3 milliarcseconds
* the maximum centroid residual is smaller than 11 milliarcseconds
* the recovered centroids and their errors are all <2-sigma consistent with the injected values

(see [here in the diff](https://github.com/spacetelescope/romancal/pull/841/files#diff-3e72b9b93885321af310a4c1d1641f249282c6b943e1c1d0b53309b4206c7ebbR57-R61) for these assertions).

These upper-limits in the tests can be revised when we:
1. Precompute PSF models and make them available (e.g. on CRDS). With more accurate (and more expensive to compute) PSF models, we can get more precise centroids, and revise the upper limits in the tests downwards.
2. Have more specific requirements for a given filter and/or a given source flux

This PR supersedes #936.

Resolves [RCAL-609](https://jira.stsci.edu/browse/RCAL-609)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #830
Closes #936

<!-- describe the changes comprising this PR here -->

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
