### PR TITLE
rcal-457 Add test for spectral preview files

### DIFF
--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -531,4 +531,4 @@ def test_level2_grism_preview(rtdata, ignore_asdf_paths):
         rtdata.input,
     ]
     subprocess.run(args)
-    assert os.path.exists(rtdata.output) == True
+    assert os.path.exists(rtdata.output) is True

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -515,9 +515,30 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
+@metrics_logger("DMS281")
+def test_level2_image_preview(rtdata, ignore_asdf_paths):
+    """Tests for flat field image preview requirements DMS 281"""
+    input_data = "r0000501001001001001_01101_0001_WFI01_cal.asdf"
+    rtdata.get_data(f"WFI/grism/{input_data}")
+    rtdata.input = input_data
+
+    # Test Pipeline
+    output = "r0000501001001001001_01101_0001_WFI01_cal_thumb.png"
+    rtdata.output = output
+    args = [
+        "roman_static_preview",
+        "thumbnail",
+        rtdata.input,
+    ]
+    subprocess.run(args)
+    assert os.path.exists(rtdata.output) is True
+
+    
+@pytest.mark.bigdata
+@pytest.mark.soctests
 @metrics_logger("DMS278")
 def test_level2_grism_preview(rtdata, ignore_asdf_paths):
-    """Tests for flat field grism preview requirements DMS90, DMS91 & DMS 278"""
+    """Tests for flat field grism preview requirements DMS 278"""
     input_data = "r0000501001001001001_01101_0001_WFI01_cal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -512,6 +512,7 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
     assert model.meta.cal_step.flat_field == "SKIPPED"
     assert model.meta.cal_step.photom == "SKIPPED"
 
+
 @pytest.mark.bigdata
 @pytest.mark.soctests
 @metrics_logger("DMS278")
@@ -531,4 +532,3 @@ def test_level2_grism_preview(rtdata, ignore_asdf_paths):
     ]
     subprocess.run(args)
     assert os.path.exists(rtdata.output) == True
-    

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -533,7 +533,7 @@ def test_level2_image_preview(rtdata, ignore_asdf_paths):
     subprocess.run(args)
     assert os.path.exists(rtdata.output) is True
 
-    
+
 @pytest.mark.bigdata
 @pytest.mark.soctests
 @metrics_logger("DMS278")

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -1,5 +1,7 @@
 """ Roman tests for flat field correction """
 import copy
+import os
+import subprocess
 
 import numpy as np
 import pytest
@@ -509,3 +511,24 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
     assert model.meta.cal_step.assign_wcs == "SKIPPED"
     assert model.meta.cal_step.flat_field == "SKIPPED"
     assert model.meta.cal_step.photom == "SKIPPED"
+
+@pytest.mark.bigdata
+@pytest.mark.soctests
+@metrics_logger("DMS278")
+def test_level2_grism_preview(rtdata, ignore_asdf_paths):
+    """Tests for flat field grism preview requirements DMS90, DMS91 & DMS 278"""
+    input_data = "r0000501001001001001_01101_0001_WFI01_cal.asdf"
+    rtdata.get_data(f"WFI/grism/{input_data}")
+    rtdata.input = input_data
+
+    # Test Pipeline
+    output = "r0000501001001001001_01101_0001_WFI01_cal_thumb.png"
+    rtdata.output = output
+    args = [
+        "roman_static_preview",
+        "thumbnail",
+        rtdata.input,
+    ]
+    subprocess.run(args)
+    assert os.path.exists(rtdata.output) == True
+    


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds a check for the preview file that needs to be generated for DMS278 (https://jira.stsci.edu/projects/RDM/issues/RDM-3153) and for imaging previews DMS281 (https://jira.stsci.edu/browse/RDM-3152)

**Checklist**
- [N/A] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
