### PR TITLE
Provide a default WCS for ramp fitting.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,13 @@ documentation
 
 - added user documentation for ``roman_static_preview`` script [#1046]
 
+
+ramp_fitting
+------------
+
+- Add default WCS when constructing image model from ramp model [#1072]
+
+
 general
 -------
 

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -271,7 +271,7 @@ def create_image_model(input_model, image_info):
 
     # Create output datamodel
     # ... and add all keys from input
-    meta = {}
+    meta = dict(wcs=None)  # default empty WCS
     meta.update(input_model.meta)
     meta["cal_step"]["ramp_fit"] = "INCOMPLETE"
     meta["photometry"] = maker_utils.mk_photometry()


### PR DESCRIPTION
Units test started failing when we made the WCS a required argument, because the unit tests relied on being able to construct ImageModels from default RampModels.  The latter don't have default WCSes, but the former require them, so the code to construct the one from the other needs to add a default WCS.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
