### PR TITLE
Filter catalog sources that are outside of the bounding box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,12 @@ resample
 --------
 - Implement resampling step. [#787]
 
+tweakreg
+--------
+
+- Fix a bug due to which source catalog may contain sources
+  outside of the bounding box. [#947]
+
 
 0.12.0 (2023-08-18)
 ===================

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -190,8 +190,6 @@ class TweakRegStep(RomanStep):
                         "Please either run SourceDetectionStep or provide a"
                         "custom source catalog."
                     )
-                # set meta.tweakreg_catalog
-                image_model.meta["tweakreg_catalog"] = catalog
                 # remove 4D numpy array from meta.source_detection
                 if is_tweakreg_catalog_present:
                     del image_model.meta.source_detection["tweakreg_catalog"]
@@ -214,6 +212,8 @@ class TweakRegStep(RomanStep):
                             "'xcentroid' and 'ycentroid'."
                         )
 
+            filename = image_model.meta.filename
+
             # filter out sources outside the WCS bounding box
             bb = image_model.meta.wcs.bounding_box
             if bb is not None:
@@ -223,7 +223,16 @@ class TweakRegStep(RomanStep):
                 mask = (x > xmin) & (x < xmax) & (y > ymin) & (y < ymax)
                 catalog = catalog[mask]
 
-            filename = image_model.meta.filename
+            n_removed_src = np.sum(np.logical_not(mask))
+            if n_removed_src:
+                self.log.info(
+                    f"Removed {n_removed_src} sources from {filename}'s "
+                    "catalog that were outside of the bounding box."
+                )
+
+            # set meta.tweakreg_catalog
+            image_model.meta["tweakreg_catalog"] = catalog
+
             nsources = len(catalog)
             if nsources == 0:
                 self.log.warning(f"No sources found in {filename}.")


### PR DESCRIPTION
Resolves [RCAL-688](https://jira.stsci.edu/browse/RCAL-688)

Closes #926

This PR fixes a bug in the `tweakreg` code due to which full unfiltered source catalog is being passed to `tweakwcs`. This PR makes sure that sources outside of the image's WCS bounding box are removed before the catalog is passed to `tweakwcs`.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
