### PR TITLE
switch jenkins runs to use roman-serverless for crds

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -53,7 +53,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_CONTEXT=roman_0052.pmap",
-    "CRDS_SERVER_URL=https://serverless",
+    "CRDS_SERVER_URL=https://roman-serverless",
     'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',
     'DD_SERVICE=romancal',

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -53,7 +53,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
     "CRDS_CONTEXT=roman_0052.pmap",
-    "CRDS_SERVER_URL=https://serverless",
+    "CRDS_SERVER_URL=https://roman-serverless",
     'CRDS_PATH=/grp/crds/roman/test/',
     'WEBBPSF_PATH=/grp/jwst/ote/webbpsf-data',
     'PYSYN_CDBS=/grp/hst/cdbs',


### PR DESCRIPTION
Jenkins runs show errors in the logs for the `crds list` step:
from:  https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2Fromancal/detail/romancal/1092/pipeline
```
++ crds list --contexts roman_0051.pmap --mappings

++ grep pmap

CRDS - ERROR -  (FATAL) CRDS server connection and cache load FAILED.  Cannot continue.

 See https://hst-crds.stsci.edu/docs/cmdline_bestrefs/ or https://jwst-crds.stsci.edu/docs/cmdline_bestrefs/

 for more information on configuring CRDS,  particularly CRDS_PATH and CRDS_SERVER_URL. : [Errno 2] No such file or directory: '/grp/crds/roman/test/config/jwst/server_config'

+ echo 'CRDS_CONTEXT = '

CRDS_CONTEXT =
```

This appears to be due to crds defaulting to `jwst` when an observatory is not defined.

This PR updates the `CRDS_SERVER` environment variable to allow crds to know that this is `roman`.

Regression tests running at:
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/432/

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
