### PR TITLE
rcal-697 Update exposure pipeline to add tweakreg step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ dark
 general
 -------
 
+- Update pipeline code to run through tweakreg with single files and associations [#]
+
 - Update regression tests with new data and update ramp fitting tests to use ols_cas22 [#911]
 
 - Fix bug with ``ModelContainer.get_crds_parameters`` being a property not a method [#846]
@@ -41,7 +43,6 @@ ramp_fitting
 - Fix opening mode for references to be read-only [#854]
 
 - Make uneven ramp fitting the default [#877]
-
 
 - Update Ramp fitting code to support the ``stcal`` changes to the ramp fitting
   interface which were necessary to support jump detection on uneven ramps [#933]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ dark
 general
 -------
 
-- Update pipeline code to run through tweakreg with single files and associations [#]
+- Update pipeline code to run through tweakreg with single files and associations [#960]
 
 - Update regression tests with new data and update ramp fitting tests to use ols_cas22 [#911]
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -9,9 +9,11 @@ import romancal.datamodels.filetype as filetype
 
 # step imports
 from romancal.assign_wcs import AssignWcsStep
-#from romancal.associations.exceptions import AssociationNotValidError
-#from romancal.associations.load_as_asn import LoadAsLevel2Asn
+
+# from romancal.associations.exceptions import AssociationNotValidError
+# from romancal.associations.load_as_asn import LoadAsLevel2Asn
 from romancal.dark_current import DarkCurrentStep
+from romancal.datamodels import ModelContainer
 from romancal.dq_init import dq_init_step
 from romancal.flatfield import FlatFieldStep
 from romancal.jump import jump_step
@@ -24,7 +26,6 @@ from romancal.refpix import RefPixStep
 from romancal.saturation import SaturationStep
 from romancal.source_detection import SourceDetectionStep
 from romancal.tweakreg import TweakRegStep
-from romancal.datamodels import ModelContainer
 
 from ..stpipe import RomanPipeline
 
@@ -151,14 +152,16 @@ class ExposurePipeline(RomanPipeline):
             result = self.jump(result)
             result = self.rampfit(result)
             result = self.assign_wcs(result)
-            
+
             if result.meta.exposure.type == "WFI_IMAGE":
                 result = self.flatfield(result)
                 result = self.photom(result)
                 result = self.source_detection(result)
-                if (file_type == "asn"):
+                if file_type == "asn":
                     tweakreg_input.append(result)
-                    log.info(f"Number of models to tweakreg:   {len(tweakreg_input._models), n_members}")
+                    log.info(
+                        f"Number of models to tweakreg:   {len(tweakreg_input._models), n_members}"
+                    )
             else:
                 log.info("Flat Field step is being SKIPPED")
                 log.info("Photom step is being SKIPPED")
@@ -182,11 +185,11 @@ class ExposurePipeline(RomanPipeline):
             if file_type == "asdf":
                 mc_result = self.tweakreg([result])
                 result = mc_result._models.pop()
-            if file_type == "asn" :
+            if file_type == "asn":
                 result = self.tweakreg(tweakreg_input)
 
             log.info("Roman exposure calibration pipeline ending...")
-            
+
         return results
 
     def setup_output(self, input):

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -357,19 +357,19 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     assert model.meta.cal_step.saturation == "COMPLETE"
 
     pipeline.log.info(
-    "DMS278 MSG: Testing WFI Level 2 Data Generation - Spectroscopy in Level 2 spectroscopic"
-    " output......." + passfail(model.meta.cal_step.dq_init == "COMPLETE") +
-                           passfail(model.meta.cal_step.saturation == "COMPLETE" )+
-                           passfail(model.meta.cal_step.refpix == "COMPLETE") +
-                           passfail(model.meta.cal_step.linearity == "COMPLETE") +
-                           passfail(model.meta.cal_step.jump == "COMPLETE") +
-                           passfail(model.meta.cal_step.ramp_fit == "COMPLETE") +
-                           passfail(model.meta.cal_step.assign_wcs == "COMPLETE") +
-                           passfail(model.meta.cal_step.flat_field == "SKIPPED") +
-                           passfail(model.meta.cal_step.photom == "SKIPPED") +
-                           passfail(model.meta.cal_step.source_detection == "SKIPPED") +
-                           passfail(model.meta.cal_step.tweakreg == "SKIPPED")
-
+        "DMS278 MSG: Testing WFI Level 2 Data Generation - Spectroscopy in Level 2 spectroscopic"
+        " output......."
+        + passfail(model.meta.cal_step.dq_init == "COMPLETE")
+        + passfail(model.meta.cal_step.saturation == "COMPLETE")
+        + passfail(model.meta.cal_step.refpix == "COMPLETE")
+        + passfail(model.meta.cal_step.linearity == "COMPLETE")
+        + passfail(model.meta.cal_step.jump == "COMPLETE")
+        + passfail(model.meta.cal_step.ramp_fit == "COMPLETE")
+        + passfail(model.meta.cal_step.assign_wcs == "COMPLETE")
+        + passfail(model.meta.cal_step.flat_field == "SKIPPED")
+        + passfail(model.meta.cal_step.photom == "SKIPPED")
+        + passfail(model.meta.cal_step.source_detection == "SKIPPED")
+        + passfail(model.meta.cal_step.tweakreg == "SKIPPED")
     )
     assert model.meta.cal_step.dq_init == "COMPLETE"
     assert model.meta.cal_step.saturation == "COMPLETE"

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -258,9 +258,9 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
-@metrics_logger("DMS90", "DMS91", "DMS9")
+@metrics_logger("DMS278", "DMS90", "DMS91", "DMS9")
 def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
-    """Tests for flat field grism processing requirements DMS90 & DMS 91"""
+    """Tests for flat field grism processing requirements DMS90, DMS91 & DMS 278"""
     input_data = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data
@@ -355,6 +355,33 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
         " output......." + passfail(model.meta.cal_step.saturation == "COMPLETE")
     )
     assert model.meta.cal_step.saturation == "COMPLETE"
+
+    pipeline.log.info(
+    "DMS278 MSG: Testing WFI Level 2 Data Generation - Spectroscopy in Level 2 spectroscopic"
+    " output......." + passfail(model.meta.cal_step.dq_init == "COMPLETE") +
+                           passfail(model.meta.cal_step.saturation == "COMPLETE" )+
+                           passfail(model.meta.cal_step.refpix == "COMPLETE") +
+                           passfail(model.meta.cal_step.linearity == "COMPLETE") +
+                           passfail(model.meta.cal_step.jump == "COMPLETE") +
+                           passfail(model.meta.cal_step.ramp_fit == "COMPLETE") +
+                           passfail(model.meta.cal_step.assign_wcs == "COMPLETE") +
+                           passfail(model.meta.cal_step.flat_field == "SKIPPED") +
+                           passfail(model.meta.cal_step.photom == "SKIPPED") +
+                           passfail(model.meta.cal_step.source_detection == "SKIPPED") +
+                           passfail(model.meta.cal_step.tweakreg == "SKIPPED")
+
+    )
+    assert model.meta.cal_step.dq_init == "COMPLETE"
+    assert model.meta.cal_step.saturation == "COMPLETE"
+    assert model.meta.cal_step.refpix == "COMPLETE"
+    assert model.meta.cal_step.linearity == "COMPLETE"
+    assert model.meta.cal_step.jump == "COMPLETE"
+    assert model.meta.cal_step.ramp_fit == "COMPLETE"
+    assert model.meta.cal_step.assign_wcs == "COMPLETE"
+    assert model.meta.cal_step.flat_field == "SKIPPED"
+    assert model.meta.cal_step.photom == "SKIPPED"
+    assert model.meta.cal_step.source_detection == "SKIPPED"
+    assert model.meta.cal_step.tweakreg == "SKIPPED"
 
     # DMS91 data quality tests
     pipeline.log.info(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-697](https://jira.stsci.edu/browse/rcal-697)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #951

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
Jenkins is down the local regression test passes


pytest --bigdata /Users/ddavis/src/Roman/romancal/romancal/regtest/ --basetemp=/Users/ddavis/src/Roman/develop/test/tmp_tc -k test_level2_grism_processing 2>&1 |  tee test_pipeline_Oct27_2023_4.log
```
============================= test session starts ==============================
platform darwin -- Python 3.11.0, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/ddavis/src/Roman/romancal
configfile: pyproject.toml
plugins: remotedata-0.4.0, asdf-2.15.0, hypothesis-6.82.0, doctestplus-0.13.0, cov-4.1.0, filter-subpackage-0.1.2, mock-3.11.1, astropy-header-0.2.2, anyio-3.7.1, astropy-0.10.0, ci-watson-0.6.1, openfiles-0.5.0, env-0.8.2, arraydiff-0.5.0
collected 32 items / 31 deselected / 1 selected
../../../romancal/romancal/regtest/test_wfi_pipeline.py .                [100%]
=============================== warnings summary ===============================
romancal/regtest/test_wfi_pipeline.py::test_level2_grism_processing_pipeline
  /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/asdf/asdf.py:352: AsdfWarning: File 'file:///Users/ddavis/src/Roman/develop/test/tmp_tc/test_level2_grism_processing_p0/r0000201001001001002_01101_0001_WFI01_uncal.asdf' was created with extension class 'asdf.extension.BuiltinExtension' (from package asdf==2.15.1), but older package (asdf==2.15.0) is installed.
    warnings.warn(msg, AsdfWarning)
romancal/regtest/test_wfi_pipeline.py::test_level2_grism_processing_pipeline
  /Users/ddavis/src/Roman/romancal/romancal/refpix/data.py:418: RuntimeWarning: invalid value encountered in divide
    kern = (cov / mask_conv).reshape(rows, columns)
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

========== 1 passed, 31 deselected, 2 warnings in 1233.11s (0:20:33) ===========

The run time warning is from refpix.

