### PR TITLE
replace `pyupgrade` `isort` and `black` with `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,31 +25,9 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.15.0'
-  hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.1.4'
+  rev: v0.1.4
   hooks:
     - id: ruff
       args: ["--fix"]
-
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-    - id: isort
-
-- repo: https://github.com/psf/black
-  rev: 23.10.1
-  hooks:
-    - id: black
-
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.5
-  hooks:
-    - id: bandit
-      args: ["-c", "pyproject.toml"]
-      additional_dependencies: ["bandit[toml]"]
+    - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,10 @@ repos:
     - id: ruff
       args: ["--fix"]
     - id: ruff-format
+
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.5
+  hooks:
+    - id: bandit
+      args: ["-c", "pyproject.toml"]
+      additional_dependencies: ["bandit[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,36 +166,23 @@ report = { exclude_lines = [
 [tool.bandit]
 skips = ["B101", "B307", "B404", "B603"]
 
-[tool.isort]
-profile = "black"
-filter_files = true
-line_length = 88
-
-[tool.black]
-line-length = 88
-force-exclude = '''
-^/(
-  (
-      \.eggs
-    | \.git
-    | \.pytest_cache
-    | \.tox
-  )/
-)
-'''
-
 [tool.ruff]
 line-length = 88
 exclude = [
-    'jdocs',
-    '.tox',
     '.eggs',
+    '.git',
+    '.pytest_cache',
+    '.tox',
+    'jdocs',
     'build',
 ]
 ignore = [
     'E741', # ambiguous variable name
 ]
 extend-select = ['NPY']
+extend-include = ["*.ipynb"]
+
+[tool.ruff.lint.isort]
 
 [tool.ruff.extend-per-file-ignores]
 "romancal/associations/__init__.py" = ["E402"]

--- a/romancal/associations/tests/helpers.py
+++ b/romancal/associations/tests/helpers.py
@@ -64,10 +64,9 @@ class BasePoolRule:
         for ppars in self.pools:
             pool = combine_pools(ppars.path, **ppars.kwargs)
             asns = generate(pool, rules)
-            assert (
-                len(asns) == ppars.n_asns
-            ), ppars.path + ": n_asns not expected {} {}".format(
-                len(asns), ppars.n_asns
+            assert len(asns) == ppars.n_asns, (
+                ppars.path
+                + ": n_asns not expected {} {}".format(len(asns), ppars.n_asns)
             )
             for asn, candidates in zip(asns, ppars.candidates):
                 assert set(asn.candidates) == set(candidates)
@@ -77,10 +76,9 @@ class BasePoolRule:
                     for member in product["members"]:
                         if member["exptype"] == "science":
                             match = file_regex.match(member["expname"])
-                            assert (
-                                match is not None
-                            ), ppars.path + ": No suffix match for {}".format(
-                                member["expname"]
+                            assert match is not None, (
+                                ppars.path
+                                + ": No suffix match for {}".format(member["expname"])
                             )
                             assert (
                                 match.groupdict()["suffix"] in ppars.valid_suffixes

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -251,9 +251,7 @@ def create_image_model(input_model, image_info):
     var_poisson = u.Quantity(
         var_poisson, u.electron**2 / u.s**2, dtype=var_poisson.dtype
     )
-    var_rnoise = u.Quantity(
-        var_rnoise, u.electron**2 / u.s**2, dtype=var_rnoise.dtype
-    )
+    var_rnoise = u.Quantity(var_rnoise, u.electron**2 / u.s**2, dtype=var_rnoise.dtype)
     err = u.Quantity(err, u.electron / u.s, dtype=err.dtype)
     if dq is None:
         dq = np.zeros(data.shape, dtype="u4")

--- a/romancal/refpix/tests/reference_utils.py
+++ b/romancal/refpix/tests/reference_utils.py
@@ -308,7 +308,7 @@ def fft_interp(
             # meaningfully
             chanFrameData_Flat = spfft.irfft(
                 fftResult * chanFrameData_Flat.size,
-                workers=1
+                workers=1,
                 # )
             ).astype(chanFrameData_Flat.dtype)
             # Return read only pixels

--- a/romancal/resample/gwcs_drizzle.py
+++ b/romancal/resample/gwcs_drizzle.py
@@ -94,9 +94,7 @@ class GWCSDrizzle:
         elif self.outcon.ndim != 3:
             raise ValueError(
                 "Drizzle context image has wrong dimensions: \
-                {}".format(
-                    product
-                )
+                {}".format(product)
             )
 
         # Check field values

--- a/romancal/skymatch/skymatch.py
+++ b/romancal/skymatch/skymatch.py
@@ -403,8 +403,9 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
 
             # log sky values:
             log.info(
-                "   *  Group ID={}. Sky background of "
-                "component images:".format(img.id)
+                "   *  Group ID={}. Sky background of " "component images:".format(
+                    img.id
+                )
             )
 
             for im, old_sky, new_sky in zip(img, old_img_sky, new_img_sky):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR replaces the `pre-commit` checks for `pyupgrade`, `isort`, and `black` with  `ruff format`

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] ~updated relevant tests~
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
