### PR TITLE
rcal-687 Initial code for the high level pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ general
 
 - Update elp pipeline code to capture a list from tweakreg [#985]
 
+- Add code to run the steps needed for the high level processing (roman_hlp) [#980]
+
 - Update pipeline code to correct cal_step and suffixes [#971]
 
 - Update pipeline code to run through tweakreg with single files and associations [#960]

--- a/romancal/pipeline/__init__.py
+++ b/romancal/pipeline/__init__.py
@@ -3,5 +3,6 @@ This module collects all of the stpipe.Pipeline subclasses
 made available by this package.
 """
 from .exposure_pipeline import ExposurePipeline
+from .highlevel_pipeline import HighLevelPipeline
 
-__all__ = ["ExposurePipeline"]
+__all__ = ["ExposurePipeline", "HighLevelPipeline"]

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -22,7 +22,7 @@ class HighLevelPipeline(RomanPipeline):
     """
     HighLevelPipeline: Apply all calibration steps to the roman data
     to produce level 3 products. Included steps are:
-     ``skymatch``, ``outlier_detection`` and ``resample``.
+    ``skymatch``, ``outlier_detection`` and ``resample``.
     """
 
     class_alias = "roman_hlp"

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -56,7 +56,6 @@ class HighLevelPipeline(RomanPipeline):
 
         # open the input file
         file_type = filetype.check(input)
-        asn = None
         if file_type == "asdf":
             log.info("The level three pipeline input needs to be an association")
             return

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python
 import logging
 from os.path import basename
+import pdb
+
+import numpy as np
+from roman_datamodels import datamodels as rdm
 
 import romancal.datamodels.filetype as filetype
-from romancal.datamodels import ModelContainer
-from romancal.outlier_detection import OutlierDetectionStep
-from romancal.resample import ResampleStep
 
 # step imports
 from romancal.skymatch import SkyMatchStep
+from romancal.outlier_detection import OutlierDetectionStep
+from romancal.resample import ResampleStep
+from romancal.lib import dqflags
+from romancal.datamodels import ModelContainer
+
 
 from ..stpipe import RomanPipeline
 
@@ -35,7 +41,7 @@ class HighLevelPipeline(RomanPipeline):
     # Define aliases to steps
     step_defs = {
         "skymatch": SkyMatchStep,
-        "outlierdet": OutlierDetectionStep,
+        "outlierdetection": OutlierDetectionStep,
         "resample": ResampleStep,
     }
 
@@ -64,9 +70,7 @@ class HighLevelPipeline(RomanPipeline):
             result = self.outlierdetection(asn)
             self.skymatch.suffix = "i2d"
             result = self.resample(result)
-            if input_filename:
-                result.meta.filename = input_filename
-
+   
         return result
 
     def setup_output(self, input):
@@ -78,3 +82,4 @@ class HighLevelPipeline(RomanPipeline):
             self.output_file = input.meta.filename
         else:
             self.suffix = "cal"
+

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -70,6 +70,8 @@ class HighLevelPipeline(RomanPipeline):
             result = self.outlierdetection(asn)
             self.skymatch.suffix = "i2d"
             result = self.resample(result)
+            if input_filename:
+                result.meta.filename = input_filename
    
         return result
 

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -29,7 +29,7 @@ class HighLevelPipeline(RomanPipeline):
     """
     HighLevelPipeline: Apply all calibration steps to the roman data
     to produce level 3 products. Included steps are:
-    skymatch, Outlierdetection and resample.
+     ``skymatch``, ``outlier_detection`` and ``resample``.
     """
 
     class_alias = "roman_hlp"

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python
 import logging
 from os.path import basename
-import pdb
-
-import numpy as np
-from roman_datamodels import datamodels as rdm
 
 import romancal.datamodels.filetype as filetype
+from romancal.outlier_detection import OutlierDetectionStep
+from romancal.resample import ResampleStep
 
 # step imports
 from romancal.skymatch import SkyMatchStep
-from romancal.outlier_detection import OutlierDetectionStep
-from romancal.resample import ResampleStep
-from romancal.lib import dqflags
-
 
 from ..stpipe import RomanPipeline
 
@@ -64,12 +58,10 @@ class HighLevelPipeline(RomanPipeline):
             self.skymatch.suffix = "skymatch"
             result = self.skymatch(input)
             self.skymatch.suffix = "outlier_detection"
-            #result = self.outlier_detection(input)
+            # result = self.outlier_detection(input)
             self.skymatch.suffix = "i2d"
             result = self.resample(input)
             if input_filename:
                 result.meta.filename = input_filename
-   
+
         return result
-
-

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -13,7 +13,6 @@ from romancal.skymatch import SkyMatchStep
 from romancal.outlier_detection import OutlierDetectionStep
 from romancal.resample import ResampleStep
 from romancal.lib import dqflags
-from romancal.datamodels import ModelContainer
 
 
 from ..stpipe import RomanPipeline
@@ -41,7 +40,7 @@ class HighLevelPipeline(RomanPipeline):
     # Define aliases to steps
     step_defs = {
         "skymatch": SkyMatchStep,
-        "outlierdetection": OutlierDetectionStep,
+        "outlier_detection": OutlierDetectionStep,
         "resample": ResampleStep,
     }
 
@@ -63,25 +62,15 @@ class HighLevelPipeline(RomanPipeline):
             return
 
         if file_type == "asn":
-            asn = ModelContainer.read_asn(input)
             self.skymatch.suffix = "skymatch"
             result = self.skymatch(input)
-            self.skymatch.suffix = "outlierdetection"
-            result = self.outlierdetection(asn)
+            self.skymatch.suffix = "outlier_detection"
+            #result = self.outlier_detection(input)
             self.skymatch.suffix = "i2d"
-            result = self.resample(result)
+            result = self.resample(input)
             if input_filename:
                 result.meta.filename = input_filename
    
         return result
 
-    def setup_output(self, input):
-        """Determine the proper file name suffix to use later"""
-        if input.meta.cal_step.ramp_fit == "COMPLETE":
-            self.suffix = "cal"
-            input.meta.filename = input.meta.filename.replace("uncal", self.suffix)
-            input["output_file"] = input.meta.filename
-            self.output_file = input.meta.filename
-        else:
-            self.suffix = "cal"
 

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -29,7 +29,7 @@ class HighLevelPipeline(RomanPipeline):
     """
     HighLevelPipeline: Apply all calibration steps to the roman data
     to produce level 3 products. Included steps are:
-    skymatch, Outlierdetectionn and resample.
+    skymatch, Outlierdetection and resample.
     """
 
     class_alias = "roman_hlp"

--- a/romancal/stpipe/integration.py
+++ b/romancal/stpipe/integration.py
@@ -22,6 +22,7 @@ def get_steps():
     # romancal.step to keep the CLI snappy.
     return [
         ("romancal.pipeline.ExposurePipeline", "roman_elp", True),
+        ("romancal.pipeline.HighLevelPipeline", "roman_hlp", True),
         ("romancal.step.DarkCurrentStep", None, False),
         ("romancal.step.DQInitStep", None, False),
         ("romancal.step.FlatFieldStep", None, False),

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -19,6 +19,7 @@ NON_STEPS = [
     "RomancalPipeline",
     "RomanPipeline",
     "ExposurePipeline",
+    "HighLevelPipeline",
     "RomanStep",
     "Pipeline",
     "Step",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

Resolves [RCAL-687](https://jira.stsci.edu/browse/rcal-687)

Closes https://github.com/spacetelescope/romancal/issues/924

This PR adds the level 3 pipeline code for high level processing. Testing the steps will need new data from INS.
Once we have the data the documentation and examples will be added to rtd.

The command to run the pipeline
strun --disable-crds-steppar roman_hlp r00005-a3001_image_001_short_asn.json
2023-11-14 14:34:26,342 - stpipe - WARNING - **WARNING**: LOCAL JWST PRD VERSION PRDOPSSOC-062 CANNOT BE CHECKED AGAINST ONLINE VERSION
2023-11-14 14:34:26,386 - stpipe.HighLevelPipeline - INFO - HighLevelPipeline instance created.
2023-11-14 14:34:26,387 - stpipe.HighLevelPipeline.skymatch - INFO - SkyMatchStep instance created.
2023-11-14 14:34:26,388 - stpipe.HighLevelPipeline.outlier_detection - INFO - OutlierDetectionStep instance created.
2023-11-14 14:34:26,389 - stpipe.HighLevelPipeline.resample - INFO - ResampleStep instance created.
2023-11-14 14:34:26,389 - stpipe - INFO - Hostname: attilla.fios-router.home.stsci.edu
2023-11-14 14:34:26,389 - stpipe - INFO - OS: Darwin
2023-11-14 14:34:26,457 - stpipe.HighLevelPipeline - INFO - Step HighLevelPipeline running with args ('r00005-a3001_image_001_short_asn.json',).
2023-11-14 14:34:26,460 - stpipe.HighLevelPipeline - INFO - Step HighLevelPipeline parameters are: {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': True, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': '', 'steps': {'skymatch': {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': False, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': '', 'skymethod': 'match', 'match_down': True, 'subtract': False, 'stepsize': None, 'skystat': 'mode', 'dqbits': '~DO_NOT_USE+NON_SCIENCE', 'lower': None, 'upper': None, 'nclip': 5, 'lsigma': 4.0, 'usigma': 4.0, 'binwidth': 0.1}, 'outlier_detection': {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': False, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': ''}, 'resample': {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': False, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': '', 'pixfrac': 1.0, 'kernel': 'square', 'fillval': 'INDEF', 'weight_type': 'ivm', 'output_shape': None, 'crpix': None, 'crval': None, 'rotation': None, 'pixel_scale_ratio': 1.0, 'pixel_scale': None, 'output_wcs': '', 'single': False, 'blendheaders': True, 'allowed_memory': None, 'in_memory': True}}}
2023-11-14 14:34:26,460 - stpipe.HighLevelPipeline - INFO - Starting Roman high level calibration pipeline ...
2023-11-14 14:34:26,530 - stpipe.HighLevelPipeline.skymatch - INFO - Step skymatch running with args ('r00005-a3001_image_001_short_asn.json',).
2023-11-14 14:34:26,531 - stpipe.HighLevelPipeline.skymatch - INFO - Step skymatch parameters are: {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': False, 'skip': False, 'suffix': 'skymatch', 'search_output_file': True, 'input_dir': '', 'skymethod': 'match', 'match_down': True, 'subtract': False, 'stepsize': None, 'skystat': 'mode', 'dqbits': '~DO_NOT_USE+NON_SCIENCE', 'lower': None, 'upper': None, 'nclip': 5, 'lsigma': 4.0, 'usigma': 4.0, 'binwidth': 0.1}
2023-11-14 14:34:27,064 - stpipe.HighLevelPipeline.skymatch - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "dtf2d" yielded 1 of "dubious year (Note 6)"
2023-11-14 14:34:27,064 - stpipe.HighLevelPipeline.skymatch - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:34:27,064 - stpipe.HighLevelPipeline.skymatch - WARNING -
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO -
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO - ***** romancal.skymatch.skymatch.match() started on 2023-11-14 14:34:27.692978
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO -
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO - Sky computation method: 'match'
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO - Sky matching direction: DOWN
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO - Sky subtraction from image data: OFF
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO -
2023-11-14 14:34:27,693 - stpipe.HighLevelPipeline.skymatch - INFO - ----  Computing differences in sky values in overlapping regions.
2023-11-14 14:34:29,811 - stpipe.HighLevelPipeline.skymatch - INFO -    *  Image ID=None. Sky background: 0 electron / s
2023-11-14 14:34:29,812 - stpipe.HighLevelPipeline.skymatch - INFO -    *  Image ID=None. Sky background: 0.836698 electron / s
2023-11-14 14:34:29,812 - stpipe.HighLevelPipeline.skymatch - INFO -
2023-11-14 14:34:29,812 - stpipe.HighLevelPipeline.skymatch - INFO - ***** romancal.skymatch.skymatch.match() ended on 2023-11-14 14:34:29.812262
2023-11-14 14:34:29,812 - stpipe.HighLevelPipeline.skymatch - INFO - ***** romancal.skymatch.skymatch.match() TOTAL RUN TIME: 0:00:02.119284
2023-11-14 14:34:29,812 - stpipe.HighLevelPipeline.skymatch - INFO -
2023-11-14 14:34:29,818 - stpipe.HighLevelPipeline.skymatch - INFO - Step skymatch done
2023-11-14 14:34:29,900 - stpipe.HighLevelPipeline.resample - INFO - Step resample running with args ('r00005-a3001_image_001_short_asn.json',).
2023-11-14 14:34:29,902 - stpipe.HighLevelPipeline.resample - INFO - Step resample parameters are: {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.asdf', 'output_use_model': False, 'output_use_index': True, 'save_results': False, 'skip': False, 'suffix': None, 'search_output_file': True, 'input_dir': '', 'pixfrac': 1.0, 'kernel': 'square', 'fillval': 'INDEF', 'weight_type': 'ivm', 'output_shape': None, 'crpix': None, 'crval': None, 'rotation': None, 'pixel_scale_ratio': 1.0, 'pixel_scale': None, 'output_wcs': '', 'single': False, 'blendheaders': True, 'allowed_memory': None, 'in_memory': True}
2023-11-14 14:34:30,486 - stpipe.HighLevelPipeline.resample - INFO - Setting drizzle's default parameters...
2023-11-14 14:34:30,487 - stpipe.HighLevelPipeline.resample - INFO -   using: pixfrac=1.0
2023-11-14 14:34:30,487 - stpipe.HighLevelPipeline.resample - INFO -   using: kernel='square'
2023-11-14 14:34:30,487 - stpipe.HighLevelPipeline.resample - INFO -   using: fillval='INDEF'
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO -   using: wht_type='ivm'
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO -   using: pscale_ratio=1.0
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO - Driz parameter kernel: square
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO - Driz parameter pixfrac: 1.0
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO - Driz parameter fillval: INDEF
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO - Driz parameter weight_type: ivm
2023-11-14 14:34:30,488 - stpipe.HighLevelPipeline.resample - INFO - Output pixel scale ratio: 1.0
2023-11-14 14:34:30,902 - stpipe.HighLevelPipeline.resample - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:34:30,902 - stpipe.HighLevelPipeline.resample - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:34:30,902 - stpipe.HighLevelPipeline.resample - WARNING -
2023-11-14 14:34:30,907 - stpipe.HighLevelPipeline.resample - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:34:30,907 - stpipe.HighLevelPipeline.resample - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:34:30,907 - stpipe.HighLevelPipeline.resample - WARNING -
2023-11-14 14:34:31,297 - stpipe.HighLevelPipeline.resample - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:34:31,297 - stpipe.HighLevelPipeline.resample - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:34:31,297 - stpipe.HighLevelPipeline.resample - WARNING -
2023-11-14 14:34:31,300 - stpipe.HighLevelPipeline.resample - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:34:31,300 - stpipe.HighLevelPipeline.resample - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:34:31,300 - stpipe.HighLevelPipeline.resample - WARNING -
2023-11-14 14:34:31,723 - stpipe.HighLevelPipeline.resample - INFO - Skipping blendheaders for now.
2023-11-14 14:34:31,735 - stpipe.HighLevelPipeline.resample - INFO - Resampling science data
2023-11-14 14:34:39,102 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:34:43,925 - stpipe.HighLevelPipeline.resample - INFO - Results from cdrizzle.tdriz():             '_vers'=Callable C-based DRIZZLE Version 1.12 (28th June 2018), 'nmiss'=-4088, 'nskip'=0
2023-11-14 14:34:50,513 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:34:55,273 - stpipe.HighLevelPipeline.resample - INFO - Results from cdrizzle.tdriz():             '_vers'=Callable C-based DRIZZLE Version 1.12 (28th June 2018), 'nmiss'=-4058, 'nskip'=0
2023-11-14 14:34:55,306 - stpipe.HighLevelPipeline.resample - INFO - Resampling var_rnoise
2023-11-14 14:35:01,954 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:35:13,729 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:35:18,807 - stpipe.HighLevelPipeline.resample - INFO - Resampling var_poisson
2023-11-14 14:35:25,536 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:35:37,467 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:35:42,687 - stpipe.HighLevelPipeline.resample - INFO - Resampling var_flat
2023-11-14 14:35:49,194 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:36:00,585 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:36:05,466 - stpipe.HighLevelPipeline.resample - INFO - Resampling exposure time
2023-11-14 14:36:12,117 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:36:23,781 - stpipe.HighLevelPipeline.resample - INFO - Drizzling (4088, 4088) --> (5003, 4358)
2023-11-14 14:36:29,153 - stpipe.HighLevelPipeline.resample - INFO - Mean, max exposure times: 285.8, 285.8
2023-11-14 14:36:29,160 - stpipe.HighLevelPipeline.resample - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:36:29,160 - stpipe.HighLevelPipeline.resample - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:36:29,160 - stpipe.HighLevelPipeline.resample - WARNING -
2023-11-14 14:36:29,248 - stpipe.HighLevelPipeline.resample - INFO - Update S_REGION to POLYGON ICRS  80.021216639 29.980879920 79.869310622 30.056876908 79.793002337 29.942238797 79.944791638 29.866329380
2023-11-14 14:36:29,304 - stpipe.HighLevelPipeline.resample - INFO - Step resample done
2023-11-14 14:36:29,529 - stpipe.HighLevelPipeline - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:36:29,530 - stpipe.HighLevelPipeline - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:36:29,530 - stpipe.HighLevelPipeline - WARNING -
2023-11-14 14:36:29,534 - stpipe.HighLevelPipeline - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:36:29,534 - stpipe.HighLevelPipeline - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:36:29,534 - stpipe.HighLevelPipeline - WARNING -
2023-11-14 14:36:29,601 - stpipe.HighLevelPipeline - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:36:29,601 - stpipe.HighLevelPipeline - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:36:29,601 - stpipe.HighLevelPipeline - WARNING -
2023-11-14 14:36:29,604 - stpipe.HighLevelPipeline - WARNING - /Users/ddavis/miniconda3/envs/rcal_dev/lib/python3.11/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
2023-11-14 14:36:29,604 - stpipe.HighLevelPipeline - WARNING -   warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
2023-11-14 14:36:29,604 - stpipe.HighLevelPipeline - WARNING -
2023-11-14 14:36:30,792 - stpipe.HighLevelPipeline - INFO - Saved model in r00005-a3001_image_001_short_asn_highlevelpipeline.asdf
2023-11-14 14:36:30,792 - stpipe.HighLevelPipeline - INFO - Step HighLevelPipeline done
...
Note: outlier detection is still being skipped and the output filename is a bit crazy. 
We have: r00005-a3001_image_001_short_asn_highlevelpipeline.asdf
I'd prefer something like,
r0000501001001001001_WFI01_<filter>_i2d.asdf

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
 Regression tests will fail until we have new files from INS