### PR TITLE
drop sphinx-asdf requirement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ jump detection
 documentation
 -------------
 
+- Remove ``sphinx-asdf`` requirement, fix issue where menu does not scroll. [#1063]
+
 - Update jump step docs [#1035]
 
 - added user documentation for ``roman_static_preview`` script [#1046]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,6 @@ extensions = [
     "sphinx_automodapi.automodsumm",
     "sphinx_automodapi.autodoc_enhancements",
     "sphinx_automodapi.smart_resolver",
-    "sphinx_asdf",
     "sphinxcontrib.jquery",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dynamic = ['version']
 docs = [
     'matplotlib',
     'sphinx',
-    'sphinx-asdf',
     'sphinx-astropy',
     'sphinx-automodapi',
     'sphinx-rtd-theme',


### PR DESCRIPTION
This PR removes `sphinx-asdf` as a requirement. It's primary purpose is to render asdf schemas in the docs. As romancal contains no schemas (those are in `rad`) the requirement for `sphinx-asdf` is not needed.

This fixes the current issue where the docs are rendered with a side/navigation menu that does not scroll when it overflows.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
