### PR TITLE
RCAL-647 Update pipeline to include refpix step as default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ ramp_fitting
 
 - Fix opening mode for references to be read-only [#854]
 
+refpix
+------
+
+- Update cal_step, add suffix and add to the exposure pipeline [#890]
+  
 
 0.12.0 (2023-08-18)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ refpix
 ------
 
 - Update cal_step, add suffix and add to the exposure pipeline [#890]
-  
+
 
 0.12.0 (2023-08-18)
 ===================

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -132,6 +132,7 @@ class ExposurePipeline(RomanPipeline):
                     "source_detection",
                     "dark",
                     "jump",
+                    "refpix",
                     "linearity",
                     "ramp_fit",
                 ]:
@@ -143,6 +144,7 @@ class ExposurePipeline(RomanPipeline):
                 # Return fully saturated image file (stopping pipeline)
                 return results
 
+            result = self.refpix(result)
             result = self.linearity(result)
             result = self.dark_current(result)
             result = self.jump(result)

--- a/romancal/refpix/refpix_step.py
+++ b/romancal/refpix/refpix_step.py
@@ -54,7 +54,7 @@ class RefPixStep(RomanStep):
                 self.cosine_interpolate,
                 self.fft_interpolate,
             )
-             # Update the step status
+            # Update the step status
             output.meta.cal_step["refpix"] = "COMPLETE"
             if self.save_results:
                 try:

--- a/romancal/refpix/refpix_step.py
+++ b/romancal/refpix/refpix_step.py
@@ -46,7 +46,7 @@ class RefPixStep(RomanStep):
         with rdm.open(ref_file) as refs:
             # Run the correction
             log.debug("Running the reference pixel correction")
-            return refpix.run_steps(
+            output = refpix.run_steps(
                 datamodel,
                 refs,
                 self.remove_offset,
@@ -54,3 +54,11 @@ class RefPixStep(RomanStep):
                 self.cosine_interpolate,
                 self.fft_interpolate,
             )
+             # Update the step status
+            output.meta.cal_step["refpix"] = "COMPLETE"
+            if self.save_results:
+                try:
+                    self.suffix = "refpix"
+                except AttributeError:
+                    self["suffix"] = "refpix"
+        return output

--- a/romancal/regtest/test_refpix.py
+++ b/romancal/regtest/test_refpix.py
@@ -17,7 +17,7 @@ def test_refpix_step(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
 
     # Again I have no idea here
-    output = "r0000101001001001001_01101_0001_WFI01_refpixstep.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_refpix.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-647](https://jira.stsci.edu/browse/rcal-647)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #883 

<!-- describe the changes comprising this PR here -->
This PR adds the refpix step to the standard pipeline processing. It also has the refpix step update the cal_step attribute and uses the standard suffix "refpix" instead of the fallback of "refpixstep".

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
The regression test is at https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/381
besides the known errors that are due to deepdiff, no other errors are seen. 