### PR TITLE
Update resample test to use new files.

### DIFF
--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -3,7 +3,6 @@ import pytest
 from metrics_logger.decorators import metrics_logger
 from roman_datamodels import datamodels as rdm
 
-from romancal.associations import asn_from_list
 from romancal.resample.resample_step import ResampleStep
 from romancal.stpipe import RomanStep
 

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -24,13 +24,10 @@ def test_resample_single_file(rtdata, ignore_asdf_paths):
     output_data = "mosaic_resamplestep.asdf"
 
     [rtdata.get_data(f"WFI/image/{data}") for data in input_data]
+    asnfn = "mosaic_asn.json"
+    rtdata.get_data(f"WFI/image/{asnfn}")
     rtdata.get_truth(f"truth/WFI/image/{output_data}")
 
-    asn = asn_from_list.asn_from_list(input_data, product_name="mosaic")
-    asnfn = "mosaic.json"
-    _, serialized = asn.dump()
-    with open(asnfn, 'w') as outfile:
-        outfile.write(serialized)
     rtdata.input = asnfn
     rtdata.output = output_data
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -175,7 +175,9 @@ class TweakRegStep(RomanStep):
                 )
                 if is_tweakreg_catalog_present:
                     # read catalog from structured array
-                    catalog = Table(image_model.meta.source_detection.tweakreg_catalog)
+                    catalog = Table(
+                        np.asarray(image_model.meta.source_detection.tweakreg_catalog)
+                    )
                 elif is_tweakreg_catalog_name_present:
                     catalog = Table.read(
                         image_model.meta.source_detection.tweakreg_catalog_name,


### PR DESCRIPTION
This PR addresses updates the resample regression test to use file names from the newest set of files.  It also takes advantage of the asn_from_list module to jettison some home-made asn-making code.