### PR TITLE
fix opening mode for references to be read-only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ ramp_fitting
 
 - Inititial implementation of the Uneven Ramp fitting [#779]
 
+- Fix opening mode for references to be read-only [#854]
+
 
 0.12.0 (2023-08-18)
 ===================

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -43,9 +43,9 @@ class RampFitStep(RomanStep):
             readnoise_filename = self.get_reference_file(input_model, "readnoise")
             gain_filename = self.get_reference_file(input_model, "gain")
             log.info("Using READNOISE reference file: %s", readnoise_filename)
-            readnoise_model = rdd.open(readnoise_filename, mode="rw")
+            readnoise_model = rdd.open(readnoise_filename, mode="r")
             log.info("Using GAIN reference file: %s", gain_filename)
-            gain_model = rdd.open(gain_filename, mode="rw")
+            gain_model = rdd.open(gain_filename, mode="r")
 
             # Do the fitting.
             algorithm = self.algorithm.lower()


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses an issue where the `ramp_fit_step` was opening CRDS references files as read-write. This prevents use of a Central Store cache. Also, in principle, there is no reason to modify CRDS references.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- ~updated relevant tests~
- ~updated relevant documentation~
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
