### PR TITLE
update url for webbpsf data in github actions CI

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -55,7 +55,7 @@ jobs:
       - id: data
         run: |
           echo "path=/tmp/data" >> $GITHUB_OUTPUT
-          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+          echo "webbpsf_url=https://stsci.box.com/shared/static/qxpiaxsjwo15ml6m4pkhtk36c9jgj70k.gz" >> $GITHUB_OUTPUT
       - run: |
           mkdir -p tmp/data/
           mkdir -p ${{ steps.data.outputs.path }}


### PR DESCRIPTION
This PR updates the url used for fetching webbpsf data to the most recent one in the webbpsf docs.
https://webbpsf.readthedocs.io/en/latest/installation.html#installing-the-required-data-files

Based off the comments and changes in https://github.com/spacetelescope/webbpsf/pull/739
the shared url for the webbpsf data used in this PR should (hopefully) stay up-to-date for future webbpsf data releases.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
