### PR TITLE
RCAL-643 Update roman CI/CD to use CRDS local cache

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
-      CRDS_PATH: /tmp/crds_cache
+      CRDS_SERVER_URL: https://serverless
+      CRDS_PATH: /grp/crds/roman/test
     steps:
       - id: context
         run: >

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_PATH: /tmp/crds_cache
-      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+      CRDS_SERVER_URL: https://serverless
+      CRDS_PATH: /grp/crds/roman/test
     steps:
       - id: context
         run: >

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -53,8 +53,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_CONTEXT=roman_0051.pmap",
-    "CRDS_SERVER_URL=https://roman-crds.stsci.edu",
-    'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
+    "CRDS_SERVER_URL=https://serverless",
+    'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -53,8 +53,8 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_CONTEXT=roman_0051.pmap",
-    "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
-    'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
+    "CRDS_SERVER_URL=https://serverless",
+    'CRDS_PATH=/grp/crds/roman/test/',
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-643](https://jira.stsci.edu/browse/rcal-643)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #856

<!-- describe the changes comprising this PR here -->
This updates the roman_ci.yml and roman_ci_cron.yml to use the local roman crds cache with
      CRDS_SERVER_URL: https://serverless
      CRDS_PATH: /grp/crds/roman/test

**Checklist**
- [N/A] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)

The regression tests pass (https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/338/)