### PR TITLE
fix import in script for use by typer

### DIFF
--- a/romancal/scripts/static_preview.py
+++ b/romancal/scripts/static_preview.py
@@ -1,14 +1,13 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import asdf
 import numpy
 
-if TYPE_CHECKING:
-    from typing_extensions import Annotated
-
 
 def command():
+    from typing_extensions import Annotated
+
     try:
         import typer
         from stpreview.downsample import downsample_asdf_to


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue from https://github.com/spacetelescope/romancal/pull/977 where Typer doesn't have access to the imported `Annotated`

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] ~updated relevant tests~
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
