### PR TITLE
RCAL-641 Add FOV association generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.13.0 (unreleased)
 ===================
 
+associations
+------------
+
+- Add FOV associations to the  code  [#931]
+
 general
 -------
 

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -86,6 +86,7 @@ def generate(pool, rules, version_id=None, finalize=True):
                 total_reprocess += len(to_process_modified)
                 bar.next()
 
+
         logger.debug(
             "Existing associations modified: %d New associations created: %d",
             total_mod_existing,
@@ -98,10 +99,13 @@ def generate(pool, rules, version_id=None, finalize=True):
 
     # Finalize found associations
     logger.debug("# associations before finalization: %d", len(associations))
-    try:
-        finalized_asns = rules.callback.reduce("finalize", associations)
-    except KeyError:
-        finalized_asns = associations
+    finalized_asns = associations
+    if finalize:
+        logger.debug('Performing association finalization.')
+        try:
+            finalized_asns = rules.callback.reduce('finalize', associations)
+        except KeyError as exception:
+            logger.debug('Finalization failed for reason: %s', exception)
 
     return finalized_asns
 

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -86,7 +86,6 @@ def generate(pool, rules, version_id=None, finalize=True):
                 total_reprocess += len(to_process_modified)
                 bar.next()
 
-
         logger.debug(
             "Existing associations modified: %d New associations created: %d",
             total_mod_existing,
@@ -101,11 +100,11 @@ def generate(pool, rules, version_id=None, finalize=True):
     logger.debug("# associations before finalization: %d", len(associations))
     finalized_asns = associations
     if finalize:
-        logger.debug('Performing association finalization.')
+        logger.debug("Performing association finalization.")
         try:
-            finalized_asns = rules.callback.reduce('finalize', associations)
+            finalized_asns = rules.callback.reduce("finalize", associations)
         except KeyError as exception:
-            logger.debug('Finalization failed for reason: %s', exception)
+            logger.debug("Finalization failed for reason: %s", exception)
 
     return finalized_asns
 

--- a/romancal/associations/lib/dms_base.py
+++ b/romancal/associations/lib/dms_base.py
@@ -41,10 +41,24 @@ CORON_EXP_TYPES = ["mir_4qpm", "mir_lyot", "nrc_coron"]
 
 # Roman WFI detectors
 WFI_DETECTORS = [
-    "wfi01", "wfi02", "wfi03", "wfi04", "wfi05",
-    "wfi06", "wfi07", "wfi08", "wfi09", "wfi10",
-    "wfi11", "wfi12", "wfi13", "wfi14", "wfi15",
-    "wfi16", "wfi17", "wfi18",
+    "wfi01",
+    "wfi02",
+    "wfi03",
+    "wfi04",
+    "wfi05",
+    "wfi06",
+    "wfi07",
+    "wfi08",
+    "wfi09",
+    "wfi10",
+    "wfi11",
+    "wfi12",
+    "wfi13",
+    "wfi14",
+    "wfi15",
+    "wfi16",
+    "wfi17",
+    "wfi18",
 ]
 
 # Exposures that get Level2b processing

--- a/romancal/associations/lib/dms_base.py
+++ b/romancal/associations/lib/dms_base.py
@@ -21,96 +21,45 @@ _ASN_NAME_TEMPLATE = "r{program}-{acid}_{type}_{sequence:03d}_asn"
 
 # Acquisition and Confirmation images
 ACQ_EXP_TYPES = (
-    "mir_tacq",
-    "mir_taconfirm",
-    "nis_taconfirm",
-    "nis_tacq",
     "nrc_taconfirm",
     "nrc_tacq",
-    "nrs_confirm",
-    "nrs_msata",
-    "nrs_taconfirm",
-    "nrs_tacq",
-    "nrs_taslit",
-    "nrs_verify",
-    "nrs_wata",
 )
 
 # Exposure EXP_TYPE to Association EXPTYPE mapping
 # flake8: noqa: E241
 EXPTYPE_MAP = {
-    "mir_darkall": "dark",
-    "mir_darkimg": "dark",
-    "mir_darkmrs": "dark",
-    "mir_flatimage": "flat",
-    "mir_flatmrs": "flat",
-    "mir_flatimage-ext": "flat",
-    "mir_flatmrs-ext": "flat",
-    "mir_tacq": "target_acquisition",
-    "mir_taconfirm": "target_acquisition",
-    "nis_dark": "dark",
-    "nis_focus": "engineering",
-    "nis_lamp": "engineering",
-    "nis_tacq": "target_acquisition",
-    "nis_taconfirm": "target_acquisition",
     "nrc_dark": "dark",
     "nrc_flat": "flat",
     "nrc_focus": "engineering",
     "nrc_led": "engineering",
     "nrc_tacq": "target_acquisition",
     "nrc_taconfirm": "target_acquisition",
-    "nrs_autoflat": "autoflat",
-    "nrs_autowave": "autowave",
-    "nrs_confirm": "target_acquisition",
-    "nrs_dark": "dark",
-    "nrs_focus": "engineering",
-    "nrs_image": "engineering",
-    "nrs_lamp": "engineering",
-    "nrs_msata": "target_acquisition",
-    "nrs_tacq": "target_acquisition",
-    "nrs_taconfirm": "target_acquisition",
-    "nrs_taslit": "target_acquisition",
-    "nrs_wata": "target_acquisition",
 }
 
 # Coronographic exposures
 CORON_EXP_TYPES = ["mir_4qpm", "mir_lyot", "nrc_coron"]
 
+# Roman WFI detectors
+WFI_DETECTORS = [
+    "wfi01", "wfi02", "wfi03", "wfi04", "wfi05",
+    "wfi06", "wfi07", "wfi08", "wfi09", "wfi10",
+    "wfi11", "wfi12", "wfi13", "wfi14", "wfi15",
+    "wfi16", "wfi17", "wfi18",
+]
+
 # Exposures that get Level2b processing
 IMAGE2_SCIENCE_EXP_TYPES = [
     "wfi_image",
-    "mir_4qpm",
-    "mir_image",
-    "mir_lyot",
-    "nis_ami",
-    "nis_image",
-    "nrc_coron",
-    "nrc_image",
-    "nrs_mimf",
-    "nrc_tsimage",
 ]
 
 IMAGE2_NONSCIENCE_EXP_TYPES = [
-    "mir_coroncal",
-    "nis_focus",
-    "nrc_focus",
-    "nrs_focus",
-    "nrs_image",
+    "wfi_focus",
 ]
 IMAGE2_NONSCIENCE_EXP_TYPES.extend(ACQ_EXP_TYPES)
 
 SPEC2_SCIENCE_EXP_TYPES = [
-    "mir_lrs-fixedslit",
-    "mir_lrs-slitless",
-    "mir_mrs",
-    "nis_soss",
-    "nis_wfss",
-    "nrc_tsgrism",
-    "nrc_wfss",
-    "nrs_fixedslit",
-    "nrs_ifu",
-    "nrs_msaspec",
-    "nrs_brightobj",
+    "wfi_grism",
+    "wfi_prism",
 ]
 
 SPECIAL_EXPOSURE_MODIFIERS = {

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -327,8 +327,8 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         return member
 
     def make_fov_asn(self):
-        """ Take the association with and single exposure with _WFI_ and
-              expand that to include all 16 detectors.
+        """ Take the association with an single exposure with _WFI_ in the name
+              and expand that to include all 16 detectors.
 
         Returns
         -------

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -693,8 +693,6 @@ class Constraint_Filename(DMSAttrConstraint):
         super().__init__(
             name="Filename",
             sources=["filename"],
-            #force_unique=True,
-            #required=True,
         )
 
 
@@ -1031,7 +1029,6 @@ class AsnMixin_Lv2FOV:
 
         """
         if self.is_valid:
-            #self = self.make_fov_asn()
             return self.make_fov_asn()
         else:
             return None        

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -328,7 +328,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
 
     def make_fov_asn(self):
         """ Take the association with an single exposure with _WFI_ in the name
-              and expand that to include all 16 detectors.
+              and expand that to include all 18 detectors.
 
         Returns
         -------

--- a/romancal/associations/lib/rules_elpp_base.py
+++ b/romancal/associations/lib/rules_elpp_base.py
@@ -1,17 +1,13 @@
 """Base classes which define the ELPP Associations"""
 
+import copy
 import logging
 import re
-import copy
 from collections import defaultdict
-from os.path import (
-    basename,
-    split,
-    splitext
-)
+from os.path import basename, split, splitext
 
 from stpipe.format_template import FormatTemplate
-from romancal.lib.suffix import remove_suffix
+
 from romancal.associations import libpath
 from romancal.associations.association import Association
 from romancal.associations.exceptions import AssociationNotValidError
@@ -23,9 +19,9 @@ from romancal.associations.lib.dms_base import (
     IMAGE2_NONSCIENCE_EXP_TYPES,
     IMAGE2_SCIENCE_EXP_TYPES,
     SPEC2_SCIENCE_EXP_TYPES,
+    WFI_DETECTORS,
     DMSAttrConstraint,
     DMSBaseMixin,
-    WFI_DETECTORS,
 )
 from romancal.associations.lib.keyvalue_registry import KeyValueRegistryError
 from romancal.associations.lib.member import Member
@@ -327,7 +323,7 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         return member
 
     def make_fov_asn(self):
-        """ Take the association with an single exposure with _WFI_ in the name
+        """Take the association with an single exposure with _WFI_ in the name
               and expand that to include all 18 detectors.
 
         Returns
@@ -339,18 +335,23 @@ class DMS_ELPP_Base(DMSBaseMixin, Association):
         results = []
 
         # expand the products from _wfi_ to _wfi{det}_
-        for product in self['products']:
-            for member in product['members']:
+        for product in self["products"]:
+            for member in product["members"]:
                 asn = copy.deepcopy(self)
-                asn.data['products'] = None
-                product_name = splitext(split(self.data['products'][0]['members'][0]['expname'])[1])[0].rsplit('_',1)[0]+'_drzl'
+                asn.data["products"] = None
+                product_name = (
+                    splitext(
+                        split(self.data["products"][0]["members"][0]["expname"])[1]
+                    )[0].rsplit("_", 1)[0]
+                    + "_drzl"
+                )
                 asn.new_product(product_name)
-                new_members = asn.current_product['members']
-                if '_wfi_' in member['expname'] :
+                new_members = asn.current_product["members"]
+                if "_wfi_" in member["expname"]:
                     # Make and add a member for each detector
                     for det in WFI_DETECTORS:
                         new_member = copy.deepcopy(member)
-                        new_member['expname'] = member['expname'].replace('wfi', det)
+                        new_member["expname"] = member["expname"].replace("wfi", det)
                         new_members.append(new_member)
             if asn.is_valid:
                 results.append(asn)
@@ -1015,11 +1016,11 @@ class AsnMixin_Lv2FOV:
 
         super()._init_hook(item)
         self.data["asn_type"] = "FOV"
-        
+
     def finalize(self):
         """Finalize association
 
- 
+
         Returns
         -------
         associations: [association[, ...]] or None
@@ -1031,7 +1032,8 @@ class AsnMixin_Lv2FOV:
         if self.is_valid:
             return self.make_fov_asn()
         else:
-            return None        
+            return None
+
 
 class AsnMixin_Lv2Image:
     """Level 2 Image association base"""

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -35,11 +35,6 @@ class Asn_Lv2FOV(AsnMixin_Lv2FOV, DMS_ELPP_Base):
             [
                 Constraint_Base(),
                 Constraint_Target(),
-                #Constraint_Expos(),
-                #Constraint_Optical_Path(),
-                #Constraint_Sequence(),
-                #Constraint_Pass(),
-                #Constraint_Tile(),
                 Constraint_Filename(),
             ]
         )

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -6,8 +6,14 @@ from romancal.associations.lib.constraint import Constraint
 from romancal.associations.lib.rules_elpp_base import *
 from romancal.associations.registry import RegistryMarker
 
-__all__ = ["Asn_Lv2FOV", "Asn_Lv2Image", "Asn_Lv2GBTDSPass",
-                "Asn_Lv2GBTDSFull", "AsnMixin_Lv2Image","AsnMinxin_Lv2FOV"]
+__all__ = [
+    "Asn_Lv2FOV",
+    "Asn_Lv2Image",
+    "Asn_Lv2GBTDSPass",
+    "Asn_Lv2GBTDSFull",
+    "AsnMixin_Lv2Image",
+    "AsnMinxin_Lv2FOV",
+]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -63,7 +69,8 @@ class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
                 Constraint(
                     [
                         Constraint_Expos(),
-                    ], reduce=Constraint.any
+                    ],
+                    reduce=Constraint.any,
                 ),
                 Constraint_Optical_Path(),
                 Constraint_Sequence(),

--- a/romancal/associations/lib/rules_level2.py
+++ b/romancal/associations/lib/rules_level2.py
@@ -6,7 +6,8 @@ from romancal.associations.lib.constraint import Constraint
 from romancal.associations.lib.rules_elpp_base import *
 from romancal.associations.registry import RegistryMarker
 
-__all__ = ["Asn_Lv2Image", "Asn_Lv2GBTDSPass", "Asn_Lv2GBTDSFull", "AsnMixin_Lv2Image"]
+__all__ = ["Asn_Lv2FOV", "Asn_Lv2Image", "Asn_Lv2GBTDSPass",
+                "Asn_Lv2GBTDSFull", "AsnMixin_Lv2Image","AsnMinxin_Lv2FOV"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -18,15 +19,14 @@ logger.addHandler(logging.NullHandler())
 # Start of the User-level rules
 # --------------------------------
 @RegistryMarker.rule
-class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
+class Asn_Lv2FOV(AsnMixin_Lv2FOV, DMS_ELPP_Base):
     """Level2b Non-TSO Science Image Association
 
     Characteristics:
-        - Association type: ``image2``
-        - Pipeline: ``calwebb_image2``
+        - Association type: ``FOV``
+        - Pipeline: ``mosaic``
         - Image-based science exposures
-        - Single science exposure
-        - Non-TSO
+        - Science exposures for all 18 detectors
     """
 
     def __init__(self, *args, **kwargs):
@@ -35,7 +35,41 @@ class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
             [
                 Constraint_Base(),
                 Constraint_Target(),
-                Constraint_Expos(),
+                #Constraint_Expos(),
+                #Constraint_Optical_Path(),
+                #Constraint_Sequence(),
+                #Constraint_Pass(),
+                #Constraint_Tile(),
+                Constraint_Filename(),
+            ]
+        )
+
+        # Now check and continue initialization.
+        super().__init__(*args, **kwargs)
+
+
+@RegistryMarker.rule
+class Asn_Lv2Image(AsnMixin_Lv2Image, DMS_ELPP_Base):
+    """Level2b Non-TSO Science Image Association
+
+    Characteristics:
+        - Association type: ``image``
+        - Pipeline: ``ELPP``
+        - Image-based science exposures
+        - Single science exposure
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Setup constraints
+        self.constraints = Constraint(
+            [
+                Constraint_Base(),
+                Constraint_Target(),
+                Constraint(
+                    [
+                        Constraint_Expos(),
+                    ], reduce=Constraint.any
+                ),
                 Constraint_Optical_Path(),
                 Constraint_Sequence(),
                 Constraint_Pass(),

--- a/romancal/associations/tests/test_level2_basics.py
+++ b/romancal/associations/tests/test_level2_basics.py
@@ -59,7 +59,10 @@ def test_level2_productname():
                 for member in product["members"]
                 if member["exptype"] == "science" or member["exptype"] == "wfi_image"
             ]
-            assert len(science) == 2
+            if asn['asn_rule'] == "Asn_Lv2Image":
+                assert len(science) ==2
+            if asn['asn_rule'] == "Asn_Lv2FOV":
+                assert len(science) ==18
 
 
 #            match = re.match(REGEX_LEVEL2, science[0]['expname'])

--- a/romancal/associations/tests/test_level2_basics.py
+++ b/romancal/associations/tests/test_level2_basics.py
@@ -59,10 +59,10 @@ def test_level2_productname():
                 for member in product["members"]
                 if member["exptype"] == "science" or member["exptype"] == "wfi_image"
             ]
-            if asn['asn_rule'] == "Asn_Lv2Image":
-                assert len(science) ==2
-            if asn['asn_rule'] == "Asn_Lv2FOV":
-                assert len(science) ==18
+            if asn["asn_rule"] == "Asn_Lv2Image":
+                assert len(science) == 2
+            if asn["asn_rule"] == "Asn_Lv2FOV":
+                assert len(science) == 18
 
 
 #            match = re.match(REGEX_LEVEL2, science[0]['expname'])

--- a/romancal/associations/tests/test_level2_candidates.py
+++ b/romancal/associations/tests/test_level2_candidates.py
@@ -17,11 +17,11 @@ from romancal.associations.tests.helpers import (
         # Basic observation ACIDs
         (["-i", "o001"], 0),
         # Whole program
-        ([], 2),
+        ([], 5),
         # Discovered only
         (["--discover"], 0),
         # Candidates only
-        (["--all-candidates"], 2),
+        (["--all-candidates"], 5),
     ],
 )
 def test_candidate_observation(partial_args, n_asns):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-641](https://jira.stsci.edu/browse/rcal-641)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #851

<!-- describe the changes comprising this PR here -->
This PR adds the ability to create the FOV associations with all 18 detectors from a single exposure available in PSS. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/404/
The only failures are from tweakreg which this PR does not address