### PR TITLE
Include parallax correction in unit tests.

### DIFF
--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -32,7 +32,8 @@ class MockConnectionError:
 
 def get_proper_motion_correction(epoch, gaia_ref_epoch_coords, gaia_ref_epoch):
     """
-    Calculates the proper motion correction for a given epoch and Gaia reference epoch coordinates.
+    Calculates the proper motion correction for a given epoch and Gaia reference epoch
+    coordinates.
 
     Parameters
     ----------

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -8,9 +8,9 @@ import requests
 from astropy import coordinates as coord
 from astropy import table
 from astropy import units as u
-from astropy.time import Time
 from astropy.modeling import models
 from astropy.modeling.models import RotationSequence3D, Scale, Shift
+from astropy.time import Time
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
@@ -116,9 +116,7 @@ def get_parallax_correction(epoch, gaia_ref_epoch_coords):
     """
 
     obs_date = Time(epoch, format="decimalyear")
-    earths_center_barycentric_coords = coord.get_body_barycentric(
-        "earth", obs_date
-    )
+    earths_center_barycentric_coords = coord.get_body_barycentric("earth", obs_date)
     earth_X = earths_center_barycentric_coords.x
     earth_Y = earths_center_barycentric_coords.y
     earth_Z = earths_center_barycentric_coords.z
@@ -198,9 +196,7 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
-    detector = cf.Frame2D(
-        name="detector", axes_order=(0, 1), unit=(u.pix, u.pix)
-    )
+    detector = cf.Frame2D(name="detector", axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(
         name="v2v3",
         axes_order=(0, 1),
@@ -458,9 +454,7 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
         ("GAIADR3", None),
     ],
 )
-def test_create_astrometric_catalog_using_epoch(
-    tmp_path, catalog, epoch, request
-):
+def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, request):
     """Test fetching data from supported catalogs for a specific epoch."""
     output_filename = "ref_cat.ecsv"
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
@@ -627,9 +621,7 @@ def test_get_catalog_using_epoch(ra, dec, epoch):
         gaia_ref_epoch=gaia_ref_epoch,
     )
     # calculate parallax corrections
-    get_parallax_correction(
-        epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords
-    )
+    get_parallax_correction(epoch=epoch, gaia_ref_epoch_coords=gaia_ref_epoch_coords)
 
     # calculate the expected coordinates value after corrections have been applied to
     # Gaia's reference epoch coordinates


### PR DESCRIPTION
This PR adds parallax correction to the unit tests.

Since the coordinates in the catalog obtained from the VO API are now being updated for both proper motion and parallax, we also need to take that into account in the `test_astrometric_utils` suite.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [X] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
