### PR TITLE
Fix the pollution of stdout and stderr by ddtrace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ general
 - Use array comparison options (including ``nan`` equality) when
   comparing ``WCS`` objects during ``compare_asdf`` [#941]
 
+- Fix dynamic importing issue with the ``ddtrace`` package. [#1024]
+
 ramp_fitting
 ------------
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -87,7 +87,7 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-sdp.txt']
 bc0.build_cmds = [
     "pip install -e .[test]",
-    "pip install pytest-xdist pytest-sugar ddtrace",
+    "pip install pytest-xdist ddtrace",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
@@ -98,6 +98,7 @@ bc0.test_cmds = [
     "pytest -r sxf -n auto --bigdata --slow --webbpsf \
     --cov --cov-report=xml:coverage.xml \
     --ddtrace \
+    --color=no \
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
     "curl -Os https://uploader.codecov.io/latest/linux/codecov",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -85,7 +85,7 @@ bc0.conda_packages = [
 bc0.pip_reqs_files = ['requirements-dev-thirdparty.txt']
 bc0.build_cmds = [
     "pip install -e .[test]",
-    "pip install pytest-xdist pytest-sugar",
+    "pip install pytest-xdist",
     'echo "CRDS_CONTEXT = $(crds list --contexts $CRDS_CONTEXT --mappings | grep pmap)"',
 ]
 bc0.build_cmds = bc0.build_cmds + PipInject(env.OVERRIDE_REQUIREMENTS)
@@ -93,7 +93,7 @@ bc0.build_cmds = bc0.build_cmds + [
     "pip list"
 ]
 bc0.test_cmds = [
-    "pytest -r sxf -n 0 --bigdata --slow --webbpsf \
+    "pytest -r sxf -n 0 --bigdata --slow --webbpsf --color=no\
     --basetemp=${pytest_basetemp} --junit-xml=results.xml --dist=loadscope \
     --env=${artifactoryenv} ${pytest_args}",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,12 @@ results_root = 'roman-pipeline-results'
 doctest_plus = 'enabled'
 doctest_rst = 'enabled'
 text_file_format = 'rst'
-addopts = '--show-capture=no --doctest-ignore-import-errors --color=yes'
+log_cli_level = "info"
+addopts = [
+    '--show-capture=no',
+    '--doctest-ignore-import-errors',
+    '--color=yes',
+]
 markers = [
     'soctests: run only the SOC tests in the suite.',
 ]


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #943

<!-- describe the changes comprising this PR here -->
When `pytest --ddtrace` was run, like in the Jenkins CLI, the logs were getting polluted by all sorts of output from `ddtrace` This was due to two effects.

1. `pytest`'s `log_cli_level` was not set, so `pytest` was sending all the logs it did not internally generate (it will still capture and display logs as part of a failure/error message) to stdout. This has now been set to the recommended "info" level, so only logs more serious then "info" will get this treatment.
2. `ddtrace` was encountering an error as part of its injection of datadog into python every time a package was imported after this test: https://github.com/spacetelescope/romancal/blob/29cbeda93779f02122f275ac6edb9932191d0b38/romancal/lib/tests/test_suffix.py#L17-L26 was run. Indeed, I could reproduce this behavior anywhere in the test suite if I added a test (or to a test) a call which eventually resulted in https://github.com/spacetelescope/romancal/blob/29cbeda93779f02122f275ac6edb9932191d0b38/romancal/stpipe/utilities.py#L57-L91 being called. I determined that this was caused by the imported modules state of python being polluted with a module that `ddtrace` could not inject datadog logging into. In this case, `load_local_pkg` searches the file system for a particular python file and then forces python to load and then execute that file as if it was a module. `ddtrace` is unable to do its thing in this case, which resulted in a module existing that it could not log. This caused it to send an error to stderr every time a new module, which was not previously imported, was imported.

This pull request fixes both of these issues by first setting the `log_cli_level` in the `pytest` configuration, and then refactoring the `load_local_pkg` to instead use Python's built-in `pkgutils` to walk the sub-packages of an already imported Python package. This walking cases the import of all the sub-packages via the normal Python import mechanism, which allows `ddtrace` to do its thing.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
