### PR TITLE
fix caching and outputs

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -35,7 +35,7 @@ jobs:
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
     steps:
       # crds:
-      - id: context
+      - id: crds_context
         run: >
           echo "pmap=$(
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
@@ -43,9 +43,9 @@ jobs:
           )" >> $GITHUB_OUTPUT
         # Get default CRDS_CONTEXT without installing crds client
         # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
-      - id: path
+      - id: crds_path
         run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
-      - id: server
+      - id: crds_server
         run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
       # webbpsf:
       - uses: actions/checkout@v3

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -53,15 +53,14 @@ jobs:
           fetch-depth: 0
       - id: data
         run: |
-          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
           echo "path=/tmp/data" >> $GITHUB_OUTPUT
-      - run: |
-          mkdir -p ${{ steps.data.outputs.path }}
-          wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
-          cd ${{ steps.data.outputs.path }}
-          tar -xzvf minimal-webbpsf-data.tar.gz
+          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+      - run: mkdir -p ${{ steps.data.outputs.path }}
+      - run: wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
+      - run: tar -xzvf minimal-webbpsf-data.tar.gz
+        working-directory: ${{ steps.data.outputs.path }}
       - id: data_hash
-        run: echo "hash=${{ hashFiles( '/tmp/data' ) }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles( steps.data.outputs.path ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -61,7 +61,7 @@ jobs:
           cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz
       - id: data_hash
-        run: echo "hash=${{ hashFiles( steps.data.outputs.path ) }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles( '/tmp/data' ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -28,11 +28,12 @@ jobs:
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
-      crds_context: ${{ steps.crds_context.outputs.pmap }}
-      crds_path: ${{ steps.crds_path.outputs.path }}
-      crds_server: ${{ steps.crds_server.outputs.url }}
-      data_hash: ${{ steps.data_hash.outputs.hash }}
+      data_path: ${{ steps.data.outputs.path }}
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
+      data_hash: ${{ steps.data_hash.outputs.hash }}
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
     steps:
       # crds:
       - id: crds_context
@@ -66,7 +67,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}
-          key: data-${{ steps.data_hash.outputs.hash }}
+          key: data-${{ steps.data_hash.outputs.hash }}-${{ steps.crds_context.outputs.pmap }}
       - id: webbpsf_path
         run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
   check:
@@ -80,6 +81,7 @@ jobs:
     needs: [ data ]
     with:
       setenv: |
+        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
         CRDS_PATH: ${{ needs.data.outputs.crds_path }}
         CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
@@ -89,9 +91,8 @@ jobs:
         DD_GIT_REPOSITORY_URL: ${{ github.repositoryUrl }}
         DD_GIT_COMMIT_SHA: ${{ github.sha }}
         DD_GIT_BRANCH: ${{ github.ref_name }}
-        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
-      cache-path: ${{ needs.data.outputs.crds_path }}
-      cache-key: data-${{ needs.data.outputs.data_hash }}
+      cache-path: ${{ needs.data.outputs.data_path }}
+      cache-key: data-${{ needs.data.outputs.data_hash }}-${{ needs.data.outputs.crds_context }}
       envs: |
         - linux: py39-oldestdeps-cov
           pytest-results-summary: true

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -28,10 +28,10 @@ jobs:
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
-      context: ${{ steps.context.outputs.pmap }}
-      path: ${{ steps.path.outputs.path }}
-      server: ${{ steps.server.outputs.url }}
-      hash: ${{ steps.data_hash.outputs.hash }}
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
+      data_hash: ${{ steps.data_hash.outputs.hash }}
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
     steps:
       # crds:
@@ -61,7 +61,7 @@ jobs:
           cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz
       - id: data_hash
-        run: echo "hash=${{ steps.data.outputs.hash }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles( steps.data.outputs.path ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}
@@ -79,8 +79,8 @@ jobs:
     needs: [ data ]
     with:
       setenv: |
-        CRDS_PATH: ${{ needs.crds.outputs.path }}
-        CRDS_SERVER_URL: ${{ needs.crds.outputs.server }}
+        CRDS_PATH: ${{ needs.data.outputs.crds_path }}
+        CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
         DD_SERVICE: romancal
@@ -88,9 +88,9 @@ jobs:
         DD_GIT_REPOSITORY_URL: ${{ github.repositoryUrl }}
         DD_GIT_COMMIT_SHA: ${{ github.sha }}
         DD_GIT_BRANCH: ${{ github.ref_name }}
-        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
-      cache-path: ${{ needs.data.outputs.path }}
-      cache-key: data-${{ needs.data.outputs.hash }}
+        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_data_path }}
+      cache-path: ${{ needs.data.outputs.crds_path }}
+      cache-key: data-${{ needs.data.outputs.data_hash }}
       envs: |
         - linux: py39-oldestdeps-cov
           pytest-results-summary: true

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -57,8 +57,7 @@ jobs:
           echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
       - run: mkdir -p ${{ steps.data.outputs.path }}
       - run: wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
-      - run: tar -xzvf minimal-webbpsf-data.tar.gz
-        working-directory: ${{ steps.data.outputs.path }}
+      - run: tar -xzvf ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz -C ${{ steps.data.outputs.path }}
       - id: data_hash
         run: echo "hash=${{ hashFiles( steps.data.outputs.path ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -55,11 +55,14 @@ jobs:
         run: |
           echo "path=/tmp/data" >> $GITHUB_OUTPUT
           echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
-      - run: mkdir -p ${{ steps.data.outputs.path }}
-      - run: wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
-      - run: tar -xzvf ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz -C ${{ steps.data.outputs.path }}
+      - run: |
+          mkdir -p tmp/data/
+          mkdir -p ${{ steps.data.outputs.path }}
+      - run: wget ${{ steps.data.outputs.webbpsf_url }} -O tmp/minimal-webbpsf-data.tar.gz
+      - run: tar -xzvf tmp/minimal-webbpsf-data.tar.gz -C tmp/data/
       - id: data_hash
-        run: echo "hash=${{ hashFiles( '/tmp/data/**' ) }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles( 'tmp/data' ) }}" >> $GITHUB_OUTPUT
+      - run: mv tmp/data/* ${{ steps.data.outputs.path }}
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}
@@ -86,7 +89,7 @@ jobs:
         DD_GIT_REPOSITORY_URL: ${{ github.repositoryUrl }}
         DD_GIT_COMMIT_SHA: ${{ github.sha }}
         DD_GIT_BRANCH: ${{ github.ref_name }}
-        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_data_path }}
+        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: data-${{ needs.data.outputs.data_hash }}
       envs: |

--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -59,7 +59,7 @@ jobs:
       - run: wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
       - run: tar -xzvf ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz -C ${{ steps.data.outputs.path }}
       - id: data_hash
-        run: echo "hash=${{ hashFiles( steps.data.outputs.path ) }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles( '/tmp/data/**' ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -1,4 +1,3 @@
-
 name: Weekly cron
 
 on:
@@ -14,6 +13,10 @@ on:
   push:
     tags: "*"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   data:

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -44,7 +44,7 @@ jobs:
   test:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-    needs: [ crds ]
+    needs: [ data ]
     with:
       setenv: |
         CRDS_PATH: ${{ needs.data.outputs.crds_path }}

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -28,11 +28,12 @@ jobs:
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
-      crds_context: ${{ steps.crds_context.outputs.pmap }}
-      crds_path: ${{ steps.crds_path.outputs.path }}
-      crds_server: ${{ steps.crds_server.outputs.url }}
-      data_hash: ${{ steps.data_hash.outputs.hash }}
+      data_path: ${{ steps.data.outputs.path }}
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
+      data_hash: ${{ steps.data_hash.outputs.hash }}
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
     steps:
       # crds:
       - id: crds_context
@@ -66,7 +67,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ steps.data.outputs.path }}
-          key: data-${{ steps.data_hash.outputs.hash }}
+          key: data-${{ steps.data_hash.outputs.hash }}-${{ steps.crds_context.outputs.pmap }}
       - id: webbpsf_path
         run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
   test:
@@ -75,13 +76,13 @@ jobs:
     needs: [ data ]
     with:
       setenv: |
+        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
         CRDS_PATH: ${{ needs.data.outputs.crds_path }}
         CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
       cache-path: ${{ needs.data.outputs.crds_path }}
-      cache-key: data-${{ needs.data.outputs.data_hash }}
+      cache-key: data-${{ needs.data.outputs.data_hash }}-${{ needs.data.outputs.crds_context }}
       envs: |
         - linux: py39-devdeps
           pytest-results-summary: true

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  crds:
+  data:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     name: retrieve current CRDS context
     runs-on: ubuntu-latest
@@ -38,21 +38,21 @@ jobs:
       - id: server
         run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
     outputs:
-      context: ${{ steps.context.outputs.pmap }}
-      path: ${{ steps.path.outputs.path }}
-      server: ${{ steps.server.outputs.url }}
+      crds_context: ${{ steps.context.outputs.pmap }}
+      crds_path: ${{ steps.path.outputs.path }}
+      crds_server: ${{ steps.server.outputs.url }}
   test:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ crds ]
     with:
       setenv: |
-        CRDS_PATH: ${{ needs.crds.outputs.path }}
-        CRDS_SERVER_URL: ${{ needs.crds.outputs.server }}
+        CRDS_PATH: ${{ needs.data.outputs.crds_path }}
+        CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-      cache-path: ${{ needs.crds.outputs.path }}
-      cache-key: crds-${{ needs.crds.outputs.context }}
+      cache-path: ${{ needs.data.outputs.crds_path }}
+      cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
         - linux: py39-devdeps
           pytest-results-summary: true

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -21,13 +21,20 @@ concurrency:
 jobs:
   data:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
-    name: retrieve current CRDS context
+    name: retrieve current CRDS context, and WebbPSF data
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_PATH: /tmp/data
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+      CRDS_PATH: /tmp/data
+    outputs:
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
+      data_hash: ${{ steps.data_hash.outputs.hash }}
+      webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
     steps:
+      # crds:
       - id: crds_context
         run: >
           echo "pmap=$(
@@ -40,10 +47,28 @@ jobs:
         run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
       - id: crds_server
         run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
-    outputs:
-      crds_context: ${{ steps.context.outputs.pmap }}
-      crds_path: ${{ steps.path.outputs.path }}
-      crds_server: ${{ steps.server.outputs.url }}
+      # webbpsf:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: data
+        run: |
+          echo "path=/tmp/data" >> $GITHUB_OUTPUT
+          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+      - run: |
+          mkdir -p tmp/data/
+          mkdir -p ${{ steps.data.outputs.path }}
+      - run: wget ${{ steps.data.outputs.webbpsf_url }} -O tmp/minimal-webbpsf-data.tar.gz
+      - run: tar -xzvf tmp/minimal-webbpsf-data.tar.gz -C tmp/data/
+      - id: data_hash
+        run: echo "hash=${{ hashFiles( 'tmp/data' ) }}" >> $GITHUB_OUTPUT
+      - run: mv tmp/data/* ${{ steps.data.outputs.path }}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.data.outputs.path }}
+          key: data-${{ steps.data_hash.outputs.hash }}
+      - id: webbpsf_path
+        run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
   test:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
@@ -54,8 +79,9 @@ jobs:
         CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+        WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
       cache-path: ${{ needs.data.outputs.crds_path }}
-      cache-key: crds-${{ needs.data.outputs.crds_context }}
+      cache-key: data-${{ needs.data.outputs.data_hash }}
       envs: |
         - linux: py39-devdeps
           pytest-results-summary: true

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -25,7 +25,7 @@ jobs:
       CRDS_PATH: /tmp/data
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
     steps:
-      - id: context
+      - id: crds_context
         run: >
           echo "pmap=$(
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
@@ -33,9 +33,9 @@ jobs:
           )" >> $GITHUB_OUTPUT
         # Get default CRDS_CONTEXT without installing crds client
         # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
-      - id: path
+      - id: crds_path
         run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
-      - id: server
+      - id: crds_server
         run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
     outputs:
       crds_context: ${{ steps.context.outputs.pmap }}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses some issues with caching and using the output variables in the GitHub Actions workflow:
1. the `hashFiles` method apparently only works in the workspace, so attempting to hash `/tmp/data/` silently failed
2. the variable call used the old `crds` job name instead of `data`, so also silently failed

I didn't catch this issue when reviewing #794, but it should be fixed here

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
