### PR TITLE
TweakReg regression test fix.

### DIFF
--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -28,7 +28,7 @@ def create_asn_file():
                     "name": "files.asdf",
                     "members": [
                         {
-                            "expname": "r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf",
+                            "expname": "r0000501001001001001_01101_0001_WFI01_cal_tweakreg.asdf",
                             "exptype": "science"
                         }
                     ]
@@ -53,9 +53,9 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
     # - assign_wcs;
     # - photom;
     # - source_detection.
-    input_data = "r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf"
-    output_data = "r0000501001001001001_01101_0001_WFI02_output.asdf"
-    truth_data = "r0000501001001001001_01101_0001_WFI02_tweakreg.asdf"
+    input_data = "r0000501001001001001_01101_0001_WFI01_cal_tweakreg.asdf"
+    output_data = "r0000501001001001001_01101_0001_WFI01_output.asdf"
+    truth_data = "r0000501001001001001_01101_0001_WFI01_tweakreg.asdf"
 
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.get_truth(f"truth/WFI/image/{truth_data}")

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -93,7 +93,7 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
     )
     assert "v2v3corr" in tweakreg_out.meta.wcs.available_frames
 
-    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+    diff = compare_asdf(rtdata.output, rtdata.truth, atol=1e-3, **ignore_asdf_paths)
     step.log.info(
         f"DMS280 MSG: Was the proper TweakReg data produced? : {diff.identical}"
     )

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -28,7 +28,7 @@ def create_asn_file():
                     "name": "files.asdf",
                     "members": [
                         {
-                            "expname": "r0000401001001001001_01101_0001_WFI01_cal_tweakreg.asdf",
+                            "expname": "r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf",
                             "exptype": "science"
                         }
                     ]
@@ -53,9 +53,9 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
     # - assign_wcs;
     # - photom;
     # - source_detection.
-    input_data = "r0000401001001001001_01101_0001_WFI01_cal_tweakreg.asdf"
-    output_data = "r0000401001001001001_01101_0001_WFI01_output.asdf"
-    truth_data = "r0000401001001001001_01101_0001_WFI01_cal_twkreg_proc.asdf"
+    input_data = "r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf"
+    output_data = "r0000501001001001001_01101_0001_WFI02_output.asdf"
+    truth_data = "r0000501001001001001_01101_0001_WFI02_tweakreg.asdf"
 
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.get_truth(f"truth/WFI/image/{truth_data}")

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -32,7 +32,8 @@ class MockConnectionError:
 
 def get_proper_motion_correction(epoch, gaia_ref_epoch_coords, gaia_ref_epoch):
     """
-    Calculates the proper motion correction for a given epoch and Gaia reference epoch coordinates.
+    Calculates the proper motion correction for a given epoch and Gaia reference epoch
+    coordinates.
 
     Parameters
     ----------

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -117,9 +117,7 @@ def get_parallax_correction(epoch, gaia_ref_epoch_coords):
     """
 
     obs_date = Time(epoch, format="decimalyear")
-    earths_center_barycentric_coords = coord.get_body_barycentric(
-        "earth", obs_date
-    )
+    earths_center_barycentric_coords = coord.get_body_barycentric("earth", obs_date)
     earth_X = earths_center_barycentric_coords.x
     earth_Y = earths_center_barycentric_coords.y
     earth_Z = earths_center_barycentric_coords.z
@@ -199,9 +197,7 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
-    detector = cf.Frame2D(
-        name="detector", axes_order=(0, 1), unit=(u.pix, u.pix)
-    )
+    detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(
         name="v2v3",
         axes_order=(0, 1),
@@ -459,9 +455,7 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
         ("GAIADR3", None),
     ],
 )
-def test_create_astrometric_catalog_using_epoch(
-    tmp_path, catalog, epoch, request
-):
+def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, request):
     """Test fetching data from supported catalogs for a specific epoch."""
     output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
@@ -628,9 +622,7 @@ def test_get_catalog_using_epoch(ra, dec, epoch):
         gaia_ref_epoch=gaia_ref_epoch,
     )
     # calculate parallax corrections
-    get_parallax_correction(
-        epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords
-    )
+    get_parallax_correction(epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords)
 
     # calculate the expected coordinates value after corrections have been applied to
     # Gaia's reference epoch coordinates

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -8,9 +8,9 @@ import requests
 from astropy import coordinates as coord
 from astropy import table
 from astropy import units as u
-from astropy.time import Time
 from astropy.modeling import models
 from astropy.modeling.models import RotationSequence3D, Scale, Shift
+from astropy.time import Time
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
@@ -116,9 +116,7 @@ def get_parallax_correction(epoch, gaia_ref_epoch_coords):
     """
 
     obs_date = Time(epoch, format="decimalyear")
-    earths_center_barycentric_coords = coord.get_body_barycentric(
-        "earth", obs_date
-    )
+    earths_center_barycentric_coords = coord.get_body_barycentric("earth", obs_date)
     earth_X = earths_center_barycentric_coords.x
     earth_Y = earths_center_barycentric_coords.y
     earth_Z = earths_center_barycentric_coords.z
@@ -198,9 +196,7 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
-    detector = cf.Frame2D(
-        name="detector", axes_order=(0, 1), unit=(u.pix, u.pix)
-    )
+    detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(
         name="v2v3",
         axes_order=(0, 1),
@@ -458,9 +454,7 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
         ("GAIADR3", None),
     ],
 )
-def test_create_astrometric_catalog_using_epoch(
-    tmp_path, catalog, epoch, request
-):
+def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, request):
     """Test fetching data from supported catalogs for a specific epoch."""
     output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
@@ -627,9 +621,7 @@ def test_get_catalog_using_epoch(ra, dec, epoch):
         gaia_ref_epoch=gaia_ref_epoch,
     )
     # calculate parallax corrections
-    get_parallax_correction(
-        epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords
-    )
+    get_parallax_correction(epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords)
 
     # calculate the expected coordinates value after corrections have been applied to
     # Gaia's reference epoch coordinates

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -117,7 +117,9 @@ def get_parallax_correction(epoch, gaia_ref_epoch_coords):
     """
 
     obs_date = Time(epoch, format="decimalyear")
-    earths_center_barycentric_coords = coord.get_body_barycentric("earth", obs_date)
+    earths_center_barycentric_coords = coord.get_body_barycentric(
+        "earth", obs_date
+    )
     earth_X = earths_center_barycentric_coords.x
     earth_Y = earths_center_barycentric_coords.y
     earth_Z = earths_center_barycentric_coords.z
@@ -197,7 +199,9 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
-    detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
+    detector = cf.Frame2D(
+        name="detector", axes_order=(0, 1), unit=(u.pix, u.pix)
+    )
     v2v3 = cf.Frame2D(
         name="v2v3",
         axes_order=(0, 1),
@@ -455,7 +459,9 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
         ("GAIADR3", None),
     ],
 )
-def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, request):
+def test_create_astrometric_catalog_using_epoch(
+    tmp_path, catalog, epoch, request
+):
     """Test fetching data from supported catalogs for a specific epoch."""
     output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
@@ -622,7 +628,9 @@ def test_get_catalog_using_epoch(ra, dec, epoch):
         gaia_ref_epoch=gaia_ref_epoch,
     )
     # calculate parallax corrections
-    get_parallax_correction(epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords)
+    get_parallax_correction(
+        epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords
+    )
 
     # calculate the expected coordinates value after corrections have been applied to
     # Gaia's reference epoch coordinates
@@ -638,11 +646,9 @@ def test_get_catalog_using_epoch(ra, dec, epoch):
     )
 
     assert len(result) > 0
-    # choosing atol=0 corresponds to abs(a - b) / abs(b) <= rtol,
-    # where a is the returned value from the VO API and b is the expected
-    # value from applying the calculated PM and parallax corrections.
-    assert np.isclose(returned_ra, expected_ra, atol=0, rtol=1e-5).all()
-    assert np.isclose(returned_dec, expected_dec, atol=0, rtol=1e-5).all()
+
+    assert np.isclose(returned_ra, expected_ra, atol=1e-5, rtol=0).all()
+    assert np.isclose(returned_dec, expected_dec, atol=1e-5, rtol=0).all()
 
 
 def test_get_catalog_timeout():

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -31,9 +31,7 @@ def _oxford_or_str_join(str_list):
     elif nelem == 2:
         return f"{str_list[0]} or {str_list[1]}"
     else:
-        return (
-            ", ".join(map(repr, str_list[:-1])) + ", or " + repr(str_list[-1])
-        )
+        return ", ".join(map(repr, str_list[:-1])) + ", or " + repr(str_list[-1])
 
 
 SINGLE_GROUP_REFCAT = ["GAIADR3", "GAIADR2", "GAIADR1"]
@@ -146,9 +144,7 @@ class TweakRegStep(RomanStep):
             self.catalog_path = os.getcwd()
 
         self.catalog_path = Path(self.catalog_path).as_posix()
-        self.log.info(
-            f"All source catalogs will be saved to: {self.catalog_path}"
-        )
+        self.log.info(f"All source catalogs will be saved to: {self.catalog_path}")
 
         if self.abs_refcat is None or len(self.abs_refcat.strip()) == 0:
             self.abs_refcat = DEFAULT_ABS_REFCAT
@@ -240,9 +236,7 @@ class TweakRegStep(RomanStep):
         grp_img = list(images.models_grouped)
 
         self.log.info("")
-        self.log.info(
-            f"Number of image groups to be aligned: {len(grp_img):d}."
-        )
+        self.log.info(f"Number of image groups to be aligned: {len(grp_img):d}.")
         self.log.info("Image groups:")
 
         if len(grp_img) == 1 and not ALIGN_TO_ABS_REFCAT:
@@ -252,9 +246,7 @@ class TweakRegStep(RomanStep):
             self.log.info("")
 
             # we need at least two exposures to perform image alignment
-            self.log.warning(
-                "At least two exposures are required for image alignment."
-            )
+            self.log.warning("At least two exposures are required for image alignment.")
             self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
             self.skip = True
             for model in images:
@@ -328,8 +320,7 @@ class TweakRegStep(RomanStep):
             except ValueError as e:
                 msg = e.args[0]
                 if (
-                    msg
-                    == "Too few input images (or groups of images) with non-empty"
+                    msg == "Too few input images (or groups of images) with non-empty"
                     " catalogs."
                 ):
                     # we need at least two exposures to perform image alignment
@@ -337,9 +328,7 @@ class TweakRegStep(RomanStep):
                     self.log.warning(
                         "At least two exposures are required for image alignment."
                     )
-                    self.log.warning(
-                        "Nothing to do. Skipping 'TweakRegStep'..."
-                    )
+                    self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if not ALIGN_TO_ABS_REFCAT:
@@ -365,9 +354,7 @@ class TweakRegStep(RomanStep):
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if ALIGN_TO_ABS_REFCAT:
-                        self.log.warning(
-                            "Skipping relative alignment (stage 1)..."
-                        )
+                        self.log.warning("Skipping relative alignment (stage 1)...")
                     else:
                         self.log.warning("Skipping 'TweakRegStep'...")
                         self.skip = True
@@ -495,9 +482,7 @@ class TweakRegStep(RomanStep):
                 # (typecasting numpy objects to python types so that it doesn't cause an
                 # issue when saving datamodel to ASDF)
                 wcs_fit_results = {
-                    k: v.tolist()
-                    if isinstance(v, (np.ndarray, np.bool_))
-                    else v
+                    k: v.tolist() if isinstance(v, (np.ndarray, np.bool_)) else v
                     for k, v in imcat.meta["fit_info"].items()
                 }
                 # add fit results and new WCS to datamodel
@@ -591,9 +576,7 @@ def _common_name(group):
     file_names = []
     for im in group:
         if isinstance(im, rdm.DataModel):
-            file_names.append(
-                os.path.splitext(im.meta.filename)[0].strip("_- ")
-            )
+            file_names.append(os.path.splitext(im.meta.filename)[0].strip("_- "))
         else:
             raise TypeError("Input must be a list of datamodels list.")
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -31,7 +31,9 @@ def _oxford_or_str_join(str_list):
     elif nelem == 2:
         return f"{str_list[0]} or {str_list[1]}"
     else:
-        return ", ".join(map(repr, str_list[:-1])) + ", or " + repr(str_list[-1])
+        return (
+            ", ".join(map(repr, str_list[:-1])) + ", or " + repr(str_list[-1])
+        )
 
 
 SINGLE_GROUP_REFCAT = ["GAIADR3", "GAIADR2", "GAIADR1"]
@@ -144,7 +146,9 @@ class TweakRegStep(RomanStep):
             self.catalog_path = os.getcwd()
 
         self.catalog_path = Path(self.catalog_path).as_posix()
-        self.log.info(f"All source catalogs will be saved to: {self.catalog_path}")
+        self.log.info(
+            f"All source catalogs will be saved to: {self.catalog_path}"
+        )
 
         if self.abs_refcat is None or len(self.abs_refcat.strip()) == 0:
             self.abs_refcat = DEFAULT_ABS_REFCAT
@@ -236,7 +240,9 @@ class TweakRegStep(RomanStep):
         grp_img = list(images.models_grouped)
 
         self.log.info("")
-        self.log.info(f"Number of image groups to be aligned: {len(grp_img):d}.")
+        self.log.info(
+            f"Number of image groups to be aligned: {len(grp_img):d}."
+        )
         self.log.info("Image groups:")
 
         if len(grp_img) == 1 and not ALIGN_TO_ABS_REFCAT:
@@ -246,7 +252,9 @@ class TweakRegStep(RomanStep):
             self.log.info("")
 
             # we need at least two exposures to perform image alignment
-            self.log.warning("At least two exposures are required for image alignment.")
+            self.log.warning(
+                "At least two exposures are required for image alignment."
+            )
             self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
             self.skip = True
             for model in images:
@@ -320,7 +328,8 @@ class TweakRegStep(RomanStep):
             except ValueError as e:
                 msg = e.args[0]
                 if (
-                    msg == "Too few input images (or groups of images) with non-empty"
+                    msg
+                    == "Too few input images (or groups of images) with non-empty"
                     " catalogs."
                 ):
                     # we need at least two exposures to perform image alignment
@@ -328,7 +337,9 @@ class TweakRegStep(RomanStep):
                     self.log.warning(
                         "At least two exposures are required for image alignment."
                     )
-                    self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
+                    self.log.warning(
+                        "Nothing to do. Skipping 'TweakRegStep'..."
+                    )
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if not ALIGN_TO_ABS_REFCAT:
@@ -354,7 +365,9 @@ class TweakRegStep(RomanStep):
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
                     if ALIGN_TO_ABS_REFCAT:
-                        self.log.warning("Skipping relative alignment (stage 1)...")
+                        self.log.warning(
+                            "Skipping relative alignment (stage 1)..."
+                        )
                     else:
                         self.log.warning("Skipping 'TweakRegStep'...")
                         self.skip = True
@@ -482,7 +495,9 @@ class TweakRegStep(RomanStep):
                 # (typecasting numpy objects to python types so that it doesn't cause an
                 # issue when saving datamodel to ASDF)
                 wcs_fit_results = {
-                    k: v.tolist() if isinstance(v, (np.ndarray, np.bool_)) else v
+                    k: v.tolist()
+                    if isinstance(v, (np.ndarray, np.bool_))
+                    else v
                     for k, v in imcat.meta["fit_info"].items()
                 }
                 # add fit results and new WCS to datamodel
@@ -529,10 +544,14 @@ class TweakRegStep(RomanStep):
                 catalog_format = self.catalog_format
             else:
                 catalog_format = "ascii.ecsv"
-            cat_name = str(catalog)
+
             if isinstance(catalog, str):
+                # a string with the name of the catalog was provided
                 catalog = Table.read(catalog, format=catalog_format)
-            catalog.meta["name"] = cat_name
+
+            catalog.meta["name"] = (
+                str(catalog) if isinstance(catalog, str) else model_name
+            )
         except OSError:
             self.log.error(f"Cannot read catalog {catalog}")
 
@@ -572,7 +591,9 @@ def _common_name(group):
     file_names = []
     for im in group:
         if isinstance(im, rdm.DataModel):
-            file_names.append(os.path.splitext(im.meta.filename)[0].strip("_- "))
+            file_names.append(
+                os.path.splitext(im.meta.filename)[0].strip("_- ")
+            )
         else:
             raise TypeError("Input must be a list of datamodels list.")
 


### PR DESCRIPTION
This PR implements the following items to fix TweakReg's (TR) regression test:

- fix TR's catalog metadata: a bug was preventing the catalog metadata `name` from being properly set;
- updated the files used by TweakReg's regression test:
   * input: `roman-pipeline/dev/WFI/image/r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf`;
   * truth: `roman-pipeline/dev/truth/WFI/image/r0000501001001001001_01101_0001_WFI02_tweakreg.asdf`.

The truth file in Artifactory was created by processing the cal file through the `TweakRegStep`:
```python
from romancal.stpipe import RomanStep
from romancal.tweakreg.tweakreg_step import TweakRegStep

step = TweakRegStep()

args = [
    "romancal.step.TweakRegStep",
    "/full/path/to/association/file/asn_filename.json",
    "--output_file='tweakreg_truth_filename.asdf'",
    "--suffix='output'",
]
RomanStep.from_cmdline(args)
```
The association file (named `asn_filename.json` above) used in the creation of the truth file has the following content:
```json
{
       "asn_type": "None",
       "asn_rule": "DMS_ELPP_Base",
       "version_id": null,
       "code_version": "0.9.1.dev28+ge987cc9.d20230106",
       "degraded_status": "No known degraded exposures in association.",
       "program": "noprogram",
       "constraints": "No constraints",
       "asn_id": "a3001",
       "target": "none",
       "asn_pool": "test_pool_name",
       "products": [
           {
               "name": "files.asdf",
               "members": [
                   {
                       "expname": "r0000501001001001001_01101_0001_WFI02_cal_tweakreg.asdf",
                       "exptype": "science"
                   }
               ]
            }
       ]
}
```

The file used as input for the regression test, `r0000501001001001001_01101_0001_WFI02_cal.asdf`, was provided by @tddesjardins and has been processed through `assign_wcs`, `photom`, and `source_detection`. We added the `tweakreg` suffix before uploading it to Artifactory.

**Astrometric Utils unit tests**
This PR also adds parallax correction to the unit tests for the `astrometric_utils` package.

Since the coordinates in the catalog obtained from the VO API are now being updated for proper motion and parallax, we must consider that in the `test_astrometric_utils` suite.

**Regression test**
~All regression tests are passing: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/401/~
${\text{\color{red}The regression tests are failing to start and Zach and William are working on fixing it.}}$

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
