### PR TITLE
RCAL-661/667/654/656 Implement next round of SOC verification tests for uneven ramps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ ramp_fitting
 - Enable jump detection within the Cas22 ramp fitting be default, and add
   regression tests for it. [#991]
 
+- Implement next round of SOC verification tests for uneven ramps [#970]
+
 refpix
 ------
 

--- a/romancal/lib/dms.py
+++ b/romancal/lib/dms.py
@@ -5,6 +5,7 @@ decorator for this is defined in this module.
 """
 from stpipe import log as stpipe_log
 
+
 def log_result(requirement, message, result):
     """Log individual test results that relate to a requirement
 
@@ -20,7 +21,6 @@ def log_result(requirement, message, result):
         The result of the test
     """
     logger = stpipe_log.delegator.log
-    result_text = 'PASS' if result else 'FAIL'
-    log_msg = f'{requirement} MSG: {message}.......{result_text}'
+    result_text = "PASS" if result else "FAIL"
+    log_msg = f"{requirement} MSG: {message}.......{result_text}"
     logger.info(log_msg)
-

--- a/romancal/lib/dms.py
+++ b/romancal/lib/dms.py
@@ -4,8 +4,12 @@ Example: Certain tests are required by DMS to log in a specific way. The
 decorator for this is defined in this module.
 """
 from functools import wraps
+import logging
+from metrics_logger.decorators import metrics_logger
 
-def result_logger(message, logger):
+from stpipe import log as stpipe_log
+
+def result_logger(requirement, message):
     """Decorator to log assertion status
 
     Parameters
@@ -20,11 +24,14 @@ def result_logger(message, logger):
         def inner(*args, **kwargs):
 
             def log_result(result):
+                logger = stpipe_log.delegator.log
                 result_text = 'PASS' if result else 'FAIL'
-                logger.info(message + result_text)
+                log_msg = f'{requirement} MSG: {message}.......{result_text}'
+                logger.info(log_msg)
 
+            metrics_func = metrics_logger(requirement)(test_function)
             try:
-                test_function(*args, **kwargs)
+                metrics_func(*args, **kwargs)
             except Exception:
                 log_result(False)
                 raise

--- a/romancal/lib/dms.py
+++ b/romancal/lib/dms.py
@@ -1,0 +1,37 @@
+"""Functionality required by DMS outside of core functionality of the package
+
+Example: Certain tests are required by DMS to log in a specific way. The
+decorator for this is defined in this module.
+"""
+from functools import wraps
+
+def result_logger(message, logger):
+    """Decorator to log assertion status
+
+    Parameters
+    ----------
+    message : str
+        The message to use. Note that the phrase of either "PASS" or "FAIL"
+        will be appended to the end of the message.
+    """
+    def decorator(test_function):
+
+        @wraps(test_function)
+        def inner(*args, **kwargs):
+
+            def log_result(result):
+                result_text = 'PASS' if result else 'FAIL'
+                logger.info(message + result_text)
+
+            try:
+                test_function(*args, **kwargs)
+            except Exception:
+                log_result(False)
+                raise
+            else:
+                log_result(True)
+
+        return inner
+
+    return decorator
+

--- a/romancal/lib/dms.py
+++ b/romancal/lib/dms.py
@@ -3,42 +3,24 @@
 Example: Certain tests are required by DMS to log in a specific way. The
 decorator for this is defined in this module.
 """
-from functools import wraps
-import logging
-from metrics_logger.decorators import metrics_logger
-
 from stpipe import log as stpipe_log
 
-def result_logger(requirement, message):
-    """Decorator to log assertion status
+def log_result(requirement, message, result):
+    """Log individual test results that relate to a requirement
 
     Parameters
     ----------
+    requirement : str
+        The requirement being logged. I.e "DMS363"
+
     message : str
-        The message to use. Note that the phrase of either "PASS" or "FAIL"
-        will be appended to the end of the message.
+        Message describing what is being tested
+
+    result : bool
+        The result of the test
     """
-    def decorator(test_function):
-
-        @wraps(test_function)
-        def inner(*args, **kwargs):
-
-            def log_result(result):
-                logger = stpipe_log.delegator.log
-                result_text = 'PASS' if result else 'FAIL'
-                log_msg = f'{requirement} MSG: {message}.......{result_text}'
-                logger.info(log_msg)
-
-            metrics_func = metrics_logger(requirement)(test_function)
-            try:
-                metrics_func(*args, **kwargs)
-            except Exception:
-                log_result(False)
-                raise
-            else:
-                log_result(True)
-
-        return inner
-
-    return decorator
+    logger = stpipe_log.delegator.log
+    result_text = 'PASS' if result else 'FAIL'
+    log_msg = f'{requirement} MSG: {message}.......{result_text}'
+    logger.info(log_msg)
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -1,10 +1,41 @@
 """ Module to test rampfit with optional output """
-
+from pathlib import Path
 import pytest
 
+import roman_datamodels as rdm
+from romancal.lib.suffix import replace_suffix
+from romancal.ramp_fitting import RampFitStep
 from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
+
+
+@pytest.mark.bigdata
+def test_is_uneven(rampfit_result):
+    """Verify that the provided model represents uneven ramps
+
+
+    Using Roman terminology, a "read pattern" is a list of resultants. Each element of this list
+    is a list of reads that were combined, on-board, to create a resultant. An example read pattern is
+
+    [[1], [2, 3], [4], [5, 6, 7, 8], [9, 10], [11]]
+
+    This pattern has 6 resultants, the first consistent of the first read, the
+    next consisting of reads 2 and 3, the third consists of read 4, and so on.
+
+    An uneven read pattern should have resultants that are created from different number of reads.
+    If the length of each resultant read list is the same for all resultants, that is an even set
+    of ramps and will fail that test
+
+    Parameters
+    ----------
+    rampfit_result : `roman_datamodels.ImageModel`
+        Model created from `RampFitStep`
+    """
+    model, _ = rampfit_result
+    length_set = {len(resultant) for resultant in model.meta.exposure.read_pattern}
+
+    assert len(length_set) > 1
 
 
 @pytest.mark.bigdata
@@ -25,3 +56,33 @@ def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
 
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
+
+
+# ######################
+# fixtures and utilities
+# ######################
+@pytest.fixture(scope='module')
+def rampfit_result(rtdata_module):
+    """Run RampFitStep
+
+    Parameters
+    ----------
+    tmpdir : pytest.fixture
+        Temporary working directory
+
+    Returns
+    -------
+    model, path : `ImageModel`, `pathlib.Path`
+        Model and path to model
+    """
+    input_data = 'random_dqinit.asdf'
+    input_data = rtdata_module.get_data(f'WFI/image/{input_data}')
+    with rdm.open(input_data) as input_model:
+        result_model = RampFitStep.call(input_model, save_results=True)
+
+    expected_path = replace_suffix(Path(input_data).stem, 'rampfit') + '.asdf'
+
+    try:
+        yield result_model, expected_path
+    finally:
+        result_model.close()

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -17,7 +17,7 @@ from .regtestdata import compare_asdf
 # fixtures and utilities
 # ######################
 @pytest.fixture(scope='module',
-                params=[('DMS362', Path('WFI/image/image_uneven_dqinit.asdf')),
+                params=[('DMS362', Path('WFI/image/r0000501001001001001_01101_0001_WFI01_dqinit.asdf')),
                         ('DMS366', Path('WFI/grism/spec_uneven_dqinit.asdf'))])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -3,7 +3,7 @@
 Notes
 -----
 A requirement for the larger mission verification project is to have
-tests tied to reqirements. 
+tests tied to reqirements.
 """
 from pathlib import Path
 
@@ -14,7 +14,6 @@ from metrics_logger.decorators import metrics_logger
 from romancal.lib.dms import log_result
 from romancal.lib.suffix import replace_suffix
 from romancal.ramp_fitting import RampFitStep
-from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
 
@@ -120,7 +119,7 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
             CONDITIONS_TRUNC,
         ),
     ],
-    ids=['image_full', 'spec_full', 'image_trunc', 'spec_trunc']
+    ids=["image_full", "spec_full", "image_trunc", "spec_trunc"],
 )
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -19,7 +19,8 @@ from .regtestdata import compare_asdf
 @pytest.fixture(scope='module',
                 params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf')),
                         ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf')),
-                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf'))])
+                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf')),
+                        ('DMS367', Path('WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf'))])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -17,7 +17,7 @@ from .regtestdata import compare_asdf
 # fixtures and utilities
 # ######################
 @pytest.fixture(scope='module',
-                params=[('DMS362', Path('WFI/image/r0000501001001001001_01101_0001_WFI01_dqinit.asdf')),
+                params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf')),
                         ('DMS366', Path('WFI/grism/spec_uneven_dqinit.asdf'))])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -11,6 +11,15 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
+def test_is_asdf(rampfit_result):
+    """Check that the filename has the correct file type"""
+    _, result_path = rampfit_result
+
+    assert result_path.exists()
+    assert result_path.suffix == '.asdf'
+
+
+@pytest.mark.bigdata
 def test_is_imagemodel(rampfit_result):
     """Check that the result is an ImageModel"""
     model, _ = rampfit_result
@@ -72,10 +81,10 @@ def rampfit_result(rtdata_module):
     """
     input_data = 'random_dqinit.asdf'
     input_data = rtdata_module.get_data(f'WFI/image/{input_data}')
-    with rdm.open(input_data) as input_model:
-        result_model = RampFitStep.call(input_model, save_results=True)
+    result_model = RampFitStep.call(input_data, save_results=True)
 
-    expected_path = replace_suffix(Path(input_data).stem, 'rampfit') + '.asdf'
+    input_data_path = Path(input_data)
+    expected_path = input_data_path.parent / (replace_suffix(input_data_path.stem, 'rampfit') + '.asdf')
 
     try:
         yield result_model, expected_path

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -130,7 +130,7 @@ def passfail(bool_expr):
 # Tests
 # #####
 @pytest.mark.bigdata
-def test_rampfit_success(rampfit_result, rtdata_module, ignore_asdf_paths):
+def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
     """Test rampfit result against various conditions"""
     requirement, model, expected_path, conditions = rampfit_result
     success = True

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -37,6 +37,14 @@ def test_is_rampfit(rampfit_result):
 
 
 @pytest.mark.bigdata
+def test_is_step_complete(rampfit_result):
+    """Check that the calibration step is marked complete"""
+    model, _ = rampfit_result
+
+    assert model.meta.cal_step.ramp_fit == 'COMPLETE'
+
+
+@pytest.mark.bigdata
 def test_is_uneven(rampfit_result):
     """Verify that the provided model represents uneven ramps
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -105,7 +105,7 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
         ),
         (
             "DMS366",
-            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_darkcurrent.asdf"),
+            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf"),
             CONDITIONS_FULL,
         ),
         (

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -44,14 +44,15 @@ def cond_is_step_complete(requirement, model, expected_path):
     return result
 
 
-def cond_is_uneven(requirement, model, expected_path):
-    """Verify that the provided model represents uneven ramps
+def cond_is_truncated(requirement, model, expected_path):
+    """Check if the data represents a truncated MA table/read pattern"""
+    result = model.meta.exposure.truncated
+    log_result(requirement, 'Testing if data represents a truncated MA table', result)
+    return result
 
-    Parameters
-    ----------
-    rampfit_result : `roman_datamodels.ImageModel`
-        Model created from `RampFitStep`
-    """
+
+def cond_is_uneven(requirement, model, expected_path):
+    """Verify that the provided model represents uneven ramps"""
     length_set = {len(resultant) for resultant in model.meta.exposure.read_pattern}
 
     result = len(length_set) > 1
@@ -71,6 +72,7 @@ def cond_science_verification(requirement, model, expected_path, rtdata_module, 
 
 
 CONDITIONS_FULL = [cond_is_asdf, cond_is_imagemodel, cond_is_rampfit, cond_is_step_complete, cond_is_uneven]
+CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
 
 # ######################
 # fixtures and utilities
@@ -78,8 +80,8 @@ CONDITIONS_FULL = [cond_is_asdf, cond_is_imagemodel, cond_is_rampfit, cond_is_st
 @pytest.fixture(scope='module',
                 params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf'), CONDITIONS_FULL),
                         ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf'), CONDITIONS_FULL),
-                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf'), CONDITIONS_FULL),
-                        ('DMS367', Path('WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf'), CONDITIONS_FULL)])
+                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf'), CONDITIONS_TRUNC),
+                        ('DMS367', Path('WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf'), CONDITIONS_TRUNC)])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -1,13 +1,13 @@
 """ Module to test rampfit with optional output """
-from metrics_logger.decorators import metrics_logger
 from pathlib import Path
-import pytest
 
+import pytest
 import roman_datamodels as rdm
+from metrics_logger.decorators import metrics_logger
+
 from romancal.lib.dms import log_result
 from romancal.lib.suffix import replace_suffix
 from romancal.ramp_fitting import RampFitStep
-from romancal.regtest.conftest import ignore_asdf_paths, rtdata_module
 from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
@@ -18,36 +18,40 @@ from .regtestdata import compare_asdf
 # ##########
 def cond_is_asdf(requirement, model, expected_path):
     """Check that the filename has the correct file type"""
-    result = expected_path.exists() and expected_path.suffix == '.asdf'
-    log_result(requirement, 'Testing that result file path has file type "asdf"', result)
+    result = expected_path.exists() and expected_path.suffix == ".asdf"
+    log_result(
+        requirement, 'Testing that result file path has file type "asdf"', result
+    )
     return result
 
 
 def cond_is_imagemodel(requirement, model, expected_path):
     """Check that the result is an ImageModel"""
     result = isinstance(model, rdm.datamodels.ImageModel)
-    log_result(requirement, 'Testing that the result model is Level 2', result)
+    log_result(requirement, "Testing that the result model is Level 2", result)
     return result
 
 
 def cond_is_rampfit(requirement, model, expected_path):
     """Check that the calibration suffix is 'rampfit'"""
-    result = expected_path.exists() and expected_path.stem.endswith('rampfit')
-    log_result(requirement, 'Testing that the result file has the suffix "rampfit"', result)
+    result = expected_path.exists() and expected_path.stem.endswith("rampfit")
+    log_result(
+        requirement, 'Testing that the result file has the suffix "rampfit"', result
+    )
     return result
 
 
 def cond_is_step_complete(requirement, model, expected_path):
     """Check that the calibration step is marked complete"""
-    result = model.meta.cal_step.ramp_fit == 'COMPLETE'
-    log_result(requirement, 'Testing that RampFitStep completed', result)
+    result = model.meta.cal_step.ramp_fit == "COMPLETE"
+    log_result(requirement, "Testing that RampFitStep completed", result)
     return result
 
 
 def cond_is_truncated(requirement, model, expected_path):
     """Check if the data represents a truncated MA table/read pattern"""
     result = model.meta.exposure.truncated
-    log_result(requirement, 'Testing if data represents a truncated MA table', result)
+    log_result(requirement, "Testing if data represents a truncated MA table", result)
     return result
 
 
@@ -56,32 +60,61 @@ def cond_is_uneven(requirement, model, expected_path):
     length_set = {len(resultant) for resultant in model.meta.exposure.read_pattern}
 
     result = len(length_set) > 1
-    log_result(requirement, 'Testing that the ramps are uneven', result)
+    log_result(requirement, "Testing that the ramps are uneven", result)
     return result
 
 
-def cond_science_verification(requirement, model, expected_path, rtdata_module, ignore_asdf_paths):
+def cond_science_verification(
+    requirement, model, expected_path, rtdata_module, ignore_asdf_paths
+):
     """Check against expected data results"""
     diff = compare_asdf(rtdata_module.output, rtdata_module.truth, **ignore_asdf_paths)
 
     result = diff.identical
     if not result:
         diff.report()
-    log_result(requirement, 'Testing science veracity', result)
+    log_result(requirement, "Testing science veracity", result)
     return result
 
 
-CONDITIONS_FULL = [cond_is_asdf, cond_is_imagemodel, cond_is_rampfit, cond_is_step_complete, cond_is_uneven]
+CONDITIONS_FULL = [
+    cond_is_asdf,
+    cond_is_imagemodel,
+    cond_is_rampfit,
+    cond_is_step_complete,
+    cond_is_uneven,
+]
 CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
+
 
 # ######################
 # fixtures and utilities
 # ######################
-@pytest.fixture(scope='module',
-                params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf'), CONDITIONS_FULL),
-                        ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf'), CONDITIONS_FULL),
-                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf'), CONDITIONS_TRUNC),
-                        ('DMS367', Path('WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf'), CONDITIONS_TRUNC)])
+@pytest.fixture(
+    scope="module",
+    params=[
+        (
+            "DMS362",
+            Path("WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf"),
+            CONDITIONS_FULL,
+        ),
+        (
+            "DMS366",
+            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf"),
+            CONDITIONS_FULL,
+        ),
+        (
+            "DMS363",
+            Path("WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf"),
+            CONDITIONS_TRUNC,
+        ),
+        (
+            "DMS367",
+            Path("WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf"),
+            CONDITIONS_TRUNC,
+        ),
+    ],
+)
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 
@@ -105,12 +138,12 @@ def rampfit_result(request, rtdata_module):
 
     # Setup outputs
     input_data_path = Path(input_data)
-    output = (replace_suffix(input_data_path.stem, 'rampfit') + '.asdf')
+    output = replace_suffix(input_data_path.stem, "rampfit") + ".asdf"
     expected_path = input_data_path.parent / output
 
     # Get truths
     rtdata_module.output = output
-    output_artifactory_path = Path('truth') / artifactory_path.parent / output
+    output_artifactory_path = Path("truth") / artifactory_path.parent / output
     rtdata_module.get_truth(str(output_artifactory_path))
 
     try:
@@ -138,13 +171,15 @@ def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
         success = success and condition(requirement, model, expected_path)
 
     # Always do a full regression check.
-    success = success and cond_science_verification(requirement, model, expected_path, rtdata_module, ignore_asdf_paths)
+    success = success and cond_science_verification(
+        requirement, model, expected_path, rtdata_module, ignore_asdf_paths
+    )
 
     @metrics_logger(requirement)
     def test_success():
         assert success
-    test_success()
 
+    test_success()
 
 
 @pytest.mark.bigdata

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -18,7 +18,8 @@ from .regtestdata import compare_asdf
 # ######################
 @pytest.fixture(scope='module',
                 params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf')),
-                        ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf'))])
+                        ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf')),
+                        ('DMS363', Path('WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf'))])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -105,7 +105,7 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
         ),
         (
             "DMS366",
-            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf"),
+            Path("WFI/grism/r0000201001001001001_01101_0001_WFI17_dqinit.asdf"),
             CONDITIONS_FULL,
         ),
         (

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -1,4 +1,10 @@
-""" Module to test rampfit with optional output """
+""" Module to test rampfit with optional output
+
+Notes
+-----
+A requirement for the larger mission verification project is to have
+tests tied to reqirements. 
+"""
 from pathlib import Path
 
 import pytest
@@ -95,12 +101,12 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
     params=[
         (
             "DMS362",
-            Path("WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf"),
+            Path("WFI/image/r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"),
             CONDITIONS_FULL,
         ),
         (
             "DMS366",
-            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf"),
+            Path("WFI/grism/r0000201001001001001_01101_0001_WFI05_darkcurrent.asdf"),
             CONDITIONS_FULL,
         ),
         (
@@ -114,6 +120,7 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
             CONDITIONS_TRUNC,
         ),
     ],
+    ids=['image_full', 'spec_full', 'image_trunc', 'spec_trunc']
 )
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
@@ -163,7 +170,7 @@ def passfail(bool_expr):
 # Tests
 # #####
 @pytest.mark.bigdata
-def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
+def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths):
     """Test rampfit result against various conditions"""
     requirement, model, expected_path, conditions = rampfit_result
     error_msgs = []
@@ -186,23 +193,3 @@ def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
         assert not len(error_msgs), "\n".join(error_msgs)
 
     test_success()
-
-
-@pytest.mark.bigdata
-def test_ramp_fitting_step(rtdata, ignore_asdf_paths):
-    """Testing the ramp fitting step"""
-    input_data = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
-    rtdata.get_data(f"WFI/image/{input_data}")
-    rtdata.input = input_data
-
-    args = [
-        "romancal.step.RampFitStep",
-        rtdata.input,
-    ]
-    RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_rampfit.asdf"
-    rtdata.output = output
-    rtdata.get_truth(f"truth/WFI/image/{output}")
-
-    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    assert diff.identical, diff.report()

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -1,9 +1,9 @@
 """ Module to test rampfit with optional output """
-import functools
 from pathlib import Path
 import pytest
 
 import roman_datamodels as rdm
+from romancal.lib.dms import result_logger
 from romancal.lib.suffix import replace_suffix
 from romancal.ramp_fitting import RampFitStep
 from romancal.stpipe import RomanStep
@@ -14,39 +14,8 @@ from .regtestdata import compare_asdf
 logger = RampFitStep().log
 
 
-def result_logger(message, logger=logger):
-    """Decorator to log assertion status
-
-    Parameters
-    ----------
-    message : str
-        The message to use. Note that the phrase of either "PASS" or "FAIL"
-        will be appended to the end of the message.
-    """
-    def decorator(test_function):
-
-        @functools.wraps(test_function)
-        def inner(*args, **kwargs):
-
-            def log_result(result):
-                result_text = 'PASS' if result else 'FAIL'
-                logger.info(message + result_text)
-
-            try:
-                test_function(*args, **kwargs)
-            except Exception:
-                log_result(False)
-                raise
-            else:
-                log_result(True)
-
-        return inner
-
-    return decorator
-
-
 @pytest.mark.bigdata
-@result_logger('DMS362 MSG: Testing that the result file is of type "asdf".......')
+@result_logger('DMS362 MSG: Testing that the result file is of type "asdf".......', logger)
 def test_is_asdf(rampfit_result):
     """Check that the filename has the correct file type"""
     _, result_path = rampfit_result
@@ -55,7 +24,7 @@ def test_is_asdf(rampfit_result):
 
 
 @pytest.mark.bigdata
-@result_logger('DMS362 MSG: Testing that the result model is Level 2.......')
+@result_logger('DMS362 MSG: Testing that the result model is Level 2.......', logger)
 def test_is_imagemodel(rampfit_result):
     """Check that the result is an ImageModel"""
     model, _ = rampfit_result
@@ -64,7 +33,7 @@ def test_is_imagemodel(rampfit_result):
 
 
 @pytest.mark.bigdata
-@result_logger('DMS362 MSG: Testing that the result file has the suffix "rampfit".......')
+@result_logger('DMS362 MSG: Testing that the result file has the suffix "rampfit".......', logger)
 def test_is_rampfit(rampfit_result):
     """Check that the calibration suffix is 'rampfit'"""
     _, result_path = rampfit_result
@@ -73,7 +42,7 @@ def test_is_rampfit(rampfit_result):
 
 
 @pytest.mark.bigdata
-@result_logger('DMS362 MSG: Testing that RampFitStep completed.......')
+@result_logger('DMS362 MSG: Testing that RampFitStep completed.......', logger)
 def test_is_step_complete(rampfit_result):
     """Check that the calibration step is marked complete"""
     model, _ = rampfit_result
@@ -82,7 +51,7 @@ def test_is_step_complete(rampfit_result):
 
 
 @pytest.mark.bigdata
-@result_logger('DMS362 MSG: Testing that the ramps are uneven.......')
+@result_logger('DMS362 MSG: Testing that the ramps are uneven.......', logger)
 def test_is_uneven(rampfit_result):
     """Verify that the provided model represents uneven ramps
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -19,14 +19,14 @@ from .regtestdata import compare_asdf
 def cond_is_asdf(requirement, model, expected_path):
     """Check that the filename has the correct file type"""
     msg = 'Testing that result file path has file type "asdf"'
-    result = expected_path.exists() and expected_path.suffix == '.asdf'
+    result = expected_path.exists() and expected_path.suffix == ".asdf"
     log_result(requirement, msg, result)
     assert result, msg
 
 
 def cond_is_imagemodel(requirement, model, expected_path):
     """Check that the result is an ImageModel"""
-    msg = 'Testing that the result model is Level 2'
+    msg = "Testing that the result model is Level 2"
     result = isinstance(model, rdm.datamodels.ImageModel)
     log_result(requirement, msg, result)
     assert result, msg
@@ -35,22 +35,22 @@ def cond_is_imagemodel(requirement, model, expected_path):
 def cond_is_rampfit(requirement, model, expected_path):
     """Check that the calibration suffix is 'rampfit'"""
     msg = 'Testing that the result file has the suffix "rampfit"'
-    result = expected_path.exists() and expected_path.stem.endswith('rampfit')
+    result = expected_path.exists() and expected_path.stem.endswith("rampfit")
     log_result(requirement, msg, result)
     assert result, msg
 
 
 def cond_is_step_complete(requirement, model, expected_path):
     """Check that the calibration step is marked complete"""
-    msg = 'Testing that RampFitStep completed'
-    result = model.meta.cal_step.ramp_fit == 'COMPLETE'
+    msg = "Testing that RampFitStep completed"
+    result = model.meta.cal_step.ramp_fit == "COMPLETE"
     log_result(requirement, msg, result)
     assert result, msg
 
 
 def cond_is_truncated(requirement, model, expected_path):
     """Check if the data represents a truncated MA table/read pattern"""
-    msg = 'Testing if data represents a truncated MA table'
+    msg = "Testing if data represents a truncated MA table"
     result = model.meta.exposure.truncated
     log_result(requirement, msg, result)
     assert result, msg
@@ -58,7 +58,7 @@ def cond_is_truncated(requirement, model, expected_path):
 
 def cond_is_uneven(requirement, model, expected_path):
     """Verify that the provided model represents uneven ramps"""
-    msg = 'Testing that the ramps are uneven'
+    msg = "Testing that the ramps are uneven"
     length_set = {len(resultant) for resultant in model.meta.exposure.read_pattern}
     result = len(length_set) > 1
     log_result(requirement, msg, result)
@@ -69,7 +69,7 @@ def cond_science_verification(
     requirement, model, expected_path, rtdata_module, ignore_asdf_paths
 ):
     """Check against expected data results"""
-    msg = 'Testing science veracity'
+    msg = "Testing science veracity"
     diff = compare_asdf(rtdata_module.output, rtdata_module.truth, **ignore_asdf_paths)
 
     result = diff.identical
@@ -175,13 +175,16 @@ def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
 
     # Always do a full regression check.
     try:
-        cond_science_verification(requirement, model, expected_path, rtdata_module, ignore_asdf_paths)
+        cond_science_verification(
+            requirement, model, expected_path, rtdata_module, ignore_asdf_paths
+        )
     except AssertionError as e:
         error_msgs.append(str(e))
 
     @metrics_logger(requirement)
     def test_success():
-        assert not len(error_msgs), '\n'.join(error_msgs)
+        assert not len(error_msgs), "\n".join(error_msgs)
+
     test_success()
 
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -18,7 +18,7 @@ from .regtestdata import compare_asdf
 # ######################
 @pytest.fixture(scope='module',
                 params=[('DMS362', Path('WFI/image/r0000101001001001001_01101_0001_WFI01_dqinit.asdf')),
-                        ('DMS366', Path('WFI/grism/spec_uneven_dqinit.asdf'))])
+                        ('DMS366', Path('WFI/grism/r0000201001001001001_01101_0001_WFI05_dqinit.asdf'))])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -11,21 +11,16 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
+def test_is_imagemodel(rampfit_result):
+    """Check that the result is an ImageModel"""
+    model, _ = rampfit_result
+
+    assert isinstance(model, rdm.datamodels.ImageModel)
+
+
+@pytest.mark.bigdata
 def test_is_uneven(rampfit_result):
     """Verify that the provided model represents uneven ramps
-
-
-    Using Roman terminology, a "read pattern" is a list of resultants. Each element of this list
-    is a list of reads that were combined, on-board, to create a resultant. An example read pattern is
-
-    [[1], [2, 3], [4], [5, 6, 7, 8], [9, 10], [11]]
-
-    This pattern has 6 resultants, the first consistent of the first read, the
-    next consisting of reads 2 and 3, the third consists of read 4, and so on.
-
-    An uneven read pattern should have resultants that are created from different number of reads.
-    If the length of each resultant read list is the same for all resultants, that is an even set
-    of ramps and will fail that test
 
     Parameters
     ----------
@@ -67,8 +62,8 @@ def rampfit_result(rtdata_module):
 
     Parameters
     ----------
-    tmpdir : pytest.fixture
-        Temporary working directory
+    rtdata_module : pytest.fixture
+        artifactory fixture for data retrieval
 
     Returns
     -------

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -184,7 +184,6 @@ def test_rampfit_dmsreqs(rampfit_result, rtdata_module, ignore_asdf_paths):
         assert not len(error_msgs), '\n'.join(error_msgs)
     test_success()
 
-    test_success()
 
 @pytest.mark.bigdata
 def test_ramp_fitting_step(rtdata, ignore_asdf_paths):

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -16,8 +16,8 @@ from .regtestdata import compare_asdf
 # fixtures and utilities
 # ######################
 @pytest.fixture(scope='module',
-                params=[('DMS362', 'WFI/image/random_dqinit.asdf'),
-                        ('DMS366', 'WFI/grism/spec_fixedreadpattern_dqinit.asdf')])
+                params=[('DMS362', 'WFI/image/image_uneven_dqinit.asdf'),
+                        ('DMS366', 'WFI/grism/spec_uneven_dqinit.asdf')])
 def rampfit_result(request, rtdata_module):
     """Run RampFitStep
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -28,6 +28,15 @@ def test_is_imagemodel(rampfit_result):
 
 
 @pytest.mark.bigdata
+def test_is_rampfit(rampfit_result):
+    """Check that the calibration suffix is 'rampfit'"""
+    _, result_path = rampfit_result
+
+    assert result_path.exists()
+    assert result_path.stem.endswith('rampfit')
+
+
+@pytest.mark.bigdata
 def test_is_uneven(rampfit_result):
     """Verify that the provided model represents uneven ramps
 

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -26,7 +26,7 @@ def passfail(bool_expr):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
-@metrics_logger("DMS86", "DMS87", "DMS88", "DMS361")
+@metrics_logger("DMS86", "DMS87", "DMS88", "DMS361", "DMS280")
 def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     """Tests for flat field imaging processing requirements DMS86 & DMS 87"""
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
@@ -50,6 +50,12 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
     # Initial prep
     model = rdm.open(rtdata.output, lazy_load=False)
     pipeline = ExposurePipeline()
+
+    # DMS280 result is an ImageModel
+    pipeline.log.info(
+        "DMS280 MSG: Testing that result is a Level 2 model......."
+        + passfail(isinstance(model, rdm.datamodels.ImageModel))
+    )
 
     # DMS86 instrument artifact correction tests
     pipeline.log.info(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-661](https://jira.stsci.edu/browse/rcal-661)
Resolves [RCAL-667](https://jira.stsci.edu/browse/rcal-667)
Resolves [RCAL-654](https://jira.stsci.edu/browse/rcal-654)
Resolves [RCAL-656](https://jira.stsci.edu/browse/rcal-656)

<!-- describe the changes comprising this PR here -->
This PR implements the SOC test requirements for being able to calibrate uneven ramps in both the `RampFitStep` and `ExposurePipeline`

Note that RCAL_667 was mostly already done in the test `test_wfi_pipeline.py` module; the requirement message was simply updated. An additional check on `ImageModel` was added.

Note: Currently draft awaiting official test data.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
