### PR TITLE
Make remove_trends more robust against outliers / CRs.

### DIFF
--- a/romancal/refpix/data.py
+++ b/romancal/refpix/data.py
@@ -12,7 +12,7 @@ from enum import IntEnum
 
 import numpy as np
 from astropy import units as u
-from scipy import fft, stats, optimize
+from scipy import fft, optimize, stats
 
 
 class Const(IntEnum):
@@ -388,13 +388,15 @@ class ChannelView(BaseView):
                 # # Perform the fit using a 1st order polynomial, (i.e. linear fit)
                 # m, b = np.polyfit(x_vals, y_vals, 1)
 
-                std = stats.median_abs_deviation(y_vals, scale='normal')
+                std = stats.median_abs_deviation(y_vals, scale="normal")
                 std = np.hypot(std, 1)
 
                 fitres = optimize.least_squares(
-                    chi, [0, 0],
+                    chi,
+                    [0, 0],
                     kwargs=dict(datax=x_vals, datay=y_vals, sdev=std),
-                    loss='soft_l1')
+                    loss="soft_l1",
+                )
                 m, b = fitres.x
 
                 # Remove the fit from the data


### PR DESCRIPTION
This PR solves an issue where information in the border pixels in L1 files can lead to weird amp discontinuities in reference pixel corrected data.  This is not a PR that we should merge, but it illustrates what we need to do to improve the robustness of the reference pixel correction algorithm.

The trend removal algorithm is conceptually simple; it fits a linear function to the reference pixels in amplifier as a function of readout time and subtracts it.  This algorithm nevertheless has two important issues.
1. It uses the pixel value being zero as a signal for the pixel being invalid and requiring exclusion from the fit.
2. It is not a robust fit and therefore can pull the whole amp around if there are serious outliers.

The use of zero as a signal seems okay but is badly exacerbated by the current CRDS read noise reference files which have read noises artificially low (much less than 1 DN).  This means that the images have no read noise, so only Poisson noise from signal pixels contributes to the noise.  The reference pixels have no signal, so they are just constants + CRs.  The remove_trends step sees the pixels after a constant has been removed; this makes the reference pixels zeros + CRs.  This means that almost all of the reference pixels are ignored in the current Roman L1 files and _only_ the ones corrupted by CRs are actually seen.  Oops!  This PR "fixes" that issue by artificially leaving on a signal of 1e-9 DN for pixels that are originally non-zero but are zeroed after constant subtraction.  That's a dumb hack and a better approach would check the "offset" file correctly to see if the offset was also zero.

This could also be fixed by fixing the CRDS reference files, though some change along the lines of this PR is still needed since with real read noises of ~5 DN we will still be throwing away meaningful numbers of reference pixels for no reason with the current != 0 mask.

Note that for most amps there are only reference pixels at the beginning and end, and so the fit could basically be taking a median of the beginning and end reference pixels and fitting a line to those two points.  That would be fairly robust and would do what is needed.

This PR also has a little change to the linear fitting to make it robust to outliers.  This is not as important as the change to include pixels with values equal to zero, but is also a good idea.

The Goddard code has a hook that imagines calling an external routine to identify and remove cosmic rays.  We need that to eventually exist.  Currently I think CRs in the border pixels will still have some impact blurring out and affecting science pixels, just not nearly as badly as they previously had.