### PR TITLE
Fix for failing regression tests from PSF fitting methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ general
 
 - Fix random seed bug in PSF fitting methods [#862]
 
+- Fix regression tests for PSF fitting methods [#872]
+
 ramp_fitting
 ------------
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -57,6 +57,7 @@ env_vars = [
     'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',
+    'WEBBPSF_PATH=${WORKSPACE}/data/webbpsf-data'
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))
@@ -87,6 +88,9 @@ bc0.build_cmds = [
     "pip install -e .[test]",
     "pip install pytest-xdist pytest-sugar ddtrace",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
+    "mkdir ${WORKSPACE}/data",
+    "curl -L https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -o ${WORKSPACE}/data/webbpsf-data.tar.gz",
+    "tar -xzvf ${WORKSPACE}/data/webbpsf-data.tar.gz -C ${WORKSPACE}/data",
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.build_cmds = bc0.build_cmds + [

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -57,7 +57,7 @@ env_vars = [
     'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',
-    'WEBBPSF_PATH=${WORKSPACE}/data/webbpsf-data'
+    'WEBBPSF_PATH=data/webbpsf-data'
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))
@@ -88,9 +88,9 @@ bc0.build_cmds = [
     "pip install -e .[test]",
     "pip install pytest-xdist pytest-sugar ddtrace",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
-    "mkdir ${WORKSPACE}/data",
-    "curl -L https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -o ${WORKSPACE}/data/webbpsf-data.tar.gz",
-    "tar -xzvf ${WORKSPACE}/data/webbpsf-data.tar.gz -C ${WORKSPACE}/data",
+    "mkdir data",
+    "curl -L https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -o data/webbpsf-data.tar.gz",
+    "tar -xzvf data/webbpsf-data.tar.gz -C data",
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.build_cmds = bc0.build_cmds + [


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->

This PR addresses failing regression tests due to the new dependence on WebbPSF in the the PSF fitting methods introduced in #794. 

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
