### PR TITLE
add `.git` to dev dependency specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'gwcs >=0.18.1',
     'jsonschema >=4.8',
     'numpy >=1.22',
-    'photutils @ git+https://github.com/astropy/photutils.git@main',
+    'photutils @ git+https://github.com/astropy/photutils.git',
     'pyparsing >=2.4.7',
     'requests >=2.22',
     'rad >= 0.17.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'gwcs >=0.18.1',
     'jsonschema >=4.8',
     'numpy >=1.22',
-    'photutils @ git+https://github.com/astropy/photutils.git',
+    'photutils @ git+https://github.com/astropy/photutils.git@main',
     'pyparsing >=2.4.7',
     'requests >=2.22',
     'rad >= 0.17.1',

--- a/requirements-dev-st.txt
+++ b/requirements-dev-st.txt
@@ -1,13 +1,13 @@
 # Roman upstream packages
-git+https://github.com/spacetelescope/roman_datamodels
-git+https://github.com/spacetelescope/rad
+git+https://github.com/spacetelescope/roman_datamodels.git
+git+https://github.com/spacetelescope/rad.git
 
 # shared upstream packages
-git+https://github.com/spacetelescope/stcal
-git+https://github.com/spacetelescope/stpipe
+git+https://github.com/spacetelescope/stcal.git
+git+https://github.com/spacetelescope/stpipe.git
 
 # Other important upstream packages
-git+https://github.com/spacetelescope/crds
-git+https://github.com/spacetelescope/gwcs
-git+https://github.com/spacetelescope/metrics_logger
-git+https://github.com/spacetelescope/tweakwcs
+git+https://github.com/spacetelescope/crds.git
+git+https://github.com/spacetelescope/gwcs.git
+git+https://github.com/spacetelescope/metrics_logger.git
+git+https://github.com/spacetelescope/tweakwcs.git

--- a/requirements-dev-thirdparty.txt
+++ b/requirements-dev-thirdparty.txt
@@ -1,12 +1,12 @@
 # ASDF upstream packages
-git+https://github.com/asdf-format/asdf-standard
-git+https://github.com/asdf-format/asdf
-git+https://github.com/asdf-format/asdf-transform-schemas
-git+https://github.com/asdf-format/asdf-coordinates-schemas
-git+https://github.com/asdf-format/asdf-wcs-schemas
+git+https://github.com/asdf-format/asdf-standard.git
+git+https://github.com/asdf-format/asdf.git
+git+https://github.com/asdf-format/asdf-transform-schemas.git
+git+https://github.com/asdf-format/asdf-coordinates-schemas.git
+git+https://github.com/asdf-format/asdf-wcs-schemas.git
 
 # Use weekly astropy dev build
-git+https://github.com/astropy/asdf-astropy
+git+https://github.com/astropy/asdf-astropy.git
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 git+https://github.com/astropy/photutils.git
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
related to https://github.com/spacetelescope/roman_datamodels/pull/281; addresses potential issue where the resolver does not exactly match the dev dependencies, by making sure they all have `.git` suffixes and no branch specifier

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] ~updated relevant tests~
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
