### PR TITLE
Find and fix all the tmpdir usages

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,4 +1,22 @@
+import os
+from contextlib import contextmanager
+
 import pytest
+
+# chdir contextmanager was added with Python 3.11
+try:
+    from contextlib import chdir
+except ImportError:
+
+    @contextmanager
+    def chdir(path):
+        old_path = os.getcwd()
+
+        try:
+            os.chdir(path)
+            yield
+        finally:
+            os.chdir(old_path)
 
 
 @pytest.fixture(autouse=True)
@@ -6,8 +24,8 @@ def _docdir(request):
     # Trigger ONLY for doctestplus.
     doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
     if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-        tmpdir = request.getfixturevalue("tmpdir")
-        with tmpdir.as_cwd():
+        tmp_path = request.getfixturevalue("tmp_path")
+        with chdir(tmp_path):
             yield
     else:
         yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ addopts = [
     '--show-capture=no',
     '--doctest-ignore-import-errors',
     '--color=yes',
+    # '-p no:legacypath',  # disables the legacy tmpdir fixture, when ASDF > 3.0.1 is required this can be uncommented
 ]
 markers = [
     'soctests: run only the SOC tests in the suite.',

--- a/romancal/assign_wcs/tests/test_wcs.py
+++ b/romancal/assign_wcs/tests/test_wcs.py
@@ -48,8 +48,8 @@ def create_step():
 
 @pytest.mark.parametrize("distortion", create_distortion())
 @pytest.mark.parametrize("step", create_step())
-def test_wcs(tmpdir, distortion, step):
-    file_name = str(tmpdir / "distortion.asdf")
+def test_wcs(tmp_path, distortion, step):
+    file_name = str(tmp_path / "distortion.asdf")
     dist = rdm.DistortionRefModel(distortion)
     dist.save(file_name)
 

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -100,15 +100,15 @@ def test_cmdline_fails():
 
 
 @pytest.mark.parametrize("format", ["json", "yaml"])
-def test_cmdline_success(format, tmpdir):
+def test_cmdline_success(format, tmp_path):
     """Create ELPP associations in different formats"""
-    path = tmpdir.join("test_asn.json")
+    path = tmp_path / "test_asn.json"
     product_name = "test_product"
     inlist = ["a", "b", "c"]
-    args = ["-o", path.strpath, "--product-name", product_name, "--format", format]
+    args = ["-o", str(path), "--product-name", product_name, "--format", format]
     args = args + inlist
     Main(args)
-    with open(path.strpath) as fp:
+    with path.open() as fp:
         asn = load_asn(fp, format=format)
     assert len(asn["products"]) == 1
     assert asn["products"][0]["name"] == product_name
@@ -117,14 +117,14 @@ def test_cmdline_success(format, tmpdir):
     assert inlist == expnames
 
 
-def test_cmdline_change_rules(tmpdir):
+def test_cmdline_change_rules(tmp_path):
     """Command line change the rule"""
     rule = "Asn_Lv2Image"
-    path = tmpdir.join("test_asn.json")
+    path = tmp_path / "test_asn.json"
     inlist = ["a", "b", "c"]
     args = [
         "-o",
-        path.strpath,
+        str(path),
         "-r",
         rule,
         "--product-name",
@@ -132,7 +132,7 @@ def test_cmdline_change_rules(tmpdir):
     ]
     args = args + inlist
     Main(args)
-    with open(path.strpath) as fp:
+    with path.open() as fp:
         asn = load_asn(fp, registry=AssociationRegistry(include_bases=True))
     # assert inlist == asn['members']
     assert inlist[0] == asn["products"][0]["members"][0]["expname"]

--- a/romancal/associations/tests/test_pool.py
+++ b/romancal/associations/tests/test_pool.py
@@ -4,11 +4,14 @@ from romancal.associations.tests.helpers import t_path
 POOL_FILE = t_path("data/jw93060_20150312T160130_pool.csv")
 
 
-def test_pool(tmpdir):
+def test_pool(tmp_path):
     pool = AssociationPool.read(POOL_FILE)
     assert len(pool) == 636
 
-    tmp_pool = str(tmpdir.mkdir(__name__).join("tmp_pool.csv"))
+    file_path = tmp_path / __name__
+    file_path.mkdir()
+
+    tmp_pool = str(file_path / "tmp_pool.csv")
     pool.write(tmp_pool)
 
     roundtrip = AssociationPool.read(tmp_pool)

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -83,9 +83,9 @@ def test_dark_step_subtraction(instrument, exptype):
         ("WFI", "WFI_IMAGE"),
     ],
 )
-def test_dark_step_output_dark_file(tmpdir, instrument, exptype):
+def test_dark_step_output_dark_file(tmp_path, instrument, exptype):
     """Test that the the step can output a proper (optional) dark file"""
-    path = str(tmpdir / "dark_out.asdf")
+    path = str(tmp_path / "dark_out.asdf")
 
     # Set test size
     shape = (2, 20, 20)
@@ -112,9 +112,9 @@ def test_dark_step_output_dark_file(tmpdir, instrument, exptype):
         ("WFI", "WFI_IMAGE"),
     ],
 )
-def test_dark_step_getbestrefs(tmpdir, instrument, exptype):
+def test_dark_step_getbestrefs(tmp_path, instrument, exptype):
     """Test that the the step will skip if CRDS returns N/A for the ref file"""
-    path = str(tmpdir / "dark_out.asdf")
+    path = str(tmp_path / "dark_out.asdf")
 
     # Set test size
     shape = (2, 20, 20)

--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -21,9 +21,9 @@ MAXIMUM_CORES = ["none", "quarter", "half", "all"]
 
 
 @pytest.fixture(scope="module")
-def generate_wfi_reffiles(tmpdir_factory):
-    gainfile = str(tmpdir_factory.mktemp("ndata").join("gain.asdf"))
-    readnoisefile = str(tmpdir_factory.mktemp("ndata").join("readnoise.asdf"))
+def generate_wfi_reffiles(tmp_path_factory):
+    gainfile = str(tmp_path_factory.mktemp("ndata") / "gain.asdf")
+    readnoisefile = str(tmp_path_factory.mktemp("ndata") / "readnoise.asdf")
 
     ingain = 6
     xsize = 20


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
[`pytest` recommends creating temporary directories with the `tmp_path` fixture instead of the legacy `tmpdir`](https://docs.pytest.org/en/latest/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures). To check for use of the legacy method one can run with
```
pytest -p no:legacypath
```
This PR used that command to discover all uses of `tmpdir` and correct them. It does not add this as a permanent check because the `pytest_asdf` plugin that is built into the `asdf` package relies on this legacy system. This was fixed by asdf_format/asdf#1759, but has not been released yet.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
