### PR TITLE
Turn on the apodized FFT interpolation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -129,6 +129,8 @@ refpix
 
 - Update cal_step, add suffix and add to the exposure pipeline [#890]
 
+- Enable apodized FFT interpolation by default. [#1017]
+
 resample
 --------
 

--- a/romancal/refpix/refpix.py
+++ b/romancal/refpix/refpix.py
@@ -18,7 +18,7 @@ def run_steps(
     remove_offset: bool = True,
     remove_trends: bool = True,
     cosine_interpolate: bool = True,
-    fft_interpolate: bool = False,
+    fft_interpolate: bool = True,
 ) -> RampModel:
     """
     Organize the steps to run the reference pixel correction.

--- a/romancal/refpix/refpix_step.py
+++ b/romancal/refpix/refpix_step.py
@@ -24,7 +24,7 @@ class RefPixStep(RomanStep):
     # linear trends
     cosine_interpolate = boolean(default=True) # Turn on or off the cosine
     # interpolation of the reference pixels
-    fft_interpolate = boolean(default=False) # Turn on or off the FFT interpolation
+    fft_interpolate = boolean(default=True) # Turn on or off the FFT interpolation
     # of the reference pixel padded values.
     """
 

--- a/romancal/refpix/tests/reference_utils.py
+++ b/romancal/refpix/tests/reference_utils.py
@@ -256,7 +256,7 @@ def interp_zeros_channel_fun(
 
 def cos_interp_reference(dataUniformTime, numFrames):
     numRows = dataUniformTime.shape[2]
-    return interp_zeros_channel_fun(
+    interp_zeros_channel_fun(
         REFERENCE_CHAN,
         getTrigInterpolationFunction(dataUniformTime),
         dataUniformTime,
@@ -507,8 +507,10 @@ def apply_correction(data, alpha, gamma, zeta):
     # Perform cosine weighted interpolation
     cos_interp_reference(dataUniformTime, dataUniformTime.shape[1])
 
-    # Perform fft interpolation (does nothing right now)
-    fft_interp_amp33(dataUniformTime, dataUniformTime.shape[1])
+    # Perform fft interpolation
+    dataUniformTime[REFERENCE_CHAN, :, :, :] = fft_interp_amp33(
+        dataUniformTime, dataUniformTime.shape[1]
+    )
 
     # Perform the correction
     data0 = apply_correction_to_data(

--- a/romancal/refpix/tests/test_data.py
+++ b/romancal/refpix/tests/test_data.py
@@ -535,25 +535,6 @@ class TestChannelView:
     def test_fft_interpolate_regression(self, channels):
         """
         Run fft interpolation regression test
-
-        NOTE:
-            The reference code assumes the data will be changed in-place for all
-            its major operations.However, the reference code violates this assumption
-            for the Amp33 FFT interpolation step. It does make an in-place change to
-            a sub-array, `dataReferenceChan_FramesFlat`. However
-            `dataReferenceChan_FramesFlat` loses its view on the original data array
-            because it unnecessarily recasts the dtype, which is a non-view compatible
-            change.
-
-            romancal does not make this mistake because it does not recast the dtype.
-
-            The reference utils are modified to output the data array which is modified
-            as a functional return value. This is so that the reference code's
-            computation can be tests against the romancal code's computation.
-
-            After this step is computed, the reference code an romancal code will
-            diverge in values, because the changes made by this will propagate in
-            romancal but the do not in the reference code.
         """
         non_view_data = channels.data.copy()
 

--- a/romancal/refpix/tests/test_refpix.py
+++ b/romancal/refpix/tests/test_refpix.py
@@ -12,7 +12,7 @@ def test_run_steps_regression(datamodel, ref_pix_ref):
         regression, ref_pix_ref.alpha, ref_pix_ref.gamma, ref_pix_ref.zeta
     )
 
-    result = run_steps(datamodel, ref_pix_ref, True, True, True, False)
+    result = run_steps(datamodel, ref_pix_ref, True, True, True, True)
 
     assert (result.data.value == regression_out).all()
     # regression_out does not return amp33 data


### PR DESCRIPTION
The original Goddard code effectively had this turned off, so in order to replicate those results this was turned off in `romancal` on purpose too even though was part of the Goddard code. This was reported to Goddard as a potential bug, and was confirmed to be a bug in the reference implementation by Goddard.

This PR enables the apodized FFT interpolation by default

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
