### PR TITLE
fix compare_asdf model difference

### DIFF
--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -739,10 +739,6 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
             custom_operators=operators,
             exclude_paths=exclude_paths,
             math_epsilon=atol,
+            ignore_type_in_groups=[asdf.tags.core.NDArrayType, np.ndarray],
         )
-        # the conversion between NDArrayType and ndarray adds a bunch
-        # of type changes, ignore these for now.
-        # TODO Ideally we could find a way to remove just the NDArrayType ones
-        if "type_changes" in diff:
-            del diff["type_changes"]
         return DiffResult(diff)

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -90,3 +90,18 @@ def test_compare_asdf_tables(tmp_path, modification):
     else:
         assert not diff.identical, diff.report()
         assert "tables_differ" in diff.diff
+
+
+def test_model_difference(tmp_path):
+    fn0 = tmp_path / "a.asdf"
+    fn1 = tmp_path / "b.asdf"
+    ma = rdm.DistortionRefModel(maker_utils.mk_distortion())
+    mb = rdm.LinearityRefModel(maker_utils.mk_linearity())
+    ma.save(fn0)
+    mb.save(fn1)
+    diff = compare_asdf(fn0, fn1)
+    assert not diff.identical
+    assert (
+        """'type_changes': {"root['roman']": {'new_type': <class 'roman_datamodels.stnode.DistortionRef'>"""
+        in diff.report()
+    )


### PR DESCRIPTION
As noted https://github.com/spacetelescope/romancal/pull/1065#issue-2088562393
`compare_asdf` fails to identify differences if the `DataModel` type differs. This PR updates `compare_asdf` to identify these differences and adds a test for the fix.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
