### PR TITLE
RCAL-724: Add additional information to `compare_asdf` diff reports.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 0.13.1 (unreleased)
 ===================
 
+general
+-------
+
+- Updated the ``compare_asdf`` diff reports to include descriptive information
+  about what is being compared. [#1044]
+
 dq_init
 -------
 

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -6,6 +6,7 @@ import sys
 from difflib import unified_diff
 from glob import glob as _sys_glob
 from pathlib import Path
+from textwrap import dedent
 
 import asdf
 import astropy.table
@@ -657,15 +658,38 @@ class WCSOperator(NDArrayTypeOperator):
 
 
 class DiffResult:
-    def __init__(self, diff):
+    def __init__(self, diff, result, truth):
         self.diff = diff
+        self.result = result
+        self.truth = truth
 
     @property
     def identical(self):
         return not self.diff
 
+    @staticmethod
+    def _model_type(file):
+        import roman_datamodels as rdm
+
+        try:
+            with rdm.open(file) as mdl:
+                return mdl.__class__.__name__
+        except Exception:
+            return "Not a model"
+
     def report(self, **kwargs):
-        return pprint.pformat(self.diff)
+        title = dedent(
+            f"""
+            Diff report for:
+                result file: {self.result}
+                    model type: {self._model_type(self.result)}
+                truth file: {self.truth}
+                    model type: {self._model_type(self.result)}
+            """
+        )
+        report = pprint.pformat(self.diff)
+
+        return f"{title}\n{report}"
 
 
 def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
@@ -742,4 +766,4 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
             math_epsilon=atol,
             ignore_type_in_groups=[asdf.tags.core.NDArrayType, np.ndarray],
         )
-        return DiffResult(diff)
+        return DiffResult(diff, result, truth)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-724](https://jira.stsci.edu/browse/RCAL-724)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1027

<!-- describe the changes comprising this PR here -->
Currently the `compare_asdf` diff reports only return the deep diff results which indicate any differences between two asdf files. Why this is very useful, it does not tell the entire story; namely, it does not indicate what the diff was of. Issue #1027 indicates that it would be useful to know both the files being compared and the model names for the `roman_datamodels` included within those files (if applicable).

This PR adds a small header string to the start of the diff report that indicates the files input into `compare_asdf` and attempts to determine the `roman_datamodels` model described by the file (returning `Not a model` if the file does not describe a `roman_datamodel`), returning both for the "result" and "truth" inputs to `compare_asdf`. This is just a header stuck on top of the diff report string already being output, so it will not change any of our current regression tests or other reports. It will simply insert clarifying information into the report format.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
