### PR TITLE
Fix typo from #831

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ pass_env =
     CODECOV_*
     DD_*
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simpl
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 extras =
     test


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
A url was accidentally broken in the changes from #831. This prevents us from actually testing against the weekly wheels from numpy and scipy.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
