### PR TITLE
add astropy Table support to compare_asdf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ general
   ``asdf.commands.diff`` with ``deepdiff`` and add ``deepdiff`` as
   a test dependency [#868]
 
+- Add ``astropy.table.Table`` support to ``compare_asdf`` [#915]
+
 ramp_fitting
 ------------
 

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -1,3 +1,7 @@
+import asdf
+import astropy.table
+import numpy as np
+import pytest
 from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
@@ -25,3 +29,30 @@ def test_compare_asdf_differ(tmp_path):
     assert not diff.identical, diff.report()
     assert "arrays_differ" in diff.diff
     assert "root['roman']['data']" in diff.diff["arrays_differ"]
+
+
+@pytest.mark.parametrize("modification", [None, "dtype", "names", "values", "meta"])
+def test_compare_asdf_tables(tmp_path, modification):
+    fn0 = tmp_path / "test0.asdf"
+    fn1 = tmp_path / "test1.asdf"
+    names = ("a",)
+    values = [1, 2, 3]
+    dtype = np.uint8
+    t0 = astropy.table.Table([np.array(values, dtype=dtype)], names=names)
+    if modification == "names":
+        names = ("b",)
+    if modification == "values":
+        values = [4, 5, 6]
+    if modification == "dtype":
+        dtype = np.float64
+    t1 = astropy.table.Table([np.array(values, dtype=dtype)], names=names)
+    if modification == "meta":
+        t1.meta["modified"] = True
+    asdf.AsdfFile({"t": t0}).write_to(fn0)
+    asdf.AsdfFile({"t": t1}).write_to(fn1)
+    diff = compare_asdf(fn0, fn1)
+    if modification is None:
+        assert diff.identical, diff.report()
+    else:
+        assert not diff.identical, diff.report()
+        assert "tables_differ" in diff.diff


### PR DESCRIPTION
`tweakreg_catalog` is now stored as an `astropy.table.Table`. This PR adds `astropy.table.Table` support to `compare_asdf` to allow regression tests to compare any `Table` instances (including `tweakreg_catalog`). This should fix tests that are failing with a reported difference that includes the `unprocessed` key (indicating that a portion of the items to being compared could not be processed due to lack of support for `Table` comparisons).

Regression tests all passed: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/393/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
