### PR TITLE
copy reference pixels during dqinit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ documentation
 
 - Fixed datamodels documentation to use correct API. [#1112]
 
+dq_init
+-------
+
+- Copy reference pixels during ``dq_init`` to avoid larger files in later
+  processing steps [#1121]
+
 
 0.14.0 (2024-02-12)
 ===================

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -101,15 +101,15 @@ class DQInitStep(RomanStep):
             # the science data until they are trimmed at ramp_fit
             # these arrays include the overlap regions in the corners
 
-            output_model.border_ref_pix_right = output_model.data[:, :, -4:]
-            output_model.border_ref_pix_left = output_model.data[:, :, :4]
-            output_model.border_ref_pix_top = output_model.data[:, :4, :]
-            output_model.border_ref_pix_bottom = output_model.data[:, -4:, :]
+            output_model.border_ref_pix_right = output_model.data[:, :, -4:].copy()
+            output_model.border_ref_pix_left = output_model.data[:, :, :4].copy()
+            output_model.border_ref_pix_top = output_model.data[:, :4, :].copy()
+            output_model.border_ref_pix_bottom = output_model.data[:, -4:, :].copy()
 
-            output_model.dq_border_ref_pix_right = output_model.pixeldq[:, -4:]
-            output_model.dq_border_ref_pix_left = output_model.pixeldq[:, :4]
-            output_model.dq_border_ref_pix_top = output_model.pixeldq[:4, :]
-            output_model.dq_border_ref_pix_bottom = output_model.pixeldq[-4:, :]
+            output_model.dq_border_ref_pix_right = output_model.pixeldq[:, -4:].copy()
+            output_model.dq_border_ref_pix_left = output_model.pixeldq[:, :4].copy()
+            output_model.dq_border_ref_pix_top = output_model.pixeldq[:4, :].copy()
+            output_model.dq_border_ref_pix_bottom = output_model.pixeldq[-4:, :].copy()
 
         else:
             # Skip DQ step if no mask files


### PR DESCRIPTION
`dqinit` adds data views to the resulting datamodel which when saved triggers asdf to save the base array resulting in large file sizes. Similar to https://github.com/spacetelescope/romancal/pull/1098 this PR adds copies of those arrays to the output datamodel to avoid larger-than-needed file sizes.

Without this PR running the `elp` benchmarks (each step in `elp) with a [330Mb input file](https://bytesalad.stsci.edu/ui/repos/tree/General/benchmark-data/roman/exposure_pipeline/r0000101001001001001_01101_0001_WFI01_uncal.asdf) produces files with sizes as follows:
| step | output file size |
| ---- | ---------------|
| dqinit | 1.5 G |
| saturation | 1.5 G |
| refpix | 2.2 G |
| linearity | 2.2 G |
| darkcurrent | 2.2 G |
| rampfit | 332 M |
| assignwcs | 332 M |
| flatfield | 395 M |
| photom | 395 M |
| sourcedetection | 395 M |

Note the jump to 2.2 G for the `refpix` output.

With this PR the file sizes are:
| step | output file size |
| ---- | ---------------|
| dqinit | 1.5 G |
| saturation | 1.5 G |
| refpix | 1.5 G |
| linearity | 1.5 G |
| darkcurrent | 1.5 G |
| rampfit | 332 M |
| assignwcs | 332 M |
| flatfield | 395 M |
| photom | 395 M |
| sourcedetection | 395 M |

Note that the jump in file size is not seen until later in the pipeline because the base array saved for the views in dqinit is shared until later when the base array is replaced.

Regtests run with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/623/

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
