### PR TITLE
remove usage of `ddtrace` as DataDog stopped working

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -54,9 +54,11 @@ jobs:
           pytest-results-summary: true
         - linux: py310-webbpsf
           pytest-results-summary: true
-        - linux: py311-ddtrace-webbpsf
+        # - linux: py311-webbpsf-ddtrace
+        - linux: py311-webbpsf
           pytest-results-summary: true
-        - macos: py311-ddtrace-webbpsf
+        # - macos: py311-webbpsf-ddtrace
+        - macos: py311-webbpsf
           pytest-results-summary: true
         - linux: py311-webbpsf-cov
           coverage: codecov

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -96,10 +96,10 @@ bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
 bc0.build_cmds = bc0.build_cmds + [
     "pip list"
 ]
+//    --ddtrace \
 bc0.test_cmds = [
     "pytest -r sxf -n auto --bigdata --slow --webbpsf \
     --cov --cov-report=xml:coverage.xml \
-    --ddtrace \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     "curl -Os https://uploader.codecov.io/latest/linux/codecov",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -86,7 +86,7 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test]",
-    "pip install pytest-xdist pytest-sugar ddtrace",
+    "pip install pytest-xdist pytest-sugar",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
     "mkdir data",
     "curl -L https://stsci.box.com/shared/static/0ojjfg3cieqdpd18vl1bjnpe63r82dx8.gz -o data/webbpsf-data.tar.gz",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
DataDog stopped accepting `ddtrace` output (see https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2Fromancal/detail/romancal/1103/pipeline/) so this PR removes usage of `ddtrace` in testing so the builds can continue

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [ ] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
