### PR TITLE
Remove quote indent from main header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> # Roman Calibration Pipeline
+# Roman Calibration Pipeline
 
 
 [![Documentation Status](https://readthedocs.org/projects/roman-pipeline/badge/?version=latest)](https://roman-pipeline.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
The [main header on the romancal README](https://github.com/spacetelescope/romancal#roman-calibration-pipeline) is in an unusual and unnecessary quote block:

<img width="927" alt="Screen Shot 2023-11-13 at 21 25 16" src="https://github.com/spacetelescope/romancal/assets/3497584/0b9a2d79-8795-4ecc-87ad-d3f7119ccec2">

