### PR TITLE
reorganize tests, make devdeps testing optional, and unpin latest Python testing

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+      CRDS_SERVER_URL: https://roman-crds.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
       data_path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+      CRDS_SERVER_URL: https://roman-crds.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
       data_path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -93,4 +93,3 @@ jobs:
           pytest-results-summary: true
         - linux: py3-pyargs
           pytest-results-summary: true
-

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -1,4 +1,4 @@
-name: Weekly cron
+name: test on schedule
 
 on:
   schedule:
@@ -11,7 +11,8 @@ on:
       - synchronize
       - labeled
   push:
-    tags: "*"
+    tags:
+      - "*"
   workflow_dispatch:
 
 concurrency:
@@ -84,31 +85,12 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: data-${{ needs.data.outputs.data_hash }}-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py39-devdeps
-          pytest-results-summary: true
-        - linux: py310-devdeps
-          pytest-results-summary: true
-        - linux: py311-devdeps
-          pytest-results-summary: true
-
-        - macos: py39-devdeps
-          pytest-results-summary: true
-        - macos: py310-devdeps
-          pytest-results-summary: true
-        - macos: py311-devdeps
-          pytest-results-summary: true
-
         - macos: py39
           pytest-results-summary: true
         - macos: py310
           pytest-results-summary: true
-
-        - linux: py39-pyargs
+        - macos: py311-sdpdeps
           pytest-results-summary: true
-        - linux: py310-pyargs
-          pytest-results-summary: true
-        - linux: py311-pyargs
+        - linux: py3-pyargs
           pytest-results-summary: true
 
-        - macos: py39-sdpdeps
-          pytest-results-summary: true

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OBSERVATORY: roman
-      CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
+      CRDS_SERVER_URL: https://roman-crds.stsci.edu
       CRDS_PATH: /tmp/data
     outputs:
       data_path: ${{ steps.data.outputs.path }}

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -86,14 +86,12 @@ jobs:
       cache-key: data-${{ needs.data.outputs.data_hash }}-${{ needs.data.outputs.crds_context }}
       envs: |
         - linux: py39-devdeps
-          pytest-results-summary: true
         - macos: py39-devdeps
-          pytest-results-summary: true
         - linux: py310-devdeps
-          pytest-results-summary: true
         - macos: py310-devdeps
-          pytest-results-summary: true
         - linux: py311-devdeps
-          pytest-results-summary: true
         - macos: py311-devdeps
+        - linux: py3-devdeps
+          pytest-results-summary: true
+        - macos: py3-devdeps
           pytest-results-summary: true

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -1,7 +1,6 @@
-name: test
+name: test with development versions
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -10,10 +9,11 @@ on:
       - '*'
   pull_request:
     branches:
-      - main
+      - master
   schedule:
     # Weekly Monday 9AM build
     - cron: "0 9 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   data:
+    if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     name: retrieve current CRDS context, and WebbPSF data
     runs-on: ubuntu-latest
     env:
@@ -70,13 +71,8 @@ jobs:
           key: data-${{ steps.data_hash.outputs.hash }}-${{ steps.crds_context.outputs.pmap }}
       - id: webbpsf_path
         run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
-  check:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      envs: |
-        - linux: check-dependencies
-        - linux: build-dist
   test:
+    if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ data ]
     with:
@@ -86,24 +82,18 @@ jobs:
         CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-        DD_SERVICE: romancal
-        DD_ENV: ci
-        DD_GIT_REPOSITORY_URL: ${{ github.repositoryUrl }}
-        DD_GIT_COMMIT_SHA: ${{ github.sha }}
-        DD_GIT_BRANCH: ${{ github.ref_name }}
       cache-path: ${{ needs.data.outputs.data_path }}
       cache-key: data-${{ needs.data.outputs.data_hash }}-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py39-oldestdeps-cov
+        - linux: py39-devdeps
           pytest-results-summary: true
-        - linux: py39
+        - macos: py39-devdeps
           pytest-results-summary: true
-        - linux: py310
+        - linux: py310-devdeps
           pytest-results-summary: true
-        - linux: py311-ddtrace
+        - macos: py310-devdeps
           pytest-results-summary: true
-        - macos: py311-ddtrace
+        - linux: py311-devdeps
           pytest-results-summary: true
-        - linux: py311-cov
-          coverage: codecov
+        - macos: py311-devdeps
           pytest-results-summary: true


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-79](https://jira.stsci.edu/browse/SCSB-79)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR reorganizes CI tests and moves devdeps tests to a new optional workflow that can be started with the label `run devdeps tests`

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
