### PR TITLE
Add NumPy ruff rule set checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ exclude = [
 ignore = [
     'E741', # ambiguous variable name
 ]
+extend-select = ['NPY']
 
 [tool.ruff.extend-per-file-ignores]
 "romancal/associations/__init__.py" = ["E402"]

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -80,7 +80,7 @@ def make_output_wcs(
     )
 
     # Check that the output data shape has no zero length dimensions
-    if not np.product(output_wcs.array_shape):
+    if not np.prod(output_wcs.array_shape):
         raise ValueError(
             f"Invalid output frame shape: {tuple(output_wcs.array_shape)}; dimensions"
             " must have length > 0."


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
PRs #771 and #862 were both made in order to cleanup our use of `numpy.random` so that our tests were more controllable, in particular #862  needed to fix intermittent failures due to "bad" random draws.

The `ruff` rule set [`NPY`](https://beta.ruff.rs/docs/rules/#numpy-specific-rules-npy), specifically has [`NPY002`](https://beta.ruff.rs/docs/rules/numpy-legacy-random/) which checks for use of the legacy NumPy randomness system, which is what was the heart of one was being corrected by #771 and #862. Additionally, its other rules will help us avoid some of the use of deprecated NumPy 2.0 functionality by automatically fixing the names of things to their non-deprecated name.

This PR adds the `NPY` rules to the rules being checked by `ruff` in order to help us avoid future randomness issues, and prevent us from using some deprecated NumPy API.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
