### PR TITLE
return a value for compare_asdf

### DIFF
--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -528,5 +528,4 @@ def _data_glob_url(*url_parts, root=None):
 def compare_asdf(result, truth, **kwargs):
     f = StringIO()
     asdf_diff([result, truth], minimal=False, iostream=f, **kwargs)
-    if f.getvalue():
-        f.getvalue()
+    return f.getvalue() or None


### PR DESCRIPTION
There are many uses of `compare_asdf` in the regression tests like the following:
https://github.com/spacetelescope/romancal/blob/68e6e0d33129c5c60d46ddc6f1eaceeaba17635a/romancal/regtest/test_wfi_pipeline.py#L43

These `assert`s are always `True` as `compare_asdf` does not return a value (so it's output will always be `None`).
https://github.com/spacetelescope/romancal/blob/68e6e0d33129c5c60d46ddc6f1eaceeaba17635a/romancal/regtest/regtestdata.py#L528-L532

This PR updates `compare_asdf` to output the string output of the diff or None if the string is empty (as is seen when the compared files are identical).

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
