### PR TITLE
Fix a few incorrect dtypes used in tests

### DIFF
--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -215,7 +215,7 @@ def test_dqinit_step_interface(instrument, exptype):
     meta["instrument"]["detector"] = "WFI01"
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
-    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
+    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
     maskref["err"] = (RNG.uniform(size=shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 
@@ -264,7 +264,7 @@ def test_dqinit_refpix(instrument, exptype):
     meta["instrument"]["detector"] = "WFI01"
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
-    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
+    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
     maskref["err"] = (RNG.uniform(size=shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 
@@ -317,7 +317,7 @@ def test_dqinit_resultantdq(instrument, exptype):
     meta["instrument"]["detector"] = "WFI01"
     maskref["meta"] = meta
     maskref["data"] = np.ones(shape[1:], dtype=np.float32)
-    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint16)
+    maskref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
     maskref["err"] = (RNG.uniform(size=shape[1:]) * 0.05).astype(np.float32)
     maskref_model = MaskRefModel(maskref)
 

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -50,7 +50,7 @@ def test_flatfield_step_interface(instrument, exptype):
     meta["instrument"]["detector"] = "WFI01"
     flatref["meta"] = meta
     flatref["data"] = np.ones(shape, dtype=np.float32)
-    flatref["dq"] = np.zeros(shape, dtype=np.uint16)
+    flatref["dq"] = np.zeros(shape, dtype=np.uint32)
     flatref["err"] = (RNG.uniform(size=shape) * 0.05).astype(np.float32)
     flatref_model = FlatRefModel(flatref)
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
In testing `romancal` using spacetelescope/rad#369, the only failures in both the unit and regression tests were due to a few incorrectly defined `dtypes` used within the tests themselves. These were all minor bugs that did not effect anything major.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~ The only changes were to normal unit tests which are run by the CI here.
