### PR TITLE
Truncate dark to the appropriate number of resultants.

### DIFF
--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -42,7 +42,7 @@ class DarkCurrentStep(RomanStep):
 
             # Do the dark correction
             out_model = input_model
-            nresultants = len(input_model.meta.exposure['read_pattern'])
+            nresultants = len(input_model.meta.exposure["read_pattern"])
             out_model.data -= dark_model.data[:nresultants]
             out_model.pixeldq |= dark_model.dq
             out_model.meta.cal_step.dark = "COMPLETE"

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -42,7 +42,8 @@ class DarkCurrentStep(RomanStep):
 
             # Do the dark correction
             out_model = input_model
-            out_model.data -= dark_model.data
+            nresultants = len(input_model.meta.exposure['read_pattern'])
+            out_model.data -= dark_model.data[:nresultants]
             out_model.pixeldq |= dark_model.dq
             out_model.meta.cal_step.dark = "COMPLETE"
 


### PR DESCRIPTION
This PR fixes a bug in dark subtraction where we try to subtract the full dark image, rather than the dark image truncated to the appropriate number of resultants.

Regression test here: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/
There appear to be some unrelated failures in test_dq_init?