### PR TITLE
Adding a basic source catalog from Source Detection Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,7 +91,9 @@ source_detection
 
 - Support for PSF fitting (optional) for accurate centroids. [#841, #984]
 
-- Save source catalog to a structured array. [#987]
+- Save tweakreg source catalog to an astropy Table. [#987, #1029]
+
+- Save basic source catalog with morphology and PSF fit metrics. [#1029]
 
 stpipe
 ------

--- a/romancal/lib/basic_utils.py
+++ b/romancal/lib/basic_utils.py
@@ -103,24 +103,3 @@ class LoggingContext:
         if self.handler and self.close:
             self.handler.close()
         # implicit return of None => don't swallow exceptions
-
-
-def recarray_to_ndarray(x, to_dtype="<f8"):
-    """
-    Convert a structured array to a 2D ndarray.
-
-    Parameters
-    ----------
-    x : np.record
-        Structured array
-    to_dtype : str
-        Cast all columns in `x` to this dtype in the output ndarray.
-
-    Returns
-    -------
-    array : np.ndarray
-        Numpy array (without labeled columns).
-    """
-    names = x.dtype.names
-    astype = [(name, to_dtype) for name in names]
-    return np.asarray(x.astype(astype).view(to_dtype).reshape((-1, len(names))))

--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -1,10 +1,8 @@
 """Test basic utils"""
 
-import numpy as np
 import pytest
-from astropy.table import Table
 
-from romancal.lib.basic_utils import bytes2human, recarray_to_ndarray
+from romancal.lib.basic_utils import bytes2human
 
 test_data = [
     (1000, "1000B"),
@@ -19,21 +17,3 @@ def test_bytes2human(input_data, result):
     """test the basic conversion"""
 
     assert bytes2human(input_data) == result
-
-
-def test_structured_array_utils():
-    arrays = [np.arange(0, 10), np.arange(10, 20), np.arange(30, 40)]
-    names = "a, b, c"
-
-    recarr0 = np.core.records.fromarrays(
-        arrays, names=names, formats=[arr.dtype for arr in arrays]
-    )
-    round_tripped = recarray_to_ndarray(recarr0)
-    assert np.all(round_tripped == np.column_stack(arrays).astype("<f8"))
-
-    astropy_table = Table(recarr0)
-    assert np.all(
-        np.array(arrays) == np.array([col.data for col in astropy_table.itercols()])
-    )
-
-    assert np.all(astropy_table.as_array() == recarr0)

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -175,9 +175,7 @@ class TweakRegStep(RomanStep):
                 )
                 if is_tweakreg_catalog_present:
                     # read catalog from structured array
-                    catalog = Table(
-                        np.asarray(image_model.meta.source_detection.tweakreg_catalog)
-                    )
+                    catalog = image_model.meta.source_detection.tweakreg_catalog
                 elif is_tweakreg_catalog_name_present:
                     catalog = Table.read(
                         image_model.meta.source_detection.tweakreg_catalog_name,
@@ -244,7 +242,7 @@ class TweakRegStep(RomanStep):
                     )
 
             # set meta.tweakreg_catalog
-            image_model.meta["tweakreg_catalog"] = catalog.as_array()
+            image_model.meta["tweakreg_catalog"] = catalog
 
             nsources = len(catalog)
             if nsources == 0:

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -174,8 +174,9 @@ class TweakRegStep(RomanStep):
                     image_model.meta.source_detection, "tweakreg_catalog_name"
                 )
                 if is_tweakreg_catalog_present:
-                    # read catalog from structured array
-                    catalog = image_model.meta.source_detection.tweakreg_catalog
+                    # read catalog produced in the Source Detection Step, ensure that
+                    # it is an astropy Table:
+                    catalog = Table(image_model.meta.source_detection.tweakreg_catalog)
                 elif is_tweakreg_catalog_name_present:
                     catalog = Table.read(
                         image_model.meta.source_detection.tweakreg_catalog_name,
@@ -554,7 +555,7 @@ class TweakRegStep(RomanStep):
                 # a string with the name of the catalog was provided
                 catalog = Table.read(catalog, format=catalog_format)
             else:
-                # catalog is a structured array, convert to astropy table:
+                # catalog is an astropy Table or structured array, convert to astropy table:
                 catalog = Table(catalog)
 
             catalog.meta["name"] = (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-719](https://jira.stsci.edu/browse/RCAL-719)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1014

<!-- describe the changes comprising this PR here -->
This PR does two things: 

1. The data structure originally used for the tweakreg catalog was a 2D ndarray without labels or metadata. Recent PRs have switched to a structured array (#987, #1001) partly because I was under the impression that an astropy table wasn't supported. I found out that this was incorrect, so this PR saves the tweakreg catalog as an astropy table.

2. One of the related catalog requirements is to predict if a source is extended or not. There are lots of useful metrics produced but not preserved during Source Detection that help with this task. Sources are found with [DAOStarFinder](https://photutils.readthedocs.io/en/stable/api/photutils.detection.DAOStarFinder.html#photutils.detection.DAOStarFinder), which estimates source centroids and fluxes, as well as sharpness and roundness metrics. Users can optionally fit PSF models to the image via [PSFPhotometry](https://photutils.readthedocs.io/en/stable/api/photutils.psf.PSFPhotometry.html#photutils.psf.PSFPhotometry.__call__) for more accurate astrometry and photometry, which also computes two quality of fit metrics (`qfit, cfit`). Those last quality metrics are best described in [this ISR](https://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/wfc3/documentation/instrument-science-reports-isrs/_documents/2021/ISR_2021_12.pdf) or in literature citations that discuss their use like [Häberle 2021](https://ui.adsabs.harvard.edu/abs/2021MNRAS.503.1490H/abstract) or [Griggio 2023](https://ui.adsabs.harvard.edu/abs/2023AN....34430006G/abstract).

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
