### PR TITLE
Consolidate regression tests into fewer files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ tweakreg
 general
 -------
 
-- Update the ``dqflags`` to use the ones stored in ``roman_datamodels`` [#1099]
+- Update the ``dqflags`` to use the ones stored in
+  ``roman_datamodels`` [#1099]
+- Add script for creating regtest files; consolidate files used for
+  some tests. [#1084]
 
 documentation
 -------------

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -106,17 +106,17 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
         ),
         (
             "DMS366",
-            Path("WFI/grism/r0000201001001001001_01101_0001_WFI17_dqinit.asdf"),
+            Path("WFI/grism/r0000201001001001001_01101_0001_WFI01_darkcurrent.asdf"),
             CONDITIONS_FULL,
         ),
         (
             "DMS363",
-            Path("WFI/image/r0000101001001001001_01101_0003_WFI01_dqinit.asdf"),
+            Path("WFI/image/r0000101001001001001_01101_0003_WFI01_darkcurrent.asdf"),
             CONDITIONS_TRUNC,
         ),
         (
             "DMS367",
-            Path("WFI/grism/r0000201001001001001_01101_0003_WFI05_dqinit.asdf"),
+            Path("WFI/grism/r0000201001001001001_01101_0003_WFI01_darkcurrent.asdf"),
             CONDITIONS_TRUNC,
         ),
     ],

--- a/romancal/regtest/test_wfi_16resultants.py
+++ b/romancal/regtest/test_wfi_16resultants.py
@@ -22,19 +22,15 @@ def test_16resultants_image_processing(rtdata, ignore_asdf_paths):
     # The input data is from INS for stress testing at some point this should be generated
     # every time new data is needed.
 
-    input_dark = "roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf"
-    rtdata.get_data(f"WFI/image/{input_dark}")
-
-    input_data = "r00r1601001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000101001001001001_01101_0004_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r00r1601001001001001_01101_0001_WFI01_cal.asdf"
+    output = "r0000101001001001001_01101_0004_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf",
         "roman_elp",
         rtdata.input,
     ]
@@ -83,19 +79,15 @@ def test_16resultants_spectral_processing(rtdata, ignore_asdf_paths):
     # The input data is from INS for stress testing at some point this should be generated
     # by INS every time new data is needed.
 
-    input_dark = "roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf"
-    rtdata.get_data(f"WFI/image/{input_dark}")
-
-    input_data = "r10r1601001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000201001001001001_01101_0004_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r10r1601001001001001_01101_0001_WFI01_cal.asdf"
+    output = "r0000201001001001001_01101_0004_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
-        "--steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf",
         "roman_elp",
         rtdata.input,
     ]

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -74,7 +74,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     """DMS25 Test: Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
-    input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -98,7 +98,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_mask" in ref_file_name
 
     # Test DQInitStep
-    output = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
+    output = "r0000201001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -41,7 +41,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     the grism and prism data should be None, only testing the grism
     case here."""
 
-    input_file = "r0000201001001001002_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -60,7 +60,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     assert ref_file_name == "N/A"
 
     # Test FlatFieldStep
-    output = "r0000201001001001002_01101_0001_WFI01_flat.asdf"
+    output = "r0000201001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
@@ -128,7 +128,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     #  to separate flat files in CRDS.
 
     # Second file
-    input_file = "r0000101001001001001_01101_0002_WFI01_assignwcs.asdf"
+    input_file = "r0000101001001001001_01101_0001_WFI01_changetime_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -151,7 +151,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     )
 
     # Test FlatFieldStep
-    output = "r0000101001001001001_01101_0002_WFI01_flat.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_changetime_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -19,7 +19,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     """DMS140 Test: Testing application of photometric correction using
     CRDS selected photom file."""
 
-    input_data = "r0000201001001001001_01101_0001_WFI01_flat.asdf"
+    input_data = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
@@ -42,7 +42,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
 
     # Test PhotomStep
-    output = "r0000201001001001001_01101_0001_WFI01_photom.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_photom.asdf"
     rtdata.output = output
     args = ["romancal.step.PhotomStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -49,7 +49,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     """Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected saturation file applied."""
 
-    input_file = "r0000201001001001002_01101_0001_WFI01_dqinit.asdf"
+    input_file = "r0000201001001001001_01101_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -63,7 +63,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_saturation" in ref_file_name
 
     # Test SaturationStep
-    output = "r0000201001001001002_01101_0001_WFI01_saturation.asdf"
+    output = "r0000201001001001001_01101_0001_WFI01_saturation.asdf"
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# takes one argument: the directory into which to start putting the regtest files.
+
+# input files needed:
+# r0000101001001001001_01101_0001_WFI01 - default for most steps
+# r0000201001001001001_01101_0001_WFI01 - equivalent for spectroscopic data
+# r0000101001001001001_01101_0002_WFI01 - a second resample exposure, only cal step needed
+# r0000101001001001001_01101_0003_WFI01 - for ramp fitting; truncated image
+# r0000201001001001001_01101_0003_WFI01 - for ramp fitting; truncated spectroscopic
+#                                         we need only darkcurrent & ramp fit for these
+#
+# Not yet found / looked at these files.
+# r00r1601001001001001_01101_0001_WFI01 - special 16 resultant file, imaging, only need cal file
+# r10r1601001001001001_01101_0001_WFI01 - special 16 resultant file, spectroscopy, only need cal file
+# roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1 - special dark for 16 resultant file
+
+outdir=$1
+
+# set up the directory structure
+mkdir -p $outdir/roman-pipeline/dev/WFI/image
+mkdir -p $outdir/roman-pipeline/dev/truth/WFI/image
+mkdir -p $outdir/roman-pipeline/dev/WFI/grism
+mkdir -p $outdir/roman-pipeline/dev/truth/WFI/grism
+
+
+# most regtests; run the pipeline and save a lot of results.
+for fn in r0000101001001001001_01101_0001_WFI01 r0000201001001001001_01101_0001_WFI01
+do
+    echo "Running pipeline on ${fn}..."
+    strun roman_elp ${fn}_uncal.asdf --steps.dq_init.save_results True --steps.saturation.save_results True --steps.linearity.save_results True --steps.dark_current.save_results True --steps.rampfit.save_results True --steps.assign_wcs.save_results True --steps.photom.save_results True --steps.refpix.save_results True --steps.flatfield.save_results True --steps.assign_wcs.save_results True
+    [[ ${fn} = r00002* ]] && dirname="grism" || dirname="image"
+    cp ${fn}_*.asdf $outdir/roman-pipeline/dev/WFI/$dirname/
+    cp ${fn}_*.asdf $outdir/roman-pipeline/dev/truth/WFI/$dirname/
+
+    # uncal file doesn't belong in truth.
+    rm $outdir/roman-pipeline/dev/truth/WFI/image/${fn}_uncal.asdf
+done
+
+
+# truncated files for ramp fit regtests
+for fn in r0000101001001001001_01101_0003_WFI01 r0000201001001001001_01101_0003_WFI01
+do
+    echo "Running pipeline on ${fn}..."
+    strun roman_elp ${fn}_uncal.asdf --steps.dark_current.save_results True --steps.rampfit.save_results True
+    [[ ${fn} = r00002* ]] && dirname="grism" || dirname="image"
+    cp ${fn}_darkcurrent.asdf $outdir/roman-pipeline/dev/WFI/$dirname/
+    cp ${fn}_rampfit.asdf $outdir/roman-pipeline/dev/truth/WFI/$dirname/
+done
+
+
+# second imaging exposure
+strun roman_elp r0000101001001001001_01101_0002_WFI01_uncal.asdf
+cp r0000101001001001001_01101_0002_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
+
+
+# resample regtest; needs r0000101001001001001_01101_000{1,2}_WFI01_cal.asdf
+# builds the appropriate asn file and calls strun with it
+echo "Creating regtest files for resample..."
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf -o mosaic_asn.json --product-name mosaic
+strun romancal.step.ResampleStep mosaic_asn.json --rotation=0 --output_file=mosaic.asdf
+cp mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
+cp mosaic_resamplestep.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+
+
+# CRDS test needs the "usual" r00001..._01101_0001_WFI01 files.
+# It also needs a hacked r00001..._01101_0001_WFI01 file, with the time changed.
+# this makes the hacked version.
+echo "Creating regtest files for CRDS tests..."
+basename="r0000101001001001001_01101_0001_WFI01"
+python -c "
+import asdf
+from roman_datamodels import stnode
+from astropy.time import Time
+basename = '$basename'
+f = asdf.open(f'{basename}_uncal.asdf')
+f['roman']['meta']['exposure']['start_time'] = Time('2027-01-01T00:00:00', format='isot')
+f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_changetime_uncal.asdf')
+f.write_to(f'{basename}_changetime_uncal.asdf')"
+strun roman_elp ${basename}_changetime_uncal.asdf --steps.assign_wcs.save_results True --steps.flatfield.save_results True
+# copy input and truth files into location
+cp ${basename}_changetime_assignwcs.asdf $outdir/roman-pipeline/dev/WFI/image
+cp ${basename}_changetime_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/image
+
+
+echo "Creating regtest files for tweakreg tests..."
+# tweakreg regtest; call tweakreg on a cal file.  Make appropriate asn file.
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf -o tweakreg_asn.json --product-name tweakreg
+strun romancal.step.TweakRegStep tweakreg_asn.json
+cp tweakreg_asn.json $outdir/roman-pipeline/dev/WFI/image/
+cp r0000101001001001001_01101_0001_WFI01_tweakregstep.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+
+# need to make a special ALL_SATURATED file for the all saturated test.
+echo "Creating regtest files for all saturated tests..."
+basename="r0000101001001001001_01101_0001_WFI01"
+python -c "
+import asdf
+from roman_datamodels import stnode
+basename = '$basename'
+f = asdf.open(f'{basename}_uncal.asdf')
+data = f['roman']['data'].copy()
+data[...] = 65535 * f['roman']['data'].unit
+f['roman']['data'] = data
+f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_ALL_SATURATED_uncal.asdf')
+f.write_to(f'{basename}_ALL_SATURATED_uncal.asdf')"
+strun roman_elp ${basename}_ALL_SATURATED_uncal.asdf
+cp ${basename}_ALL_SATURATED_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp ${basename}_ALL_SATURATED_cal.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+
+# make a special file dark file with a different name
+strun romancal.step.DarkCurrentStep r0000101001001001001_01101_0001_WFI01_linearity.asdf --output_file=Test_dark
+cp Test_darkcurrent.asdf $outdir/roman-pipeline/dev/truth/WFI/image/ 
+
+
+# make a special linearity file with a different suffix
+strun romancal.step.LinearityStep r0000101001001001001_01101_0001_WFI01_refpix.asdf --output_file=Test_linearity
+cp Test_linearity.asdf $outdir/roman-pipeline/dev/truth/WFI/image/ 
+
+
+# we have a test that runs the flat field step directly on an _L1_ spectroscopic
+# file and verifies that it gets skipped.
+# I don't really understand that but we can duplicate it for now.
+basename="r0000201001001001001_01101_0001_WFI01"
+strun romancal.step.FlatFieldStep ${basename}_uncal.asdf
+cp ${basename}_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/grism/
+
+# make a version of a file with a different pointing
+# note this makes the meta['pointing'] data inconsistent with the wcsinfo?
+# we haven't updated the filename in these files, but the regtest mechanism
+# also doesn't
+# update them, and we need to match.
+for basename in r0000101001001001001_01101_0001_WFI01 r0000201001001001001_01101_0001_WFI01
+do
+    python -c "
+import asdf
+import roman_datamodels as rdm
+from romancal.assign_wcs.assign_wcs_step import AssignWcsStep
+model = rdm.open('${basename}_cal.asdf', lazy_load=False)
+delta = [10.0, 10.0]
+wcsinfo = model.meta.wcsinfo
+if wcsinfo.ra_ref >= 350.0:
+    delta[0] *= -1.0
+if wcsinfo.dec_ref >= 80.0:
+    delta[1] *= -1.0
+wcsinfo.ra_ref += delta[0]
+wcsinfo.dec_ref += delta[1]
+model = AssignWcsStep.call(model)
+model.to_asdf(f'${basename}_cal_repoint.asdf')"
+    [[ ${basename} = r00002* ]] && dirname="grism" || dirname="image"
+    cp ${basename}_cal_repoint.asdf $outdir/roman-pipeline/dev/truth/WFI/$dirname/
+    echo $dirname
+done
+
+strun roman_elp r00r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf
+strun roman_elp r10r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf 
+cp r00r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp r10r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
+cp roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf $outdir/roman-pipeline/dev/WFI/image/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -74,7 +74,7 @@ from roman_datamodels import stnode
 from astropy.time import Time
 basename = '$basename'
 f = asdf.open(f'{basename}_uncal.asdf')
-f['roman']['meta']['exposure']['start_time'] = Time('2027-01-01T00:00:00', format='isot')
+f['roman']['meta']['exposure']['start_time'] = Time('2020-01-01T00:00:00', format='isot')
 f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_changetime_uncal.asdf')
 f.write_to(f'{basename}_changetime_uncal.asdf')"
 strun roman_elp ${basename}_changetime_uncal.asdf --steps.assign_wcs.save_results True --steps.flatfield.save_results True
@@ -153,8 +153,7 @@ model.to_asdf(f'${basename}_cal_repoint.asdf')"
     echo $dirname
 done
 
-strun roman_elp r00r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf
-strun roman_elp r10r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf
-cp r00r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
-cp r10r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
-cp roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf $outdir/roman-pipeline/dev/WFI/image/
+strun roman_elp r0000101001001001001_01101_0004_WFI01_uncal.asdf
+strun roman_elp r0000201001001001001_01101_0004_WFI01_uncal.asdf
+cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -10,7 +10,6 @@
 # r0000201001001001001_01101_0003_WFI01 - for ramp fitting; truncated spectroscopic
 #                                         we need only darkcurrent & ramp fit for these
 #
-# Not yet found / looked at these files.
 # r00r1601001001001001_01101_0001_WFI01 - special 16 resultant file, imaging, only need cal file
 # r10r1601001001001001_01101_0001_WFI01 - special 16 resultant file, spectroscopy, only need cal file
 # roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1 - special dark for 16 resultant file

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -111,12 +111,12 @@ cp ${basename}_ALL_SATURATED_cal.asdf $outdir/roman-pipeline/dev/truth/WFI/image
 
 # make a special file dark file with a different name
 strun romancal.step.DarkCurrentStep r0000101001001001001_01101_0001_WFI01_linearity.asdf --output_file=Test_dark
-cp Test_darkcurrent.asdf $outdir/roman-pipeline/dev/truth/WFI/image/ 
+cp Test_darkcurrent.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 
 # make a special linearity file with a different suffix
 strun romancal.step.LinearityStep r0000101001001001001_01101_0001_WFI01_refpix.asdf --output_file=Test_linearity
-cp Test_linearity.asdf $outdir/roman-pipeline/dev/truth/WFI/image/ 
+cp Test_linearity.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 
 # we have a test that runs the flat field step directly on an _L1_ spectroscopic
@@ -154,7 +154,7 @@ model.to_asdf(f'${basename}_cal_repoint.asdf')"
 done
 
 strun roman_elp r00r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf
-strun roman_elp r10r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf 
+strun roman_elp r10r1601001001001001_01101_0001_WFI01_uncal.asdf --steps.dark_current.override_dark=roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf
 cp r00r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp r10r1601001001001001_01101_0001_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
 cp roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1.asdf $outdir/roman-pipeline/dev/WFI/image/

--- a/romancal/tweakreg/astrometric_utils.py
+++ b/romancal/tweakreg/astrometric_utils.py
@@ -102,10 +102,12 @@ def create_astrometric_catalog(
     epoch = (
         epoch
         if epoch is not None
-        else input_models[0].meta.target["proper_motion_epoch"]
+        else input_models[0].meta.exposure.mid_time.decimalyear
     )
-    # keep only decimal point and digit characters
-    epoch = float("".join(c for c in str(epoch) if c == "." or c.isdigit()))
+    if not isinstance(epoch, float):
+        # keep only decimal point and digit characters
+        epoch = float("".join(c for c in str(epoch) if c == "." or c.isdigit()))
+
     ref_dict = get_catalog(
         fiducial[0], fiducial[1], epoch=epoch, sr=radius, catalog=catalog
     )

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -430,7 +430,7 @@ def base_image():
 
     def _base_image(shift_1=0, shift_2=0):
         l2 = maker_utils.mk_level2_image(shape=(2000, 2000))
-        l2.meta.exposure.mid_time = Time('2016-01-01T00:00:00')
+        l2.meta.exposure.mid_time = Time("2016-01-01T00:00:00")
         # update wcsinfo
         update_wcsinfo(l2)
         # add a dummy WCS object

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -430,7 +430,7 @@ def base_image():
 
     def _base_image(shift_1=0, shift_2=0):
         l2 = maker_utils.mk_level2_image(shape=(2000, 2000))
-        l2.meta.target["proper_motion_epoch"] = "2016.0"
+        l2.meta.exposure.mid_time = Time('2016-01-01T00:00:00')
         # update wcsinfo
         update_wcsinfo(l2)
         # add a dummy WCS object
@@ -523,7 +523,7 @@ def test_create_astrometric_catalog_using_epoch(tmp_path, catalog, epoch, reques
     img = request.getfixturevalue("base_image")(shift_1=1000, shift_2=1000)
 
     metadata_epoch = (
-        epoch if epoch is not None else img.meta.target["proper_motion_epoch"]
+        epoch if epoch is not None else img.meta.exposure.mid_time.decimalyear
     )
     metadata_epoch = float(
         "".join(c for c in str(metadata_epoch) if c == "." or c.isdigit())

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -14,6 +14,7 @@ from astropy import units as u
 from astropy.modeling import models
 from astropy.modeling.models import RotationSequence3D, Scale, Shift
 from astropy.table import Table
+from astropy.time import Time
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
@@ -460,7 +461,7 @@ def base_image():
 
     def _base_image(shift_1=0, shift_2=0):
         l2 = maker_utils.mk_level2_image(shape=(2000, 2000))
-        l2.meta.target["proper_motion_epoch"] = "2016.0"
+        l2.meta.exposure.mid_time = Time('2016-01-01T00:00:00')
         # update wcsinfo
         update_wcsinfo(l2)
         # add a dummy WCS object

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -461,7 +461,7 @@ def base_image():
 
     def _base_image(shift_1=0, shift_2=0):
         l2 = maker_utils.mk_level2_image(shape=(2000, 2000))
-        l2.meta.exposure.mid_time = Time('2016-01-01T00:00:00')
+        l2.meta.exposure.mid_time = Time("2016-01-01T00:00:00")
         # update wcsinfo
         update_wcsinfo(l2)
         # add a dummy WCS object


### PR DESCRIPTION
This PR consolidates the regression tests to use fewer files and adds a script to create all of the regression test files from a directory of input files.

Changes to the regression tests:
- Point ramp fitting tests to WFI01 and darkcurrent subtracted files.  We had these pointing to weird files to deal with a caching issue and a shape issue in the run-up to B12; we don't need to continue doing that.
- Point test_wfi_dq_init, test_wfi_flat_field, test_wfi_saturation tests to the one fiducial spectroscopic regression test file; these formerly used a second file but I'm not sure what the motivation for that originally was.
- Rename the munged L1 file with a different time to be clear that this is a file we are making with a weird time rather than a file from RTB.
- Move some test_wfi_photom files to use the nominal imaging L1 file rather than the grism file.

Then there is a big new script that generates all of the regtest files from the input files, which following the above changes are:

```
# r0000101001001001001_01101_0001_WFI01 - default for most steps
# r0000201001001001001_01101_0001_WFI01 - equivalent for spectroscopic data
# r0000101001001001001_01101_0002_WFI01 - a second resample exposure, only cal step needed
# r0000101001001001001_01101_0003_WFI01 - for ramp fitting; truncated image
# r0000201001001001001_01101_0003_WFI01 - for ramp fitting; truncated spectroscopic
#                                         we need only darkcurrent & ramp fit for these
#
# r00r1601001001001001_01101_0001_WFI01 - special 16 resultant file, imaging, only need cal file
# r10r1601001001001001_01101_0001_WFI01 - special 16 resultant file, spectroscopy, only need cal file
# roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1 - special dark for 16 resultant file
```

That script became a fairly messy mixture of python and shell script.  I could make it all python which might be better, though it will still have a bunch of pipeline invocations and copying that is nicer in shell.  One runs this script by:
- copying the input files above from central store/roman/eschlafly/regtestinput into a local directory
- making an output directory (e.g., data)
- running make_regtestdata.sh data


I think this would be uncontroversial except for the fact that it involves changing the names of some files.  These are presumably embedded in past requirement tickets and may be annoying to change.

The regtest directory generated by this script is 76 GB.  It may be possible to be a bit more efficient, as I have not been careful with checking that each of the intermediate steps that get saved for the processing of the "primary" imaging and spectroscopic files is actually used.  But this is probably pretty close to the minimum the current tests need.

I note that the test_wfi_flat_field/test_flat_field_grism_step is testing the flat field applied to grism data.  It's a bit annoying because a normal pipeline run doesn't run the flat fielding on grism data, and so these files aren't ordinarily created.  The regtest runs the step on an L1 file, which the flat field step shouldn't be able to process in the first place, but presumably since the step just ends up getting skipped this doesn't cause problems.  I have left in that behavior, but this test doesn't have any SOC test decoration and so I think I'd rather just delete this test and the corresponding lines in the script to generate its file.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
