### PR TITLE
Remove style check from CI

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -72,7 +72,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: check-style
         - linux: check-dependencies
         - linux: build-dist
   test:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
`romancal` already uses the pre-commit.ci robot has part of its CI. This robot runs all of our style checks and reports if they pass or not in addition to offering autofixes for some style issues. The former is duplicated by the current `check-style` check, meaning that it is now unnecessary.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
