### PR TITLE
Skip webbpsf tests by default

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -47,16 +47,16 @@ jobs:
       cache-key: data-${{ needs.data.outputs.webbpsf_hash }}-${{ needs.data.outputs.crds_context }}
       cache-restore-keys: webbpsf-${{ needs.data.outputs.webbpsf_hash }}
       envs: |
-        - linux: py39-oldestdeps-cov
+        - linux: py39-oldestdeps-webbpsf-cov
           pytest-results-summary: true
-        - linux: py39
+        - linux: py39-webbpsf
           pytest-results-summary: true
-        - linux: py310
+        - linux: py310-webbpsf
           pytest-results-summary: true
-        - linux: py311-ddtrace
+        - linux: py311-ddtrace-webbpsf
           pytest-results-summary: true
-        - macos: py311-ddtrace
+        - macos: py311-ddtrace-webbpsf
           pytest-results-summary: true
-        - linux: py311-cov
+        - linux: py311-webbpsf-cov
           coverage: codecov
           pytest-results-summary: true

--- a/.github/workflows/roman_ci_cron.yaml
+++ b/.github/workflows/roman_ci_cron.yaml
@@ -40,11 +40,11 @@ jobs:
       cache-key: data-${{ needs.data.outputs.webbpsf_hash }}-${{ needs.data.outputs.crds_context }}
       cache-restore-keys: webbpsf-${{ needs.data.outputs.webbpsf_hash }}
       envs: |
-        - macos: py39
+        - macos: py39-webbpsf
           pytest-results-summary: true
-        - macos: py310
+        - macos: py310-webbpsf
           pytest-results-summary: true
-        - macos: py311-sdpdeps
+        - macos: py311-sdpdeps-webbpsf
           pytest-results-summary: true
-        - linux: py3-pyargs
+        - linux: py3-pyargs-webbpsf
           pytest-results-summary: true

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -42,13 +42,13 @@ jobs:
       cache-key: data-${{ needs.data.outputs.webbpsf_hash }}-${{ needs.data.outputs.crds_context }}
       cache-restore-keys: webbpsf-${{ needs.data.outputs.webbpsf_hash }}
       envs: |
-        - linux: py39-devdeps
-        - macos: py39-devdeps
-        - linux: py310-devdeps
-        - macos: py310-devdeps
-        - linux: py311-devdeps
-        - macos: py311-devdeps
-        - linux: py3-devdeps
+        - linux: py39-devdeps-webbpsf
+        - macos: py39-devdeps-webbpsf
+        - linux: py310-devdeps-webbpsf
+        - macos: py310-devdeps-webbpsf
+        - linux: py311-devdeps-webbpsf
+        - macos: py311-devdeps-webbpsf
+        - linux: py3-devdeps-webbpsf
           pytest-results-summary: true
-        - macos: py3-devdeps
+        - macos: py3-devdeps-webbpsf
           pytest-results-summary: true

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -97,7 +97,7 @@ bc0.build_cmds = bc0.build_cmds + [
     "pip list"
 ]
 bc0.test_cmds = [
-    "pytest -r sxf -n auto --bigdata --slow \
+    "pytest -r sxf -n auto --bigdata --slow --webbpsf \
     --cov --cov-report=xml:coverage.xml \
     --ddtrace \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -91,7 +91,7 @@ bc0.build_cmds = bc0.build_cmds + [
     "pip list"
 ]
 bc0.test_cmds = [
-    "pytest -r sxf -n 0 --bigdata --slow \
+    "pytest -r sxf -n 0 --bigdata --slow --webbpsf \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
 ]

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ $ crds sync --contexts roman-edit
 The CRDS_READONLY_CACHE variable should not be set, since references will need to be downloaded to your local cache as
 they are requested.
 
-Additionally, currently WebbPSF data is also required. Follow [these instructions to download the data files / point to existing files on the shared internal network](https://webbpsf.readthedocs.io/en/latest/installation.html#data-install).
+> **Note**\
+> If it is desired to run tests against WebbPSF data, use the `pytest --webbpsf` flag or the `-webbpsf` tox factor and follow [these instructions to download the data files / point to existing files on the shared internal network](https://webbpsf.readthedocs.io/en/latest/installation.html#data-install).
 
 ### Running tests
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "webbpsf: mark test as requiring webbpsf data to run"
+    )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--webbpsf", action="store_true", default=False, help="run webbpsf tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--webbpsf"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_webbpsf = pytest.mark.skip(reason="need --webbpsf option to run")
+    for item in items:
+        if "webbpsf" in item.keywords:
+            item.add_marker(skip_webbpsf)

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -100,6 +100,7 @@ def add_synthetic_sources(
         synth_err[slc_lg] = np.sqrt(synth_err[slc_lg] ** 2 + model_err**2)
 
 
+@pytest.mark.webbpsf
 @pytest.mark.parametrize(
     "dx, dy, true_amp",
     zip(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     check-{style,dependencies,build}
-    test{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov}
+    test{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov,-webbpsf}
     test-numpy{120,121,122}-xdist
     build-{docs,dist}
 
@@ -46,6 +46,7 @@ description =
     cov: with coverage
     xdist: using parallel processing
     ddtrace: passing test traces to DataDog agent
+    webbpsf: run the webbpsf tests
 pass_env =
     HOME
     CI
@@ -77,6 +78,7 @@ commands =
     xdist: -n 0 \
     pyargs: {toxinidir}/docs --pyargs {posargs:romancal} \
     ddtrace: --ddtrace \
+    webbpsf: --webbpsf \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently the `romancal` testing runs tests which require the `webbpsf`'s input data by default. This is undesirable because it requires users to have to set up this data in order for the test suite to complete successfully.

This PR adds the `--webbpsf` marker which enables these tests. This means that the `--webbpsf` flag must be passed to `pytest` in order to run the tests in question. This means that by default the `webbpsf` marked tests are not run. However,
this PR does add this marker to every CI job both on GitHub and Jenkins, so that the CI will always run the `webbpsf` tests. This means we will know prior to merging any changes if these tests are broken while also removing the burden of requiring outside users to not have to worry about `webbpsf`. 

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
