### PR TITLE
add instructions for downloading WebbPSF data

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ $ crds sync --contexts roman-edit
 The CRDS_READONLY_CACHE variable should not be set, since references will need to be downloaded to your local cache as
 they are requested.
 
+Additionally, currently WebbPSF data is also required. Follow [these instructions to download the data files / point to existing files on the shared internal network](https://webbpsf.readthedocs.io/en/latest/installation.html#data-install).
+
 ### Running tests
 
 Unit tests can be run via `pytest`. Within the top level of your local `roman` repo checkout:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
WebbPSF data is currently required to run unit tests; this PR adds instructions for making it accessible with the `WEBBPSF_PATH` environment variable.

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] ~updated relevant tests~
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
