### PR TITLE
RCAL-693: Removed err array from dark tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ associations
 
 - Add FOV associations to the  code  [#931]
 
+dark
+----
+
+- Removed ``err`` array from dark current tests. [#938]
+
 general
 -------
 

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -45,10 +45,8 @@ def test_dark_step_interface(instrument, exptype):
     assert result.data.shape == shape
     assert result.groupdq.shape == shape
     assert result.pixeldq.shape == shape[1:]
-    assert result.err.shape == shape
     assert result.meta.cal_step.dark == "COMPLETE"
     assert result.data.dtype == np.float32
-    assert result.err.dtype == np.float32
     assert result.pixeldq.dtype == np.uint32
     assert result.groupdq.dtype == np.uint8
 
@@ -126,7 +124,6 @@ def test_dark_step_output_dark_file(tmpdir, instrument, exptype):
     assert dark_out_file_model.validate() is None
     assert dark_out_file_model.data.shape == shape
     assert dark_out_file_model.dq.shape == shape[1:]
-    assert dark_out_file_model.err.shape == shape
 
 
 def create_ramp_and_dark(shape, instrument, exptype):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-693](https://jira.stsci.edu/browse/RCAL-693)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #934

<!-- describe the changes comprising this PR here -->
This PR removes the `err` array from Dark Current unit tests.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
