### PR TITLE
Fix `get_crds_parameters` for `ModelContainer`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.13.0 (unreleased)
 ===================
 
--
+general
+-------
+
+- Fix bug with ``ModelContainer.get_crds_parameters`` being a property not a method [#846]
 
 0.12.0 (2023-08-18)
 ===================

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -512,7 +512,6 @@ class ModelContainer(Sequence):
         """
         return "roman"
 
-    @property
     def get_crds_parameters(self):
         """
         Get parameters used by CRDS to select references for this model.

--- a/romancal/datamodels/tests/test_datamodels.py
+++ b/romancal/datamodels/tests/test_datamodels.py
@@ -359,17 +359,11 @@ def test_get_crds_parameters(n, obj_type, tmp_path, request):
         n, obj_type, tmp_path
     )
 
-    mc = ModelContainer(filepath_list)
-
-    res = mc.get_crds_parameters
-
-    assert isinstance(res, dict)
+    assert isinstance(ModelContainer(filepath_list).get_crds_parameters(), dict)
 
 
 def test_get_crds_parameters_empty():
-    mc = ModelContainer()
-
-    crds_param = mc.get_crds_parameters
+    crds_param = ModelContainer().get_crds_parameters()
 
     assert isinstance(crds_param, dict)
     assert len(crds_param) == 0


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Part of the purpose for `ModelContainer.get_crds_parameters` is so that `stpipe` can detect that a `ModelContainer` fits the description of a `DataModel` and that `stpipe` can then perform its actions on the `ModelContainer` object. It does this by checking the `ModelContainer` against: https://github.com/spacetelescope/stpipe/blob/6f84b52ffcce764a94806a35f5aefd28f3e8f8eb/src/stpipe/datamodel.py#L4-L68
However, this check only checks for the existence of these features: https://github.com/spacetelescope/stpipe/blob/6f84b52ffcce764a94806a35f5aefd28f3e8f8eb/src/stpipe/datamodel.py#L25-L29 not that they follow the template defined in `stpipe` in general.

Currently, `ModelContainer.get_crds_parameters` is defined as a property not a method which means it cannot be executed as a function. This is contrary to https://github.com/spacetelescope/stpipe/blob/6f84b52ffcce764a94806a35f5aefd28f3e8f8eb/src/stpipe/datamodel.py#L39-L45 defining it as a method.

This PR drops turning `get_crds_parameters` into a property.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
