### PR TITLE
remove `tmpdir_factory` usage, enable no:legacypath as a tox factor

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -52,7 +52,7 @@ jobs:
           pytest-results-summary: true
         - linux: py39-webbpsf
           pytest-results-summary: true
-        - linux: py310-webbpsf
+        - linux: py310-webbpsf-nolegacypath
           pytest-results-summary: true
         - linux: py311-ddtrace-webbpsf
           pytest-results-summary: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf >=2.15.0',
+    'asdf >=3.1.0',
     'asdf-astropy >=0.5.0',
     'astropy >=5.3.0',
     'crds >=11.16.16',
@@ -138,7 +138,7 @@ addopts = [
     '--show-capture=no',
     '--doctest-ignore-import-errors',
     '--color=yes',
-    # '-p no:legacypath',  # disables the legacy tmpdir fixture, when ASDF > 3.0.1 is required this can be uncommented
+    '-p no:legacypath',
 ]
 markers = [
     'soctests: run only the SOC tests in the suite.',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf >=3.1.0',
+    'asdf >=2.15.0',
     'asdf-astropy >=0.5.0',
     'astropy >=5.3.0',
     'crds >=11.16.16',
@@ -138,7 +138,6 @@ addopts = [
     '--show-capture=no',
     '--doctest-ignore-import-errors',
     '--color=yes',
-    '-p no:legacypath',
 ]
 markers = [
     'soctests: run only the SOC tests in the suite.',

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -43,8 +43,19 @@ def slow(request):
     return request.config.getoption("--slow")
 
 
+@pytest.fixture(scope="function")
+def function_jail(tmp_path):
+    """Perform test in a pristine temporary working directory."""
+    old_dir = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield str(tmp_path)
+    finally:
+        os.chdir(old_dir)
+
+
 @pytest.fixture(scope="module")
-def jail(request, tmpdir_factory):
+def module_jail(request, tmp_path_factory):
     """Run test in a pristine temporary working directory, scoped to module.
 
     This fixture is the same as _jail in ci_watson, but scoped to module
@@ -55,7 +66,7 @@ def jail(request, tmpdir_factory):
     path = request.module.__name__.split(".")[-1]
     if request._parent_request.fixturename is not None:
         path = path + "_" + request._parent_request.fixturename
-    newpath = tmpdir_factory.mktemp(path)
+    newpath = tmp_path_factory.mktemp(path)
     os.chdir(str(newpath))
     yield newpath
     os.chdir(old_dir)

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -191,12 +191,12 @@ def _rtdata_fixture_implementation(artifactory_repos, envopt, request):
 
 
 @pytest.fixture(scope="function")
-def rtdata(artifactory_repos, envopt, request, _jail):
+def rtdata(artifactory_repos, envopt, request, function_jail):
     yield from _rtdata_fixture_implementation(artifactory_repos, envopt, request)
 
 
 @pytest.fixture(scope="module")
-def rtdata_module(artifactory_repos, envopt, request, jail):
+def rtdata_module(artifactory_repos, envopt, request, module_jail):
     yield from _rtdata_fixture_implementation(artifactory_repos, envopt, request)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     check-{style,dependencies,build}
-    test{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov,-webbpsf}
+    test{,-alldeps,-devdeps}{,-pyargs,-warnings,-regtests,-cov,-webbpsf}{-nolegacypath}
     test-numpy{120,121,122}-xdist
     build-{docs,dist}
 
@@ -78,6 +78,7 @@ commands =
     xdist: -n 0 \
     pyargs: {toxinidir}/docs --pyargs {posargs:romancal} \
     ddtrace: --ddtrace \
+    nolegacypath: -p no:legacypath \
     webbpsf: --webbpsf \
     {posargs}
 


### PR DESCRIPTION
Incompatibility between ddtrace (and ci_watson) and the `-p no:legacypath` option for pytest means that the `-p no:legacypath` option cannot be "globally" enabled.

This PR instead enables the option as a tox factor and uses the factor for a single pytest suite run `py310-webbpsf-nolegacypath`. This will allow romancal to keep the current asdf lower pin, not wait until ddtrace and ci_watson are updated and still reap most of the benefits of the `-p no:legacypath` option as all tests run during the `py310-webbpsf-nolegacypath` run will be checked for legacy path usage.

Regtests were run with no errors `-p no:legacypath` (and ddtrace disabled):
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/616/pipeline/220
The run used c843a2a88c972fc0253b02d7b0942a007a044142 which has since been removed from this PR to allow the regtests to continue to use ddtrace.

Once ddtrace is updated, the regtests should also be updated to use `-p no:legacypath`.

As the changes in this PR will not enforce `-p no:legacypath` for the regtests https://github.com/spacetelescope/romancal/issues/1115 will be updated once this PR is merged.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
