### PR TITLE
Protect imports in script better

### DIFF
--- a/romancal/scripts/static_preview.py
+++ b/romancal/scripts/static_preview.py
@@ -1,99 +1,109 @@
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import asdf
 import numpy
-from typing_extensions import Annotated
 
-try:
-    import typer
-    from stpreview.downsample import downsample_asdf_to
-    from stpreview.image import north_pole_angle, percentile_normalization, write_image
-except (ImportError, ModuleNotFoundError):
-    raise ImportError(
-        'SDP requirements not installed; do `pip install "romancal[sdp]"`'
-    )
-
-app = typer.Typer()
-
-
-@app.command()
-def preview(
-    input: Annotated[Path, typer.Argument(help="path to ASDF file with 2D image data")],
-    output: Annotated[
-        Optional[Path], typer.Argument(help="path to output image file")
-    ] = None,
-    shape: Annotated[
-        Optional[tuple[int, int]],
-        typer.Argument(help="desired pixel resolution of output image"),
-    ] = (1080, 1080),
-    compass: Annotated[
-        Optional[bool], typer.Option(help="whether to draw a north arrow on the image")
-    ] = True,
-):
-    """
-    create a preview image with a north arrow overlay indicating orientation
-    """
-
-    if output is None:
-        output = Path.cwd()
-    if output.is_dir():
-        output = output / f"{input.stem}.png"
-
-    with asdf.open(input) as file:
-        model = file["roman"]["meta"]["model_type"]
-        if "image" not in model.lower():
-            raise NotImplementedError(f'"{model}" model not supported')
-        wcs = file["roman"]["meta"]["wcs"]
-
-    data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
-
-    write_image(
-        data,
-        output,
-        shape=shape,
-        normalization=percentile_normalization(data, percentile=90),
-        colormap="afmhot",
-        north_arrow_angle=north_pole_angle(wcs).degree - 90,
-    )
-
-
-@app.command()
-def thumbnail(
-    input: Annotated[Path, typer.Argument(help="path to ASDF file with 2D image data")],
-    output: Annotated[
-        Optional[Path], typer.Argument(help="path to output image file")
-    ] = None,
-    shape: Annotated[
-        Optional[tuple[int, int]],
-        typer.Argument(help="desired pixel resolution of output image"),
-    ] = (300, 300),
-    compass: Annotated[
-        Optional[bool], typer.Option(help="whether to draw a north arrow on the image")
-    ] = False,
-):
-    if output is None:
-        output = Path.cwd()
-    if output.is_dir():
-        output = output / f"{input.stem}_thumb.png"
-
-    with asdf.open(input) as file:
-        model = file["roman"]["meta"]["model_type"]
-        if "image" not in model.lower():
-            raise NotImplementedError(f'"{model}" model not supported')
-
-    data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
-
-    write_image(
-        data,
-        output,
-        shape=shape,
-        normalization=percentile_normalization(data, percentile=90),
-        colormap="afmhot",
-    )
+if TYPE_CHECKING:
+    from typing_extensions import Annotated
 
 
 def command():
+    try:
+        import typer
+        from stpreview.downsample import downsample_asdf_to
+        from stpreview.image import (
+            north_pole_angle,
+            percentile_normalization,
+            write_image,
+        )
+    except (ImportError, ModuleNotFoundError):
+        raise ImportError(
+            'SDP requirements not installed; do `pip install "romancal[sdp]"`'
+        )
+
+    app = typer.Typer()
+
+    @app.command()
+    def preview(
+        input: Annotated[
+            Path, typer.Argument(help="path to ASDF file with 2D image data")
+        ],
+        output: Annotated[
+            Optional[Path], typer.Argument(help="path to output image file")
+        ] = None,
+        shape: Annotated[
+            Optional[tuple[int, int]],
+            typer.Argument(help="desired pixel resolution of output image"),
+        ] = (1080, 1080),
+        compass: Annotated[
+            Optional[bool],
+            typer.Option(help="whether to draw a north arrow on the image"),
+        ] = True,
+    ):
+        """
+        create a preview image with a north arrow overlay indicating orientation
+        """
+
+        if output is None:
+            output = Path.cwd()
+        if output.is_dir():
+            output = output / f"{input.stem}.png"
+
+        with asdf.open(input) as file:
+            model = file["roman"]["meta"]["model_type"]
+            if "image" not in model.lower():
+                raise NotImplementedError(f'"{model}" model not supported')
+            wcs = file["roman"]["meta"]["wcs"]
+
+        data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
+
+        write_image(
+            data,
+            output,
+            shape=shape,
+            normalization=percentile_normalization(data, percentile=90),
+            colormap="afmhot",
+            north_arrow_angle=north_pole_angle(wcs).degree - 90,
+        )
+
+    @app.command()
+    def thumbnail(
+        input: Annotated[
+            Path, typer.Argument(help="path to ASDF file with 2D image data")
+        ],
+        output: Annotated[
+            Optional[Path], typer.Argument(help="path to output image file")
+        ] = None,
+        shape: Annotated[
+            Optional[tuple[int, int]],
+            typer.Argument(help="desired pixel resolution of output image"),
+        ] = (300, 300),
+        compass: Annotated[
+            Optional[bool],
+            typer.Option(help="whether to draw a north arrow on the image"),
+        ] = False,
+    ):
+        if output is None:
+            output = Path.cwd()
+        if output.is_dir():
+            output = output / f"{input.stem}_thumb.png"
+
+        with asdf.open(input) as file:
+            model = file["roman"]["meta"]["model_type"]
+            if "image" not in model.lower():
+                raise NotImplementedError(f'"{model}" model not supported')
+
+        data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
+
+        write_image(
+            data,
+            output,
+            shape=shape,
+            normalization=percentile_normalization(data, percentile=90),
+            colormap="afmhot",
+        )
+
     app()
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #976

<!-- describe the changes comprising this PR here -->
This PR protects the external dependencies by making them local to a function. This way they are not imported immediately.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
