### PR TITLE
Update Cas22 ramp fitting to integrate with the jump detection changes in stcal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@ ramp_fitting
 
 - Make uneven ramp fitting the default [#877]
 
+- Update Ramp fitting code to support the ``stcal`` changes to the ramp fitting
+  interface which were necessary to support jump detection on uneven ramps [#933]
+
 refpix
 ------
 

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -32,6 +32,9 @@ class RampFitStep(RomanStep):
         opt_name = string(default='')
         maximum_cores = option('none','quarter','half','all',default='none') # max number of processes to create
         suffix = string(default='rampfit')  # Default suffix of results
+        use_jump_detection = boolean(default=False) # Use jump detection during ramp fitting
+        threshold_intercept = float(default=None) # Override the intercept parameter for the threshold function in the jump detection algorithm.
+        threshold_constant = float(default=None) # Override the constant parameter for the threshold function in the jump detection algorithm.
     """  # noqa: E501
 
     weighting = "optimal"  # Only weighting allowed for OLS
@@ -176,6 +179,14 @@ class RampFitStep(RomanStep):
         out_model : ImageModel
             Model containing a count-rate image.
         """
+        use_jump = self.use_jump_detection
+
+        kwargs = {}
+        if self.threshold_intercept is not None:
+            kwargs["threshold_intercept"] = self.threshold_intercept
+        if self.threshold_constant is not None:
+            kwargs["threshold_constant"] = self.threshold_constant
+
         resultants = input_model.data.value
         dq = input_model.groupdq
         read_noise = readnoise_model.data.value
@@ -191,7 +202,13 @@ class RampFitStep(RomanStep):
 
         # Fit the ramps
         output = ols_cas22_fit.fit_ramps_casertano(
-            resultants, dq, read_noise, read_time, read_pattern=read_pattern
+            resultants,
+            dq,
+            read_noise,
+            read_time,
+            read_pattern=read_pattern,
+            use_jump=use_jump,
+            **kwargs,
         )
 
         # Break out the information and fix units

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -8,6 +8,7 @@ from roman_datamodels import datamodels as rdd
 from roman_datamodels import maker_utils
 from roman_datamodels import stnode as rds
 from stcal.ramp_fitting import ols_cas22_fit, ramp_fit
+from stcal.ramp_fitting.ols_cas22 import Parameter, Variance
 
 from romancal.lib import dqflags
 from romancal.stpipe import RomanStep
@@ -179,22 +180,24 @@ class RampFitStep(RomanStep):
         dq = input_model.groupdq
         read_noise = readnoise_model.data.value
         gain = gain_model.data.value
-        read_pattern = input_model.meta.exposure.read_pattern
         read_time = input_model.meta.exposure.frame_time
 
         # account for the gain
         resultants *= gain
         read_noise *= gain
 
+        # Force read pattern to be pure lists not LNodes
+        read_pattern = [list(reads) for reads in input_model.meta.exposure.read_pattern]
+
         # Fit the ramps
-        ramppar, rampvar = ols_cas22_fit.fit_ramps_casertano(
+        output = ols_cas22_fit.fit_ramps_casertano(
             resultants, dq, read_noise, read_time, read_pattern=read_pattern
         )
 
         # Break out the information and fix units
-        slopes = ramppar[..., 1]
-        var_rnoise = rampvar[..., 0]
-        var_poisson = rampvar[..., 1]
+        slopes = output.parameters[..., Parameter.slope]
+        var_rnoise = output.variances[..., Variance.read_var]
+        var_poisson = output.variances[..., Variance.poisson_var]
         err = np.sqrt(var_poisson + var_rnoise)
 
         # Create the image model

--- a/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
@@ -129,26 +129,42 @@ def test_fits(fit_ramps, attribute):
     scope="module",
     params=[
         pytest.param(
-            (SIMPLE_RESULTANTS, 1, 0.01, False, SIMPLE_EXPECTED_DEFAULT), id="default"
+            (SIMPLE_RESULTANTS, 1, 0.01, False, SIMPLE_EXPECTED_DEFAULT, False),
+            id="default",
         ),  # No gain or noise
         pytest.param(
-            (SIMPLE_RESULTANTS, 5, 0.01, False, SIMPLE_EXPECTED_GAIN), id="extragain"
+            (SIMPLE_RESULTANTS, 5, 0.01, False, SIMPLE_EXPECTED_GAIN, False),
+            id="extragain",
         ),  # Increase gain
         pytest.param(
-            (SIMPLE_RESULTANTS, 1, 100.0, False, SIMPLE_EXPECTED_RNOISE),
+            (SIMPLE_RESULTANTS, 1, 100.0, False, SIMPLE_EXPECTED_RNOISE, False),
             id="extranoise",
+        ),  # Increase noise
+        pytest.param(
+            (SIMPLE_RESULTANTS, 1, 0.01, False, SIMPLE_EXPECTED_DEFAULT, True),
+            id="default-jump",
+        ),  # No gain or noise
+        pytest.param(
+            (SIMPLE_RESULTANTS, 5, 0.01, False, SIMPLE_EXPECTED_GAIN, True),
+            id="extragain-jump",
+        ),  # Increase gain
+        pytest.param(
+            (SIMPLE_RESULTANTS, 1, 100.0, False, SIMPLE_EXPECTED_RNOISE, True),
+            id="extranoise-jump",
         ),  # Increase noise
     ],
 )
 def fit_ramps(request):
     """Test ramp fits"""
-    resultants, ingain, rnoise, randomize, expected = request.param
+    resultants, ingain, rnoise, randomize, expected, use_jump = request.param
     ramp_model, gain_model, readnoise_model = make_data(
         resultants, ingain, rnoise, randomize
     )
+
     out_model = RampFitStep.call(
         ramp_model,
         algorithm="ols_cas22",
+        use_jump_detection=use_jump,
         override_gain=gain_model,
         override_readnoise=readnoise_model,
     )


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR is intended to only make the necessary changes in `romancal` to support the Cas22 algorithm's interface changes introduced by spacetelescope/stcal#215 for the purposes of integrating jump detection directly into the the ramp fit itself. This PR is not intended to add support for the new jump detection algorithm, instead it is intended to resolve the minor interface changes introduced which break `romancal`. A follow on PR is planned to enable and test the new jump detection algorithm in `romancal`.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
