### PR TITLE
minor fix for data hash in cache key

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -6,7 +6,7 @@ on:
       webbpsf_path:
         value: ${{ jobs.webbpsf_path.outputs.path }}
       webbpsf_hash:
-        value: ${{ jobs.webbpsf_data.outputs.hash }}
+        value: ${{ jobs.webbpsf_hash.outputs.hash }}
   workflow_dispatch:
   schedule:
     - cron: "42 4 * * 3"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses a small issue where the test cache does not contain the correct WebbPSF data hash:
<img width="716" alt="image" src="https://github.com/spacetelescope/romancal/assets/16024299/39ed7c35-1cbe-466c-990d-44bbc8253d67">

This was because the job name defined in the workflow outputs was incorrect.

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
