### PR TITLE
RCAL-707 Update elp to replace list as input to tweakreg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ dark
 general
 -------
 
+- Update elp pipeline code to capture a list from tweakreg [#]
+
 - Update pipeline code to correct cal_step and suffixes [#971]
 
 - Update pipeline code to run through tweakreg with single files and associations [#960]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ dark
 general
 -------
 
-- Update elp pipeline code to capture a list from tweakreg [#]
+- Update elp pipeline code to capture a list from tweakreg [#985]
 
 - Update pipeline code to correct cal_step and suffixes [#971]
 

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -63,7 +63,7 @@ SUFFIXES_TO_ADD = [
 
 # Suffixes that are discovered but should not be considered.
 # Used by `find_suffixes` to remove undesired values it has found.
-SUFFIXES_TO_DISCARD = ["pipeline", "step"]
+SUFFIXES_TO_DISCARD = ["highlevelpipeline", "pipeline", "step"]
 
 
 # Calculated suffixes.

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -191,8 +191,7 @@ class ExposurePipeline(RomanPipeline):
         if result.meta.exposure.type == "WFI_IMAGE":
             if file_type == "asdf":
                 result.meta.cal_step.tweakreg = "SKIPPED"
-                # mc_result = ModelContainer(result)
-                mc_result = self.tweakreg([result])
+                mc_result = ModelContainer(result)
                 if hasattr(ModelContainer(result), "_models") and mc_result._models:
                     result = mc_result._models.pop()
                 else:

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -65,8 +65,12 @@ class HighLevelPipeline(RomanPipeline):
             asn = ModelContainer.read_asn(input)
             self.skymatch.suffix = "skymatch"
             result = self.skymatch(input)
-            result = self.outlierdetection(result)
+            self.skymatch.suffix = "outlierdetection"
+            result = self.outlierdetection(asn)
+            self.skymatch.suffix = "i2d"
             result = self.resample(result)
+            if input_filename:
+                result.meta.filename = input_filename            
    
         return result
 
@@ -78,5 +82,5 @@ class HighLevelPipeline(RomanPipeline):
             input["output_file"] = input.meta.filename
             self.output_file = input.meta.filename
         else:
-            self.suffix = "ramp"
+            self.suffix = "cal"
 

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+import logging
+from os.path import basename
+
+import numpy as np
+from roman_datamodels import datamodels as rdm
+
+import romancal.datamodels.filetype as filetype
+
+# step imports
+from romancal.skymatch import SkyMatchStep
+from romancal.outlier_detection import OutlierDetectionStep
+from romancal.resample import ResampleStep
+from romancal.lib import dqflags
+from romancal.datamodels import ModelContainer
+
+
+from ..stpipe import RomanPipeline
+
+__all__ = ["HighLevelPipeline"]
+
+# Define logging
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+
+class HighLevelPipeline(RomanPipeline):
+    """
+    HighLevelPipeline: Apply all calibration steps to the roman data
+    to produce level 3 products. Included steps are:
+    skymatch, Outlierdetectionn and resample.
+    """
+
+    class_alias = "roman_hlp"
+
+    spec = """
+        save_results = boolean(default=False)
+    """
+
+    # Define aliases to steps
+    step_defs = {
+        "skymatch": SkyMatchStep,
+        "outlierdet": OutlierDetectionStep,
+        "resample": ResampleStep,
+    }
+
+    # start the actual processing
+    def process(self, input):
+        """Process the Roman WFI data from Level 2 to Level 3"""
+
+        log.info("Starting Roman high level calibration pipeline ...")
+        if isinstance(input, str):
+            input_filename = basename(input)
+        else:
+            input_filename = None
+
+        # open the input file
+        file_type = filetype.check(input)
+        asn = None
+        if file_type == "asdf":
+            log.info("The level three pipeline input needs to be an association")
+            return
+
+        if file_type == "asn":
+            asn = ModelContainer.read_asn(input)
+            self.skymatch.suffix = "skymatch"
+            result = self.skymatch(input)
+            result = self.outlierdetection(result)
+            result = self.resample(result)
+   
+        return result
+
+    def setup_output(self, input):
+        """Determine the proper file name suffix to use later"""
+        if input.meta.cal_step.ramp_fit == "COMPLETE":
+            self.suffix = "cal"
+            input.meta.filename = input.meta.filename.replace("uncal", self.suffix)
+            input["output_file"] = input.meta.filename
+            self.output_file = input.meta.filename
+        else:
+            self.suffix = "ramp"
+

--- a/romancal/pipeline/highlevel_pipeline.py
+++ b/romancal/pipeline/highlevel_pipeline.py
@@ -2,18 +2,13 @@
 import logging
 from os.path import basename
 
-import numpy as np
-from roman_datamodels import datamodels as rdm
-
 import romancal.datamodels.filetype as filetype
+from romancal.datamodels import ModelContainer
+from romancal.outlier_detection import OutlierDetectionStep
+from romancal.resample import ResampleStep
 
 # step imports
 from romancal.skymatch import SkyMatchStep
-from romancal.outlier_detection import OutlierDetectionStep
-from romancal.resample import ResampleStep
-from romancal.lib import dqflags
-from romancal.datamodels import ModelContainer
-
 
 from ..stpipe import RomanPipeline
 
@@ -70,8 +65,8 @@ class HighLevelPipeline(RomanPipeline):
             self.skymatch.suffix = "i2d"
             result = self.resample(result)
             if input_filename:
-                result.meta.filename = input_filename            
-   
+                result.meta.filename = input_filename
+
         return result
 
     def setup_output(self, input):
@@ -83,4 +78,3 @@ class HighLevelPipeline(RomanPipeline):
             self.output_file = input.meta.filename
         else:
             self.suffix = "cal"
-


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-707](https://jira.stsci.edu/browse/rcal-707)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
When running the pipeline with tweakreg set to "skip" tweakreg is returning a list and the pipeline is failing.
```
strun --disable-crds-steppar  --suffix='cal'  romancal.step.TweakRegStep test_tweakreg_asn.json
...
ERROR RUNNING STEP 'ExposurePipeline':
    'list' object has no attribute '_models'
----------------------------------------------------------------------
> /Users/ddavis/src/Roman/romancal/romancal/pipeline/exposure_pipeline.py(196)process()
-> if hasattr(ModelContainer(result), "_models") and mc_result._models:
```

This converts the list to a container object before passing the object to tweakreg and results in
```
strun --disable-crds-steppar --suffix=cal romancal.step.TweakRegStep test_tweakreg_asn.json
...
2023-11-09 12:58:26,315 - stpipe.TweakRegStep - INFO - Saved model in r0000101001001001001_01101_0001_WFI01_cal.asdf
2023-11-09 12:58:29,760 - stpipe.TweakRegStep - INFO - Saved model in r0000101001001001001_01101_0001_WFI02_cal.asdf
2023-11-09 12:58:33,037 - stpipe.TweakRegStep - INFO - Saved model in r0000101001001001001_01101_0001_WFI03_cal.asdf
2023-11-09 12:58:33,037 - stpipe.TweakRegStep - INFO - Step TweakRegStep done
```




**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [N/A] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
