### PR TITLE
force uninstall `deepdiff` to install the dev version (not dynamically versioned)

### DIFF
--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -83,6 +83,7 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-dev-thirdparty.txt']
 bc0.build_cmds = [
     "pip install -e .[test]",
+    "pip uninstall deepdiff",
     "pip install pytest-xdist pytest-sugar",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where, since `deepdiff` is not dynamically versioned (and thus does not have dev versions e.g. `6.5.0.dev12`), attempting to install the latest commit of `deepdiff` will fail if a wheel of `deepdiff` is already installed. As the Jenkins build workflow does not include support for the `--ignore-installed` option to `pip install`, this uninstalls the existing `deepdiff` installation to overwrite with the development version.

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [ ] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
