### PR TITLE
RCAL-644 Remove checks on CI in production code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,11 @@ resample
 --------
 - Implement resampling step. [#787]
 
+stpipe
+------
+
+- Remove checks on CI in production code [#955]
+
 tweakreg
 --------
 

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -2,17 +2,13 @@
 Roman Calibration Pipeline base class
 """
 import logging
-import os
 import time
 
 import roman_datamodels as rdm
 from roman_datamodels.datamodels import ImageModel
-from stpipe import Pipeline, Step
+from stpipe import Pipeline, Step, crds_client
 
 from ..lib.suffix import remove_suffix
-
-from stpipe import crds_client
-
 
 _LOG_FORMATTER = logging.Formatter(
     "%(asctime)s.%(msecs)03dZ :: %(name)s :: %(levelname)s :: %(message)s",

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -11,8 +11,7 @@ from stpipe import Pipeline, Step
 
 from ..lib.suffix import remove_suffix
 
-if os.environ.get("CI") == "false":
-    from stpipe import crds_client
+from stpipe import crds_client
 
 
 _LOG_FORMATTER = logging.Formatter(
@@ -67,13 +66,11 @@ class RomanStep(Step):
 
         # this will only run if 'parent' is none, which happens when an individual
         # step is being run or if self is a RomanPipeline and not a RomanStep.
-
-        if os.environ.get("CI") == "false":  # no CRDS connection, do not run
-            if self.parent is None:
-                model.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
-                model.meta.ref_file.crds.context_used = crds_client.get_context_used(
-                    model.crds_observatory
-                )
+        if self.parent is None:
+            model.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
+            model.meta.ref_file.crds.context_used = crds_client.get_context_used(
+                model.crds_observatory
+            )
 
     def record_step_status(self, model, step_name, success=True):
         """

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -101,15 +101,18 @@ def test_log_messages(tmp_path):
 )
 def test_crds_meta():
     """Test that context and software versions are set"""
+
     class ReflectStep(RomanStep):
         def process(self, input):
             return input
 
     im = ImageModel(mk_level2_image(shape=(20, 20)))
-    im.meta.ref_file.crds.sw_version = 'junkversion'
-    im.meta.ref_file.crds.context_used = 'junkcontext'
+    im.meta.ref_file.crds.sw_version = "junkversion"
+    im.meta.ref_file.crds.context_used = "junkcontext"
 
     result = ReflectStep.call(im)
 
     assert result.meta.ref_file.crds.sw_version == crds_client.get_svn_version()
-    assert result.meta.ref_file.crds.context_used == crds_client.get_context_used(result.crds_observatory)
+    assert result.meta.ref_file.crds.context_used == crds_client.get_context_used(
+        result.crds_observatory
+    )


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-644](https://jira.stsci.edu/browse/JP-644)

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found in I&T testing where the CRDS_CTX and CRDS_SVN are not being set properly after calibrations steps were run.

The issue was bad logic in checking whether the calibration code was running under a continuous-integration environment. Since such checks, within production code, are no longer, and should not be, needed, those checks have been removed.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
