### PR TITLE
Updates to change pass to pass_number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,11 @@ dependencies = [
     'pyparsing >=2.4.7',
     'requests >=2.26',
     #'rad >=0.19.0',
-    'rad @ git+https://github.com/spacetelescope/rad.git',
+    #'rad @ git+https://github.com/spacetelescope/rad.git',
+    'rad @ git+https://github.com/WilliamJamieson/rad.git@bugfix/pass',  # temporary until rad/roman_datamodels PRs are merged
     #'roman_datamodels >=0.19.0',
-    'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git',
+    #'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git',
+    'roman_datamodels @ git+https://github.com/WilliamJamieson/roman_datamodels.git@bugfix/pass',  # temporary until rad/roman_datamodes PRs are merged
     'scipy >=1.11',
     #'stcal >=1.5.2',
     'stcal @ git+https://github.com/spacetelescope/stcal.git@main',

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -698,7 +698,7 @@ def l2_into_l3_meta(l3_meta, l2_meta):
     """
     l3_meta.basic.visit = l2_meta.observation.visit
     l3_meta.basic.segment = l2_meta.observation.segment
-    l3_meta.basic["pass"] = l2_meta.observation["pass"]
+    l3_meta.basic.pass_number = l2_meta.observation.pass_number
     l3_meta.basic.program = l2_meta.observation.program
     l3_meta.basic.survey = l2_meta.observation.survey
     l3_meta.basic.optical_element = l2_meta.instrument.optical_element


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR makes the minor fixes needed to support the changes from spacetelescope/rad#360 and spacetelescope/roman_datamodels#306. These are to avoid a name collision with the `pass` syntax word in python.

Note that the regression test files will have to be updated because they use the word `pass` instead of `pass_number` and so will not validate when being read.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
