### PR TITLE
Update PSF fitting defaults.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ general
 
 - Use tolerance for more comparisons in ``compare_asdf`` [#917]
 
+- Update PSF fitting defaults. [#936]
+
 ramp_fitting
 ------------
 

--- a/romancal/lib/psf.py
+++ b/romancal/lib/psf.py
@@ -151,8 +151,6 @@ def create_gridded_psf_model(
         if instrument_options is not None:
             wfi.options.update(instrument_options)
 
-        (filter_central_wavelengths[f"WFI_Filter_{filt}_Center"] * 1e-6 * u.m)
-
         # Initialize the PSF library
         inst = gridded_library.CreatePSFLibrary(
             instrument=wfi,

--- a/romancal/lib/psf.py
+++ b/romancal/lib/psf.py
@@ -58,7 +58,7 @@ def create_gridded_psf_model(
     path_prefix,
     filt,
     detector,
-    oversample=12,
+    oversample=11,
     fov_pixels=12,
     sqrt_n_psfs=4,
     overwrite=False,
@@ -82,7 +82,8 @@ def create_gridded_psf_model(
         Computed gridded PSF model for this SCA.
         Examples include: `"SCA01"` or `"SCA18"`.
     oversample : int, optional
-        Oversample factor, default is 12. See WebbPSF docs for details [1]_.
+        Oversample factor, default is 11. See WebbPSF docs for details [1]_.
+        Choosing an odd number makes the pixel convolution more accurate.
     fov_pixels : int, optional
         Field of view width [pixels]. Default is 12.
         See WebbPSF docs for details [1]_.
@@ -160,7 +161,6 @@ def create_gridded_psf_model(
             filter_name=filt,
             detectors=detector.upper(),
             num_psfs=n_psfs,
-            monochromatic=central_wavelength_meters,
             oversample=oversample,
             fov_pixels=fov_pixels,
             add_distortion=False,


### PR DESCRIPTION
This PR is intended to improve the PSF fitting accuracy of romancal.

It makes two changes:
- It removes the "monochromatic" argument; in the blue filters especially, the PSF changes dramatically with wavelength (e.g., F087 has a blue cutoff at 760 nm and a red cutoff at 977 nm, leading to a ~30% change in FWHM).
- It changes the default oversampling to an odd number (12 -> 11).

The second change doesn't have much in the way of knock-on effects.  It turns out that the convolution over the pixel size done for even oversamplings isn't great, and picking an odd number just resolves this.  See https://github.com/spacetelescope/webbpsf/issues/754 .

The first change will make generating the PSF library ~10x more expensive.  I think we should also consider reducing the number of PSFs evaluated on the grid to 4 from 16, which would buy back half of this; the PSF variation is less important than the monochromaticity in my experience.  That would recover ~half of the performance loss.  We eventually plan to store these as binary files rather than to compute them on the fly, which would allow us to do arbitrarily complicated things here.

With these two changes, plus an associated change to romanisim to correctly treat the orientation of the PSF, the ability to recover the positions of bright simulated stars in romanisim in F087 improves to 0.008 pix from something like 0.2 pix.

One thing we don't yet have is an IPC implementation in WebbPSF.  This is in romanisim.  We could investigate how important an effect that is on the remaining residuals, but 0.008 pix will meet spec for now.

**Checklist**
- [X] added entry in `CHANGES.rst` under the corresponding subsection
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
