### PR TITLE
Fix RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,6 @@ conda:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD has removed the `system_packages` configuration option. We have only being setting this to false so this change does not affect how our docs are built in any meaningful way.

This PR removes the `system_packages` setting from our RTD configuration.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
