### PR TITLE
update compare_asdf to use tolerance in more comparisons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ general
 
 - Add ``astropy.table.Table`` support to ``compare_asdf`` [#915]
 
+- Use tolerance for more comparisons in ``compare_asdf`` [#917]
+
 ramp_fitting
 ------------
 

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -8,50 +8,67 @@ from roman_datamodels import maker_utils
 from romancal.regtest.regtestdata import compare_asdf
 
 
-def test_compare_asdf_identical(tmp_path):
+@pytest.mark.parametrize("modification", [None, "small", "large"])
+def test_compare_asdf(tmp_path, modification):
     fn0 = tmp_path / "test0.asdf"
     fn1 = tmp_path / "test1.asdf"
     l2 = rdm.ImageModel(maker_utils.mk_level2_image(shape=(100, 100)))
     l2.save(fn0)
+    atol = 0.0001
+    if modification == "small":
+        l2.data += (atol / 2) * l2.data.unit
+    elif modification == "large":
+        l2.data += (atol * 2) * l2.data.unit
     l2.save(fn1)
-    diff = compare_asdf(fn0, fn1)
-    assert diff.identical, diff.report()
+    diff = compare_asdf(fn0, fn1, atol=atol)
+    if modification == "large":
+        assert not diff.identical, diff.report()
+        assert "arrays_differ" in diff.diff
+        assert "root['roman']['data']" in diff.diff["arrays_differ"]
+    else:
+        assert diff.identical, diff.report()
 
 
-def test_compare_asdf_differ(tmp_path):
-    fn0 = tmp_path / "test0.asdf"
-    fn1 = tmp_path / "test1.asdf"
-    l2 = rdm.ImageModel(maker_utils.mk_level2_image(shape=(100, 100)))
-    l2.save(fn0)
-    l2.data += 1 * l2.data.unit
-    l2.save(fn1)
-    diff = compare_asdf(fn0, fn1)
-    assert not diff.identical, diff.report()
-    assert "arrays_differ" in diff.diff
-    assert "root['roman']['data']" in diff.diff["arrays_differ"]
-
-
-@pytest.mark.parametrize("modification", [None, "dtype", "names", "values", "meta"])
+@pytest.mark.parametrize(
+    "modification",
+    [
+        None,
+        "dtype",
+        "names",
+        "small_values",
+        "large_values",
+        "small_meta",
+        "large_meta",
+    ],
+)
 def test_compare_asdf_tables(tmp_path, modification):
     fn0 = tmp_path / "test0.asdf"
     fn1 = tmp_path / "test1.asdf"
+    atol = 0.0001
     names = ("a",)
-    values = [1, 2, 3]
-    dtype = np.uint8
-    t0 = astropy.table.Table([np.array(values, dtype=dtype)], names=names)
+    dtype = np.float32
+    values = np.array([1, 2, 3], dtype=dtype)
+    t0 = astropy.table.Table([values], names=names)
+    # use atol so value is a float
+    t0.meta["value"] = atol
     if modification == "names":
         names = ("b",)
-    if modification == "values":
-        values = [4, 5, 6]
+    if modification == "small_values":
+        values = values + atol / 2
+    if modification == "large_values":
+        values = values + atol * 2
     if modification == "dtype":
         dtype = np.float64
     t1 = astropy.table.Table([np.array(values, dtype=dtype)], names=names)
-    if modification == "meta":
-        t1.meta["modified"] = True
+    t1.meta["value"] = t0.meta["value"]
+    if modification == "small_meta":
+        t1.meta["value"] += atol / 2
+    if modification == "large_meta":
+        t1.meta["value"] += atol * 2
     asdf.AsdfFile({"t": t0}).write_to(fn0)
     asdf.AsdfFile({"t": t1}).write_to(fn1)
-    diff = compare_asdf(fn0, fn1)
-    if modification is None:
+    diff = compare_asdf(fn0, fn1, atol=atol)
+    if modification in (None, "small_values", "small_meta"):
         assert diff.identical, diff.report()
     else:
         assert not diff.identical, diff.report()


### PR DESCRIPTION
Provide ``atol`` to ``DeepDiff`` as ``math_epsilon`` argument to allow tolerancing scalar comparisons.

Drop use of ``astropy.utils.diff.values_differ`` as it does not provide readable output and does not allow control of ``nan`` equality. Instead, convert the table to a numpy structured array during comparison.

Add support for numpy structured array comparison.

Fixes https://github.com/spacetelescope/romancal/issues/916

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)

~Regression tests running at: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/395/~
Regression tests are failing due to unavailable webbpsf data. https://github.com/spacetelescope/romancal/pull/918 fixes the issue for the regression tests.
EDIT: the url used to fetch the data appears to be back up (for now, box is having issues), a new run passed with no errors: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/397/pipeline
