### PR TITLE
Point tweakreg to new files.  Move the asn file into artifactory.

### DIFF
--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 import pytest
 from metrics_logger.decorators import metrics_logger
 from roman_datamodels import datamodels as rdm
@@ -10,41 +8,6 @@ from romancal.tweakreg.tweakreg_step import TweakRegStep
 from .regtestdata import compare_asdf
 
 
-def create_asn_file():
-    asn_content = """
-        {
-            "asn_type": "None",
-            "asn_rule": "DMS_ELPP_Base",
-            "version_id": null,
-            "code_version": "0.9.1.dev28+ge987cc9.d20230106",
-            "degraded_status": "No known degraded exposures in association.",
-            "program": "noprogram",
-            "constraints": "No constraints",
-            "asn_id": "a3001",
-            "target": "none",
-            "asn_pool": "test_pool_name",
-            "products": [
-                {
-                    "name": "files.asdf",
-                    "members": [
-                        {
-                            "expname": "r0000501001001001001_01101_0001_WFI01_cal_tweakreg.asdf",
-                            "exptype": "science"
-                        }
-                    ]
-                }
-            ]
-        }
-    """  # noqa: E501
-    asn_file_path = "sample_asn.json"
-    asn_file = StringIO()
-    asn_file.write(asn_content)
-    with open(asn_file_path, mode="w") as f:
-        print(asn_file.getvalue(), file=f)
-
-    return asn_file_path
-
-
 @metrics_logger("DMS280")
 @pytest.mark.bigdata
 def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
@@ -53,14 +16,17 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
     # - assign_wcs;
     # - photom;
     # - source_detection.
-    input_data = "r0000501001001001001_01101_0001_WFI01_cal_tweakreg.asdf"
-    output_data = "r0000501001001001001_01101_0001_WFI01_output.asdf"
-    truth_data = "r0000501001001001001_01101_0001_WFI01_tweakreg.asdf"
+    input_data = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
+    output_data = "r0000101001001001001_01101_0001_WFI01_tweakregstep.asdf"
+    truth_data = "r0000101001001001001_01101_0001_WFI01_tweakregstep.asdf"
+
+    asn_fn = "tweakreg_asn.json"
 
     rtdata.get_data(f"WFI/image/{input_data}")
+    rtdata.get_data(f"WFI/image/{asn_fn}")
     rtdata.get_truth(f"truth/WFI/image/{truth_data}")
 
-    rtdata.input = create_asn_file()
+    rtdata.input = asn_fn
     rtdata.output = output_data
 
     # instantiate TweakRegStep (for running and log access)
@@ -70,7 +36,7 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
         "romancal.step.TweakRegStep",
         rtdata.input,
         f"--output_file='{rtdata.output}'",
-        "--suffix='output'",
+        "--suffix='tweakregstep'",
     ]
     RomanStep.from_cmdline(args)
     tweakreg_out = rdm.open(rtdata.output)


### PR DESCRIPTION
This updates the tweakreg regression test to use new files.  It also removes the association file creation logic in favor of adding an association file to artifactory.