### PR TITLE
Use dark slope in ramp fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ ramp_fitting
 
 - Add default WCS when constructing image model from ramp model [#1072]
 
+- Account for Poisson noise from dark current when fitting ramps.
+
 resample
 --------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@ ramp_fitting
 
 - Add default WCS when constructing image model from ramp model [#1072]
 
-- Account for Poisson noise from dark current when fitting ramps.
+- Account for Poisson noise from dark current when fitting ramps. [#1087]
 
 resample
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@ ramp_fitting
 
 - Add default WCS when constructing image model from ramp model [#1072]
 
-- Account for Poisson noise from dark current when fitting ramps. [#1087]
+- Account for Poisson noise from dark current when fitting ramps. [#1088]
 
 resample
 --------

--- a/docs/roman/ramp_fitting/description.rst
+++ b/docs/roman/ramp_fitting/description.rst
@@ -62,7 +62,19 @@ appropriate slopes and variances are output to the primary output product, and t
 following is a description of these computations. The notation in the equations
 is the following: the type of noise (when appropriate) will appear as the superscript
 ‘R’, ‘P’, or ‘C’ for readnoise, Poisson noise, or combined, respectively;
-and the form of the data will appear as the subscript: ‘s’, ‘o’ for segment, or overall (for the entire dataset), respectively.
+and the form of the data will appear as the subscript: ‘s’, ‘o’ for
+segment, or overall (for the entire dataset), respectively.
+
+Dark current
+++++++++++++
+Ramp fitting receives dark-subtracted ramps as input, but the Poisson noise
+in the dark current contributes to the noise in the ramps.  So we need
+to add the dark current back into the ramps before ramp fitting, and
+then subtract it off again from the ramp fits.
+
+Dark current in Roman is low and this makes very little difference for
+most pixels.
+
 
 Optimal Weighting Algorithm
 ---------------------------

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -56,9 +56,11 @@ class RampFitStep(RomanStep):
                 out_model = self.ols(input_model, readnoise_model, gain_model)
                 out_model.meta.cal_step.ramp_fit = "COMPLETE"
             elif algorithm == "ols_cas22":
-                dark_filename = self.get_reference_file(input_model, 'dark')
-                dark_model = rdd.open(dark_filename, mode='r')
-                out_model = self.ols_cas22(input_model, readnoise_model, gain_model, dark_model)
+                dark_filename = self.get_reference_file(input_model, "dark")
+                dark_model = rdd.open(dark_filename, mode="r")
+                out_model = self.ols_cas22(
+                    input_model, readnoise_model, gain_model, dark_model
+                )
                 out_model.meta.cal_step.ramp_fit = "COMPLETE"
                 if self.use_ramp_jump_detection:
                     out_model.meta.cal_step.jump = "COMPLETE"
@@ -182,17 +184,16 @@ class RampFitStep(RomanStep):
         read_time = input_model.meta.exposure.frame_time
 
         # Force read pattern to be pure lists not LNodes
-        read_pattern = [list(reads)
-                        for reads in input_model.meta.exposure.read_pattern]
+        read_pattern = [list(reads) for reads in input_model.meta.exposure.read_pattern]
         if len(read_pattern) != resultants.shape[0]:
-            raise RuntimeError('mismatch between resultants shape and '
-                               'read_pattern.')
+            raise RuntimeError("mismatch between resultants shape and " "read_pattern.")
 
         # add dark current back into resultants so that Poisson noise is
         # properly accounted for
         tbar = np.array([np.mean(reads) * read_time for reads in read_pattern])
-        resultants += (dark_model.dark_slope.to(u.DN / u.s).value[None, ...]
-                       * tbar[:, None, None])
+        resultants += (
+            dark_model.dark_slope.to(u.DN / u.s).value[None, ...] * tbar[:, None, None]
+        )
 
         # account for the gain
         resultants *= gain

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -38,7 +38,7 @@ class RampFitStep(RomanStep):
 
     weighting = "optimal"  # Only weighting allowed for OLS
 
-    reference_file_types = ["readnoise", "gain"]
+    reference_file_types = ["readnoise", "gain", "dark"]
 
     def process(self, input):
         with rdd.open(input, mode="rw") as input_model:
@@ -56,7 +56,9 @@ class RampFitStep(RomanStep):
                 out_model = self.ols(input_model, readnoise_model, gain_model)
                 out_model.meta.cal_step.ramp_fit = "COMPLETE"
             elif algorithm == "ols_cas22":
-                out_model = self.ols_cas22(input_model, readnoise_model, gain_model)
+                dark_filename = self.get_reference_file(input_model, 'dark')
+                dark_model = rdd.open(dark_filename, mode='r')
+                out_model = self.ols_cas22(input_model, readnoise_model, gain_model, dark_model)
                 out_model.meta.cal_step.ramp_fit = "COMPLETE"
                 if self.use_ramp_jump_detection:
                     out_model.meta.cal_step.jump = "COMPLETE"
@@ -138,7 +140,7 @@ class RampFitStep(RomanStep):
 
         return out_model
 
-    def ols_cas22(self, input_model, readnoise_model, gain_model):
+    def ols_cas22(self, input_model, readnoise_model, gain_model, dark_model):
         """Peform Optimal Linear Fitting on arbitrarily space resulants
 
         Parameters
@@ -151,6 +153,9 @@ class RampFitStep(RomanStep):
 
         gain_model : GainRefModel
             Model with the gain reference information.
+
+        dark_model : DarkRefModel
+            Model with the dark reference information
 
         Returns
         -------
@@ -176,12 +181,22 @@ class RampFitStep(RomanStep):
         gain = gain_model.data.value
         read_time = input_model.meta.exposure.frame_time
 
+        # Force read pattern to be pure lists not LNodes
+        read_pattern = [list(reads)
+                        for reads in input_model.meta.exposure.read_pattern]
+        if len(read_pattern) != resultants.shape[0]:
+            raise RuntimeError('mismatch between resultants shape and '
+                               'read_pattern.')
+
+        # add dark current back into resultants so that Poisson noise is
+        # properly accounted for
+        tbar = np.array([np.mean(reads) * read_time for reads in read_pattern])
+        resultants += (dark_model.dark_slope.to(u.DN / u.s).value[None, ...]
+                       * tbar[:, None, None])
+
         # account for the gain
         resultants *= gain
         read_noise *= gain
-
-        # Force read pattern to be pure lists not LNodes
-        read_pattern = [list(reads) for reads in input_model.meta.exposure.read_pattern]
 
         # Fit the ramps
         output = ols_cas22_fit.fit_ramps_casertano(
@@ -200,6 +215,9 @@ class RampFitStep(RomanStep):
         var_poisson = output.variances[..., Variance.poisson_var]
         err = np.sqrt(var_poisson + var_rnoise)
         dq = output.dq.astype(np.uint32)
+
+        # remove dark current contribution to slopes
+        slopes -= dark_model.dark_slope.to(u.DN / u.s).value * gain
 
         # Propagate DQ flags forward.
         ramp_dq = get_pixeldq_flags(dq, input_model.pixeldq, slopes, err, gain)

--- a/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
@@ -6,7 +6,11 @@ from astropy import units as u
 from astropy.time import Time
 from roman_datamodels import maker_utils
 from roman_datamodels.datamodels import (
-    GainRefModel, RampModel, ReadnoiseRefModel, DarkRefModel)
+    DarkRefModel,
+    GainRefModel,
+    RampModel,
+    ReadnoiseRefModel,
+)
 
 from romancal.ramp_fitting import RampFitStep
 
@@ -183,7 +187,8 @@ def make_data(resultants, ingain, rnoise, randomize):
     """
     ramp_model = model_from_resultants(resultants)
     gain_model, readnoise_model, dark_model = generate_wfi_reffiles(
-        ramp_model.shape[1:], ingain=ingain, rnoise=rnoise, randomize=randomize)
+        ramp_model.shape[1:], ingain=ingain, rnoise=rnoise, randomize=randomize
+    )
 
     return ramp_model, gain_model, readnoise_model, dark_model
 
@@ -238,8 +243,9 @@ def model_from_resultants(resultants, read_pattern=None):
     return ramp_model
 
 
-def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01,
-                          darkcurrent=0.01, randomize=True):
+def generate_wfi_reffiles(
+    shape, ingain=6, rnoise=0.01, darkcurrent=0.01, randomize=True
+):
     """Create GainRefModel and ReadnoiseRefModel
 
     Parameters
@@ -324,8 +330,7 @@ def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01,
     dark_ref["meta"]["exposure"]["frame_time"] = 666
 
     dark_ref["dark_slope"] = u.Quantity(
-        np.zeros(shape).astype(np.float32) * 0.01, u.DN / u.s,
-        dtype=np.float32
+        np.zeros(shape).astype(np.float32) * 0.01, u.DN / u.s, dtype=np.float32
     )
 
     dark_ref_model = DarkRefModel(dark_ref)

--- a/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
@@ -5,7 +5,8 @@ import pytest
 from astropy import units as u
 from astropy.time import Time
 from roman_datamodels import maker_utils
-from roman_datamodels.datamodels import GainRefModel, RampModel, ReadnoiseRefModel
+from roman_datamodels.datamodels import (
+    GainRefModel, RampModel, ReadnoiseRefModel, DarkRefModel)
 
 from romancal.ramp_fitting import RampFitStep
 
@@ -75,7 +76,7 @@ SIMPLE_EXPECTED_RNOISE = {
 # #####
 def test_bad_readpattern():
     """Ensure error is raised on bad readpattern"""
-    ramp_model, gain_model, readnoise_model = make_data(
+    ramp_model, gain_model, readnoise_model, dark_model = make_data(
         SIMPLE_RESULTANTS, 1, 0.01, False
     )
     bad_pattern = ramp_model.meta.exposure.read_pattern.data[1:]
@@ -87,6 +88,7 @@ def test_bad_readpattern():
             algorithm="ols_cas22",
             override_gain=gain_model,
             override_readnoise=readnoise_model,
+            override_dark=dark_model,
         )
 
 
@@ -138,7 +140,7 @@ def test_fits(fit_ramps, attribute):
 def fit_ramps(request):
     """Test ramp fits"""
     resultants, ingain, rnoise, randomize, expected, use_jump = request.param
-    ramp_model, gain_model, readnoise_model = make_data(
+    ramp_model, gain_model, readnoise_model, dark_model = make_data(
         resultants, ingain, rnoise, randomize
     )
 
@@ -148,6 +150,7 @@ def fit_ramps(request):
         use_ramp_jump_detection=use_jump,
         override_gain=gain_model,
         override_readnoise=readnoise_model,
+        override_dark=dark_model,
     )
 
     return out_model, expected
@@ -179,11 +182,10 @@ def make_data(resultants, ingain, rnoise, randomize):
         Input image and related references
     """
     ramp_model = model_from_resultants(resultants)
-    gain_model, readnoise_model = generate_wfi_reffiles(
-        ramp_model.shape[1:], ingain=ingain, rnoise=rnoise, randomize=randomize
-    )
+    gain_model, readnoise_model, dark_model = generate_wfi_reffiles(
+        ramp_model.shape[1:], ingain=ingain, rnoise=rnoise, randomize=randomize)
 
-    return ramp_model, gain_model, readnoise_model
+    return ramp_model, gain_model, readnoise_model, dark_model
 
 
 def model_from_resultants(resultants, read_pattern=None):
@@ -195,7 +197,7 @@ def model_from_resultants(resultants, read_pattern=None):
         The resultants to fit.
 
     read_pattern : [[int[,...]][,...]]
-        The read patter used to produce the resultants.
+        The read pattern used to produce the resultants.
         If None, presume a basic read pattern
     """
     if read_pattern is None:
@@ -236,7 +238,8 @@ def model_from_resultants(resultants, read_pattern=None):
     return ramp_model
 
 
-def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01, randomize=True):
+def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01,
+                          darkcurrent=0.01, randomize=True):
     """Create GainRefModel and ReadnoiseRefModel
 
     Parameters
@@ -249,6 +252,9 @@ def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01, randomize=True):
 
     rnoise : flota
         Maximum noise
+
+    darkcurrent : float
+        Dark current scale
 
     randomize : bool
         Randomize the gain and read noise data.
@@ -305,5 +311,24 @@ def generate_wfi_reffiles(shape, ingain=6, rnoise=0.01, randomize=True):
 
     rn_ref_model = ReadnoiseRefModel(rn_ref)
 
+    # Create temporary dark reference file
+    # shape needs to be 3D but does not matter because the ramp fitting
+    # step only uses the 2-D dark slope component
+    dark_ref = maker_utils.mk_dark(shape=(1,) + shape)
+    dark_ref["meta"]["instrument"]["detector"] = "WFI01"
+    dark_ref["meta"]["instrument"]["name"] = "WFI"
+    dark_ref["meta"]["reftype"] = "DARK"
+    dark_ref["meta"]["useafter"] = Time("2022-01-01T11:11:11.111")
+
+    dark_ref["meta"]["exposure"]["type"] = "WFI_IMAGE"
+    dark_ref["meta"]["exposure"]["frame_time"] = 666
+
+    dark_ref["dark_slope"] = u.Quantity(
+        np.zeros(shape).astype(np.float32) * 0.01, u.DN / u.s,
+        dtype=np.float32
+    )
+
+    dark_ref_model = DarkRefModel(dark_ref)
+
     # return gainfile, readnoisefile
-    return gain_ref_model, rn_ref_model
+    return gain_ref_model, rn_ref_model, dark_ref_model


### PR DESCRIPTION
Presently the ramp fitting step operates on dark-subtracted ramps, but assumes that the Poisson noise in those ramps can be well estimated by the square root of the rate.  The dark current contribution to the rate should be part of that Poisson noise, but is omitted because the step operates on dark-subtracted ramps.

This PR adds the dark current portion of the dark reference file (dark_slope) back into the ramp, performs the ramp fitting, and then removes the contribution from the slopes.  This is related to
https://innerspace.stsci.edu/display/RI/Ramp+Fitting+-+v1
.  It has the slight benefit of being more correct (we're choosing weights better), but being more convoluted (we're adding and subtracting dark current.

We'll also use more memory than previously---the darks are rather big, and now we need to have them in memory during ramp fitting, which is when we have peak memory usage.

This changes the variances slightly and is expected to break regression tests.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [X] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
