### PR TITLE
fix issue where the path of the WebbPSF cache was not the same as the restore cache in the subsequent workflow

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -29,10 +29,10 @@ jobs:
       path: ${{ steps.path.outputs.path }}
     steps:
       - id: path
-        run: echo "path=${{ env.DATA_PATH }}/webbpsf-data" >> $GITHUB_OUTPUT
+        run: echo "path=${{ needs.path.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
   webbpsf_data:
     if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'update webbpsf data')))
-    needs: [ webbpsf_path ]
+    needs: [ path, webbpsf_path ]
     name: download and cache WebbPSF data
     runs-on: ubuntu-latest
     env:
@@ -45,12 +45,12 @@ jobs:
       - id: cache_check
         uses: actions/cache@v3
         with:
-          path: ${{ needs.webbpsf_path.outputs.path }}
+          path: ${{ needs.path.outputs.path }}
           key: webbpsf-${{ steps.data_hash.outputs.hash }}
       - if: ${{ steps.cache_check.outputs.cache-hit != 'true' }}
-        run: mkdir -p ${{ env.DATA_PATH }}
+        run: mkdir -p ${{ needs.path.outputs.path }}
       - if: ${{ steps.cache_check.outputs.cache-hit != 'true' }}
-        run: tar -xzvf tmp/webbpsf-data.tar.gz -C ${{ env.DATA_PATH }}
+        run: tar -xzvf tmp/webbpsf-data.tar.gz -C ${{ needs.path.outputs.path }}
   webbpsf_hash:
     needs: [ webbpsf_path, webbpsf_data ]
     # run data job if webbpsf-data succeeds or is skipped. This allows


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue where the cached WebbPSF data was not actually restored:
https://github.com/spacetelescope/romancal/actions/runs/6829635768/job/18623576605?pr=980#step:3:10

This was because the paths were different; GitHub Actions caches must have the same key AND path to match an `actions/cache` call

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
