### PR TITLE
use webbpsf data from grp in jenkins runs

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -57,7 +57,8 @@ env_vars = [
     'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',
-    'WEBBPSF_PATH=data/webbpsf-data'
+    'WEBBPSF_PATH=/grp/jwst/ote/webbpsf-data',
+    'PYSYN_CDBS=/grp/hst/cdbs',
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))
@@ -88,9 +89,6 @@ bc0.build_cmds = [
     "pip install -e .[test]",
     "pip install pytest-xdist pytest-sugar ddtrace",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
-    "mkdir data",
-    "curl -L https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -o data/webbpsf-data.tar.gz",
-    "tar -xzvf data/webbpsf-data.tar.gz -C data",
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.build_cmds = bc0.build_cmds + [

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -55,6 +55,8 @@ env_vars = [
     "CRDS_CONTEXT=roman_0051.pmap",
     "CRDS_SERVER_URL=https://serverless",
     'CRDS_PATH=/grp/crds/roman/test/',
+    'WEBBPSF_PATH=/grp/jwst/ote/webbpsf-data',
+    'PYSYN_CDBS=/grp/hst/cdbs',
 ]
 if (env.ENV_VARS) {
     env_vars.addAll(MultiLineToArray(env.ENV_VARS))


### PR DESCRIPTION
The url used to fetch webbpsf data for the jenkins runs:
```
https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz
```
Appears to be down (regression test runs are failing to start and attempting to access the url locally results in a 'file upload in progress' page).

This PR updates the jenkins configuration files to use the webbpsf data on `/grp/` that is newly available from the webbpsf team as described in the docs:
https://webbpsf.readthedocs.io/en/latest/installation.html

Regression tests successfully run (these were started after the above url went down): https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/396/pipeline/220


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
