### PR TITLE
Structured array source detection catalogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,13 @@ scripts
 
 - fixed ``asn_from_list`` script [#972]
 
+source_detection
+----------------
+
+- Support for PSF fitting (optional) for accurate centroids. [#841]
+
+- Save source catalog to a structured array. [#987]
+
 stpipe
 ------
 
@@ -82,11 +89,6 @@ tweakreg
 
 - Fix a bug due to which source catalog may contain sources
   outside of the bounding box. [#947]
-
-source_detection
-----------------
-
-- Support for PSF fitting (optional) for accurate centroids. [#841]
 
 0.12.0 (2023-08-18)
 ===================

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -1,7 +1,6 @@
 """General utility objects"""
 
 import numpy as np
-from astropy.table import Table
 from roman_datamodels.datamodels import AssociationsModel
 
 from romancal.lib import dqflags
@@ -106,27 +105,6 @@ class LoggingContext:
         # implicit return of None => don't swallow exceptions
 
 
-def ndarrays_to_recarray(arrays, names):
-    """
-    Convert a list of ndarrays to structured arrays.
-
-    Parameters
-    ----------
-    arrays : list
-        List of np.ndarray
-    names : str
-        Comma-separated string of array names
-
-    Returns
-    -------
-    recarr : np.record
-    """
-    recarr = np.core.records.fromarrays(
-        arrays, names=names, formats=[arr.dtype for arr in arrays]
-    )
-    return recarr
-
-
 def recarray_to_ndarray(x, to_dtype="<f8"):
     """
     Convert a structured array to a 2D ndarray.
@@ -146,45 +124,3 @@ def recarray_to_ndarray(x, to_dtype="<f8"):
     names = x.dtype.names
     astype = [(name, to_dtype) for name in names]
     return np.asarray(x.astype(astype).view(to_dtype).reshape((-1, len(names))))
-
-
-def recarray_to_astropy_table(x):
-    """
-    Convert a structured array to an astropy table.
-
-    Parameters
-    ----------
-    x : np.record
-        Structured array
-
-    Returns
-    -------
-    tbl : astropy.table.Table
-    """
-    names = x.dtype.names
-    data = {name: x[name] for name in names}
-    return Table(data, names=names)
-
-
-def astropy_table_to_recarray(x):
-    """
-    Convert an astropy table to a structured array.
-
-    Parameters
-    ----------
-    x : astropy.table.Table
-
-    Returns
-    -------
-    arr : np.record
-        Structured array
-    """
-
-    arrays = []
-    names = []
-
-    for column in x.itercols():
-        names.append(column.name)
-        arrays.append(np.asarray(column.data))
-
-    return ndarrays_to_recarray(arrays, ", ".join(names))

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -2,14 +2,9 @@
 
 import numpy as np
 import pytest
+from astropy.table import Table
 
-from romancal.lib.basic_utils import (
-    astropy_table_to_recarray,
-    bytes2human,
-    ndarrays_to_recarray,
-    recarray_to_astropy_table,
-    recarray_to_ndarray,
-)
+from romancal.lib.basic_utils import bytes2human, recarray_to_ndarray
 
 test_data = [
     (1000, "1000B"),
@@ -30,13 +25,15 @@ def test_structured_array_utils():
     arrays = [np.arange(0, 10), np.arange(10, 20), np.arange(30, 40)]
     names = "a, b, c"
 
-    recarr0 = ndarrays_to_recarray(arrays, names)
+    recarr0 = np.core.records.fromarrays(
+        arrays, names=names, formats=[arr.dtype for arr in arrays]
+    )
     round_tripped = recarray_to_ndarray(recarr0)
     assert np.all(round_tripped == np.column_stack(arrays).astype("<f8"))
 
-    astropy_table = recarray_to_astropy_table(recarr0)
+    astropy_table = Table(recarr0)
     assert np.all(
         np.array(arrays) == np.array([col.data for col in astropy_table.itercols()])
     )
 
-    assert np.all(astropy_table_to_recarray(astropy_table) == recarr0)
+    assert np.all(astropy_table.as_array() == recarr0)

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -1,8 +1,15 @@
-"""Test basic utils bytes2human"""
+"""Test basic utils"""
 
+import numpy as np
 import pytest
 
-from romancal.lib.basic_utils import bytes2human
+from romancal.lib.basic_utils import (
+    astropy_table_to_recarray,
+    bytes2human,
+    ndarrays_to_recarray,
+    recarray_to_astropy_table,
+    recarray_to_ndarray,
+)
 
 test_data = [
     (1000, "1000B"),
@@ -17,3 +24,19 @@ def test_bytes2human(input_data, result):
     """test the basic conversion"""
 
     assert bytes2human(input_data) == result
+
+
+def test_structured_array_utils():
+    arrays = [np.arange(0, 10), np.arange(10, 20), np.arange(30, 40)]
+    names = "a, b, c"
+
+    recarr0 = ndarrays_to_recarray(arrays, names)
+    round_tripped = recarray_to_ndarray(recarr0)
+    assert np.all(round_tripped == np.column_stack(arrays).astype("<f8"))
+
+    astropy_table = recarray_to_astropy_table(recarr0)
+    assert np.all(
+        np.array(arrays) == np.array([col.data for col in astropy_table.itercols()])
+    )
+
+    assert np.all(astropy_table_to_recarray(astropy_table) == recarr0)

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -21,6 +21,7 @@ from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
 from romancal.lib import dqflags, psf
+from romancal.lib.basic_utils import astropy_table_to_recarray
 from romancal.stpipe import RomanStep
 
 log = logging.getLogger(__name__)
@@ -200,14 +201,7 @@ class SourceDetectionStep(RomanStep):
                 # meta.source_detection the table will be stored as a
                 # 1D array with the four columns concatenated, in order,
                 # with units attached
-                catalog_as_array = np.array(
-                    [
-                        catalog["id"].value,
-                        catalog["xcentroid"].value,
-                        catalog["ycentroid"].value,
-                        catalog["flux"].value,
-                    ]
-                )
+                catalog_as_recarray = astropy_table_to_recarray(catalog)
 
             # create meta.source detection section in file
             # if save_catalogs is True, this will be updated with the
@@ -228,7 +222,7 @@ class SourceDetectionStep(RomanStep):
                 log.info(f"Saving catalog to file: {cat_filename}.")
 
                 if self.output_cat_filetype == "asdf":
-                    tree = {"tweakreg_catalog": catalog_as_array}
+                    tree = {"tweakreg_catalog": catalog_as_recarray}
                     ff = AsdfFile(tree)
                     ff.write_to(cat_filename)
                 else:
@@ -240,7 +234,9 @@ class SourceDetectionStep(RomanStep):
             else:
                 # only attach catalog to file if its being passed to the next step
                 # and save_catalogs is false, since it is not in the schema
-                input_model.meta.source_detection["tweakreg_catalog"] = catalog_as_array
+                input_model.meta.source_detection[
+                    "tweakreg_catalog"
+                ] = catalog_as_recarray
 
                 if self.fit_psf:
                     input_model.meta.source_detection[

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -21,7 +21,6 @@ from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
 from romancal.lib import dqflags, psf
-from romancal.lib.basic_utils import astropy_table_to_recarray
 from romancal.stpipe import RomanStep
 
 log = logging.getLogger(__name__)
@@ -184,24 +183,7 @@ class SourceDetectionStep(RomanStep):
                     exclude_out_of_bounds=True,
                 )
 
-                # attach source catalog to output model as array in
-                # meta.source_detection the table will be stored as a
-                # 1D array with the four columns concatenated, in order,
-                # with units attached
-                catalog_as_array = np.array(
-                    [
-                        psf_photometry_table["id"].value,
-                        psf_photometry_table["x_fit"].value,
-                        psf_photometry_table["y_fit"].value,
-                        psf_photometry_table["flux_fit"].value,
-                    ]
-                )
-            else:
-                # attach source catalog to output model as array in
-                # meta.source_detection the table will be stored as a
-                # 1D array with the four columns concatenated, in order,
-                # with units attached
-                catalog_as_recarray = astropy_table_to_recarray(catalog)
+            catalog_as_recarray = catalog.as_array()
 
             # create meta.source detection section in file
             # if save_catalogs is True, this will be updated with the
@@ -232,17 +214,26 @@ class SourceDetectionStep(RomanStep):
                     "tweakreg_catalog_name"
                 ] = cat_filename
             else:
-                # only attach catalog to file if its being passed to the next step
-                # and save_catalogs is false, since it is not in the schema
-                input_model.meta.source_detection[
-                    "tweakreg_catalog"
-                ] = catalog_as_recarray
-
                 if self.fit_psf:
-                    input_model.meta.source_detection[
-                        "psf_catalog"
-                    ] = psf_photometry_table
+                    # PSF photometry centroid results are stored in an astropy table
+                    # in columns "x_fit" and "y_fit", which we'll rename for
+                    # compatibility with tweakreg:
+                    catalog = psf_photometry_table.copy()
 
+                    # rename the PSF photometry table's columns to match the
+                    # expectated columns in tweakreg:
+                    for old_name, new_name in zip(
+                        ["x_fit", "y_fit"], ["xcentroid", "ycentroid"]
+                    ):
+                        catalog.rename_column(old_name, new_name)
+
+                    input_model.meta.source_detection["psf_catalog"] = catalog
+                else:
+                    # only attach catalog to file if its being passed to the next step
+                    # and save_catalogs is false, since it is not in the schema
+                    input_model.meta.source_detection[
+                        "tweakreg_catalog"
+                    ] = catalog_as_recarray
             input_model.meta.cal_step["source_detection"] = "COMPLETE"
 
         # just pass input model to next step - catalog is stored in meta

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -8,8 +8,8 @@ import numpy as np
 import pytest
 from astropy import units as u
 
-from romancal.lib.tests.test_psf import add_sources, setup_inputs
 from romancal.lib.basic_utils import recarray_to_ndarray
+from romancal.lib.tests.test_psf import add_sources, setup_inputs
 from romancal.source_detection import SourceDetectionStep
 
 n_sources = 10
@@ -39,7 +39,9 @@ class TestSourceDetection:
         source_detect.scalar_threshold = 100
         source_detect.peakmax = None
         dao_result = source_detect.process(image_model)
-        idx, x_dao, y_dao, amp_dao = dao_result.meta.source_detection.tweakreg_catalog
+        idx, x_dao, y_dao, amp_dao = recarray_to_ndarray(
+            dao_result.meta.source_detection.tweakreg_catalog
+        ).T
 
         # check that all injected targets are found by DAO:
         assert len(x_dao) == len(x_true)
@@ -48,7 +50,7 @@ class TestSourceDetection:
         psf_result = source_detect.process(image_model)
         psf_catalog = psf_result.meta.source_detection.psf_catalog
 
-        extract_columns = ["x_fit", "x_err", "y_fit", "y_err", "flux_fit"]
+        extract_columns = ["xcentroid", "x_err", "ycentroid", "y_err", "flux_fit"]
         x_psf, x_err, y_psf, y_err, amp_psf = psf_catalog[extract_columns].itercols()
 
         # check that typical PSF centroids are more accurate than DAO centroids:

--- a/romancal/source_detection/tests/test_source_detection_step.py
+++ b/romancal/source_detection/tests/test_source_detection_step.py
@@ -9,6 +9,7 @@ import pytest
 from astropy import units as u
 
 from romancal.lib.tests.test_psf import add_sources, setup_inputs
+from romancal.lib.basic_utils import recarray_to_ndarray
 from romancal.source_detection import SourceDetectionStep
 
 n_sources = 10

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -21,6 +21,7 @@ from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
 from romancal.datamodels import ModelContainer
+from romancal.lib.basic_utils import astropy_table_to_recarray
 from romancal.tweakreg import tweakreg_step as trs
 from romancal.tweakreg.astrometric_utils import get_catalog
 
@@ -381,7 +382,7 @@ def create_base_image_source_catalog(
     t.add_column([i for i in range(len(t))], name="id", index=0)
     t.add_column([np.float64(i) for i in range(len(t))], name="flux")
     t.rename_columns(["x", "y"], ["xcentroid", "ycentroid"])
-    return t.as_array().T
+    return astropy_table_to_recarray(t)
 
 
 def add_tweakreg_catalog_attribute(
@@ -441,7 +442,7 @@ def add_tweakreg_catalog_attribute(
             tmp_path, tweakreg_catalog_filename
         )
     else:
-        # SourceDetectionStep attaches the catalog data as a 4D numpy array
+        # SourceDetectionStep attaches the catalog data as a structured array
         input_dm.meta.source_detection["tweakreg_catalog"] = source_catalog
 
 
@@ -1111,8 +1112,8 @@ def test_imodel2wcsim_valid_column_names(tmp_path, base_image, column_names):
     imcats = list(map(step._imodel2wcsim, g))
 
     assert all(x.meta["image_model"] == y for x, y in zip(imcats, [img_1, img_2]))
-    assert all(
-        all(x.meta["catalog"] == y.meta.tweakreg_catalog)
+    assert np.all(
+        x.meta["catalog"] == y.meta.tweakreg_catalog
         for x, y in zip(imcats, [img_1, img_2])
     )
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -21,7 +21,6 @@ from roman_datamodels import datamodels as rdm
 from roman_datamodels import maker_utils
 
 from romancal.datamodels import ModelContainer
-from romancal.lib.basic_utils import astropy_table_to_recarray
 from romancal.tweakreg import tweakreg_step as trs
 from romancal.tweakreg.astrometric_utils import get_catalog
 
@@ -382,7 +381,7 @@ def create_base_image_source_catalog(
     t.add_column([i for i in range(len(t))], name="id", index=0)
     t.add_column([np.float64(i) for i in range(len(t))], name="flux")
     t.rename_columns(["x", "y"], ["xcentroid", "ycentroid"])
-    return astropy_table_to_recarray(t)
+    return t.as_array()
 
 
 def add_tweakreg_catalog_attribute(

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -13,11 +13,7 @@ from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
 from tweakwcs.matchutils import XYXYMatch
 
-from romancal.lib.basic_utils import (
-    astropy_table_to_recarray,
-    is_association,
-    recarray_to_astropy_table,
-)
+from romancal.lib.basic_utils import is_association
 
 # LOCAL
 from ..datamodels import ModelContainer
@@ -179,9 +175,7 @@ class TweakRegStep(RomanStep):
                 )
                 if is_tweakreg_catalog_present:
                     # read catalog from structured array
-                    catalog = recarray_to_astropy_table(
-                        image_model.meta.source_detection.tweakreg_catalog
-                    )
+                    catalog = Table(image_model.meta.source_detection.tweakreg_catalog)
                 elif is_tweakreg_catalog_name_present:
                     catalog = Table.read(
                         image_model.meta.source_detection.tweakreg_catalog_name,
@@ -248,7 +242,7 @@ class TweakRegStep(RomanStep):
                     )
 
             # set meta.tweakreg_catalog
-            image_model.meta["tweakreg_catalog"] = astropy_table_to_recarray(catalog)
+            image_model.meta["tweakreg_catalog"] = catalog.as_array()
 
             nsources = len(catalog)
             if nsources == 0:
@@ -561,7 +555,7 @@ class TweakRegStep(RomanStep):
                 catalog = Table.read(catalog, format=catalog_format)
             else:
                 # catalog is a structured array, convert to astropy table:
-                catalog = recarray_to_astropy_table(catalog)
+                catalog = Table(catalog)
 
             catalog.meta["name"] = (
                 str(catalog) if isinstance(catalog, str) else model_name


### PR DESCRIPTION
Source Detection produces a 2D ndarray of source IDs, centroids, and fluxes, to use as inputs in tweakreg. @schlafly and I discussed in https://github.com/spacetelescope/romancal/pull/841 that we could use a self-documenting and more scalable data structure instead if additional Source Detection results are useful for tweakreg or elsewhere. 

This PR swaps the unlabeled 2D ndarray for a structured array, and adds some helper functions for converting between ndarrays, structured arrays, and astropy tables.

Resolves [RCAL-709](https://jira.stsci.edu/browse/RCAL-709)

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
