### PR TITLE
Fix regression test artifact upload

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -69,7 +69,7 @@ pytest_basetemp = "test_outputs"
 // Configure artifactory ingest
 data_config = new DataConfig()
 data_config.server_id = 'bytesalad'
-data_config.root = '${PYTEST_BASETEMP}'
+data_config.root = 'clone/${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -66,7 +66,7 @@ pytest_basetemp = "test_outputs"
 // Configure artifactory ingest
 data_config = new DataConfig()
 data_config.server_id = 'bytesalad'
-data_config.root = '${PYTEST_BASETEMP}'
+data_config.root = 'clone/${pytest_basetemp}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
 


### PR DESCRIPTION
All regression tests are failing to upload results with the following error:
```
java.lang.RuntimeException: Failed uploading artifacts by spec
```
This is due to inclusion of `astroquery` as an indirect dependency (via `webbpsf`) which includes a test file `mission_results.json`:
https://github.com/astropy/astroquery/blob/5add2e3b0ff5b56630840a0f57196c19054f5c01/astroquery/mast/tests/data/mission_results.json#L5
which `jenkins_shared_ci` finds and treats as a test result file due to the currently configured search path (`root`).

This PR changes the `root` setting avoid inclusion of the `astroquery` file in the test results and allows the regression tests to pass the `Upload artifacts` step.

Thanks @BGannon2 for finding this fix!

Regression tests passed (with 1 known test failure: https://github.com/spacetelescope/romancal/issues/949) with this PR at: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/443/
and the `Upload artifacts` step passed.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
