### PR TITLE
PSF fitting random seed fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ general
 
 - Fix bug with ``ModelContainer.get_crds_parameters`` being a property not a method [#846]
 
+- Fix random seed bug in PSF fitting methods [#862]
+
 ramp_fitting
 ------------
 

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -90,7 +90,7 @@ def add_synthetic_sources(
         model_data = fit_model(xx, yy) * image_model.data.unit
         model_err = np.sqrt(model_data.value) * model_data.unit
         synth_image[slc_lg] += (
-            np.random.normal(
+            rng.normal(
                 model_data.to_value(image_model.data.unit),
                 model_err.to_value(image_model.data.unit),
                 size=model_data.shape,


### PR DESCRIPTION

794 introduced PSF fitting methods, but one of the tests generated random sources without being reproducibly seeded, causing [some tests to fail](https://github.com/spacetelescope/romancal/actions/runs/6160941537/job/16719049660). This PR should fix it.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
