### PR TITLE
rcal-681 Update reg tests for new algorithms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 general
 -------
 
+- Update regression tests with new data and update ramp fitting tests to use ols_cas22 [#911]
+
 - Fix bug with ``ModelContainer.get_crds_parameters`` being a property not a method [#846]
 
 - Fix random seed bug in PSF fitting methods [#862]

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -17,8 +17,6 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     args = [
         "romancal.step.RampFitStep",
         rtdata.input,
-        "--save_opt=True",
-        "--opt_name=rampfit_opt.asdf",
     ]
     RomanStep.from_cmdline(args)
     output = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
@@ -27,8 +25,3 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
-    output = "rampfit_opt_fitopt.asdf"
-    rtdata.output = output
-    rtdata.get_truth(f"truth/WFI/image/{output}")
-    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    assert diff.identical, diff.report()

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -24,4 +24,3 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
-

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -15,7 +15,7 @@ from .regtestdata import compare_asdf
 def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using imaging data."""
 
-    input_data = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
+    input_data = "r0000101001001001001_01101_0001_WFI01_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-681](https://jira.stsci.edu/browse/rcal-681)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #909 

<!-- describe the changes comprising this PR here -->
This PR updates reg tests for new algorithms and removal of the optional rampfit output of fitopt since the new ols_cas22 method does not save these. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
All the regression tests now pass with the exception of the tweakreg tests, which need a new custom input file from INS.
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/390