### PR TITLE
use ndarray comparison options in wcs comparison

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ general
 
 - Use tolerance for more comparisons in ``compare_asdf`` [#917]
 
+- Use array comparison options (including ``nan`` equality) when
+  comparing ``WCS`` objects during ``compare_asdf`` [#941]
+
 ramp_fitting
 ------------
 

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -5,7 +5,15 @@ import pytest
 from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
+from romancal.assign_wcs.assign_wcs_step import load_wcs
 from romancal.regtest.regtestdata import compare_asdf
+
+
+def _add_wcs(tmp_path, model):
+    dfn = tmp_path / "wcs_distortion.asdf"
+    distortion_model = rdm.DistortionRefModel(maker_utils.mk_distortion())
+    distortion_model.save(dfn)
+    load_wcs(model, {"distortion": dfn})
 
 
 @pytest.mark.parametrize("modification", [None, "small", "large"])
@@ -13,6 +21,7 @@ def test_compare_asdf(tmp_path, modification):
     fn0 = tmp_path / "test0.asdf"
     fn1 = tmp_path / "test1.asdf"
     l2 = rdm.ImageModel(maker_utils.mk_level2_image(shape=(100, 100)))
+    _add_wcs(tmp_path, l2)
     l2.save(fn0)
     atol = 0.0001
     if modification == "small":


### PR DESCRIPTION
When comparing 2 WCS objects in the deepdiff computed between the regtest result and truth file, use the array comparison options that are used for other arrays in the diff.

These changes will mean that if both the result and truth WCS objects return `nan` when evaluated on the bounding box (this is what's used to compare the two objects) that the WCS objects can be considered equal if both WCS objects return the same `nan`s.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)

Running regression tests at: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%252FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/426/
