### PR TITLE
rcal-718 update okify script for the new jfrog cli

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
 for example RCAL-1234: <Fix a bug> -->
-Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
+Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)
 
 <!-- If this PR closes a GitHub issue, reference it here by its number -->
 Closes #

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -61,17 +61,22 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
     jfrog rt search roman-pipeline-results/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
     """  # noqa: E501
     build_name = f"RT :: {job_name}"
+    build_name = f"{job_name}"
 
     # Retreive all the okify specfiles for failed tests.
+#    args = list(
+#        ["jfrog", "rt", "dl"]
+#        + [f"{ARTIFACTORY_REPO}/*/*{suffix}"]
+#        + [f"--build={build_name}/{build_number}"]
+#        + ["--flat"]
+#    )
     args = list(
         ["jfrog", "rt", "dl"]
-        + [f"{ARTIFACTORY_REPO}/*/*{suffix}"]
-        + [f"--build={build_name}/{build_number}"]
-        + ["--flat"]
+        + [f"{ARTIFACTORY_REPO}/*RT-{build_name}-{build_number}*/*{suffix}"]
     )
-    subprocess.run(args, check=True, capture_output=True)
+    result = subprocess.run(args, check=True, capture_output=True)
 
-    return sorted(glob(f"*{suffix}"))
+    return sorted(glob(f"**/**/*{suffix}"))
 
 
 def artifactory_get_build_artifacts(build_number, job_name):

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -60,16 +60,9 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
 
     jfrog rt search roman-pipeline-results/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
     """  # noqa: E501
-    build_name = f"RT :: {job_name}"
     build_name = f"{job_name}"
 
     # Retreive all the okify specfiles for failed tests.
-#    args = list(
-#        ["jfrog", "rt", "dl"]
-#        + [f"{ARTIFACTORY_REPO}/*/*{suffix}"]
-#        + [f"--build={build_name}/{build_number}"]
-#        + ["--flat"]
-#    )
     args = list(
         ["jfrog", "rt", "dl"]
         + [f"{ARTIFACTORY_REPO}/*RT-{build_name}-{build_number}*/*{suffix}"]

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -67,7 +67,7 @@ def artifactory_get_breadcrumbs(build_number, job_name, suffix):
         ["jfrog", "rt", "dl"]
         + [f"{ARTIFACTORY_REPO}/*RT-{build_name}-{build_number}*/*{suffix}"]
     )
-    result = subprocess.run(args, check=True, capture_output=True)
+    subprocess.run(args, check=True, capture_output=True)
 
     return sorted(glob(f"**/**/*{suffix}"))
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-718](https://jira.stsci.edu/browse/rcal-718)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1108

<!-- describe the changes comprising this PR here -->
This PR updates the okify script to  the latest version of the jfrog cli

```
jfrog --version
jf version 2.51.1
```

The old version o longer supports the --build option used the in the okify script.

Update the script to conform to the new jfrog version syntax.

I've also update the pull request template so the default ticket in is RCAL-NNNN not the JWST project JP-NNNN

**Checklist**
- [N/A] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [ N/A ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
