### PR TITLE
don't run tests on `romancal/scripts`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ zip-safe = false
 minversion = 4.6
 norecursedirs = [
     'docs/_build',
-    'scripts',
+    'romancal/scripts',
     '.tox',
     '.eggs',
     'build',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where test collection fails upon attempting to import in the new `static_preview` script:
https://github.com/spacetelescope/stcal/actions/runs/6772518526/job/18405280890#step:10:174

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
