### PR TITLE
use filename instead of meta.filename for exposure pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,12 @@ general
 
 - Fix bug with ``ModelContainer.get_crds_parameters`` being a property not a method [#846]
 
+- Use filename instead of ``meta.filename`` for ``ExposurePipeline`` [#850]
+
 ramp_fitting
 ------------
 
 - Inititial implementation of the Uneven Ramp fitting [#779]
-
 
 0.12.0 (2023-08-18)
 ===================


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #818

<!-- describe the changes comprising this PR here -->
Use actual filename instead of `meta.filename` for `ExposurePipeline` to match behavior prior to #802 

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
