### PR TITLE
set CRDS_LOCKING_MODE=filelock in jenkins runs

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -55,6 +55,7 @@ env_vars = [
     "CRDS_CONTEXT=roman_0051.pmap",
     "CRDS_SERVER_URL=https://roman-crds.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
+    'CRDS_LOCKING_MODE=filelock',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',
 ]

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -55,6 +55,7 @@ env_vars = [
     "CRDS_CONTEXT=roman_0051.pmap",
     "CRDS_SERVER_URL=https://roman-crds-test.stsci.edu",
     'CRDS_PATH=${WORKSPACE}/roman-crds-test-cache',
+    'CRDS_LOCKING_MODE=filelock',
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))


### PR DESCRIPTION
Jenkins runs are using xdist which can cause seemingly random errors when two simultaneous tests fetch the same reference file. Setting `CRDS_LOCKING_MODE=filelock` should allow the jenkins runs to lock the crds cache across the processes used for the xdist run to avoid these errors. More information about the `filelock` setting can be found in the [JWST CRDS docs](https://github.com/spacetelescope/crds/blob/456d62bb53d923fbd7d5779b8a993278c40d3002/documentation/crds_users_guide/source/environment.rst#file-based-locking)

A minimal example of the issue is as follows:
```python
import os
from stpipe import crds_client


def fetch():
    params = {
        'roman.meta.instrument.optical_element': 'F158',
        'roman.meta.instrument.name': 'WFI',
        'roman.meta.model_type': 'WfiScienceRaw',
        'roman.meta.telescope': 'ROMAN',
        'roman.meta.exposure.start_time': '2021-01-01T00:00:00.000',
        'roman.meta.instrument.detector': 'WFI01'
    }
    reference_file_type = 'linearity'
    observatory = 'roman'
    reference_name = crds_client.get_reference_file(params, reference_file_type, observatory)
    return os.path.getsize(reference_name)


def test_fetch_1():
    assert fetch() == 536872886


def test_fetch_2():
    assert fetch() == 536872886
```

Running the above with pytest xdist can (and seemingly often) result in a failure if `CRDS_LOCKING_MODE=filelock` is not set. The failure occurs because one test will start downloading the reference file (creating the file in the crds cache), the second test sees the file and assumes it's good (crds does not check that the file is valid see https://github.com/spacetelescope/crds/issues/930).

Regression tests running at: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/341/

Tests finished with no errors.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
