### PR TITLE
Fix some dangling references to basic.filename and basic.telescope.

### DIFF
--- a/romancal/outlier_detection/outlier_detection.py
+++ b/romancal/outlier_detection/outlier_detection.py
@@ -107,9 +107,7 @@ class OutlierDetection:
             self.create_median(drizzled_models), unit=median_model.data.unit
         )
         median_model_output_path = self.make_output_path(
-            basepath=median_model.meta.filename.replace(
-                self.resample_suffix, ".asdf"
-            ),
+            basepath=median_model.meta.filename.replace(self.resample_suffix, ".asdf"),
             suffix="median",
         )
         median_model.save(median_model_output_path)

--- a/romancal/outlier_detection/outlier_detection.py
+++ b/romancal/outlier_detection/outlier_detection.py
@@ -107,7 +107,7 @@ class OutlierDetection:
             self.create_median(drizzled_models), unit=median_model.data.unit
         )
         median_model_output_path = self.make_output_path(
-            basepath=median_model.meta.basic.filename.replace(
+            basepath=median_model.meta.filename.replace(
                 self.resample_suffix, ".asdf"
             ),
             suffix="median",

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -194,7 +194,7 @@ class ResampleData:
             output_root = "_".join(
                 exposure[0].meta.filename.replace(output_type, "").split("_")[:-1]
             )
-            output_model.meta.basic.filename = f"{output_root}_outlier_i2d{output_type}"
+            output_model.meta.filename = f"{output_root}_outlier_i2d{output_type}"
 
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(
@@ -242,7 +242,7 @@ class ResampleData:
             output_model.context = output_model.context.astype("uint32")
             if not self.in_memory:
                 # Write out model to disk, then return filename
-                output_name = output_model.meta.basic.filename
+                output_name = output_model.meta.filename
                 output_model.save(output_name)
                 log.info(f"Exposure {output_name} saved to file")
                 output_list.append(output_name)
@@ -260,7 +260,7 @@ class ResampleData:
         Used for level 3 resampling
         """
         output_model = self.blank_output.copy()
-        output_model.meta.basic.filename = self.output_filename
+        output_model.meta.filename = self.output_filename
         output_model.meta["resample"] = maker_utils.mk_resample()
         output_model.meta.resample["members"] = []
         output_model.meta.resample.weight_type = self.weight_type
@@ -703,7 +703,7 @@ def l2_into_l3_meta(l3_meta, l2_meta):
     l3_meta.basic.survey = l2_meta.observation.survey
     l3_meta.basic.optical_element = l2_meta.instrument.optical_element
     l3_meta.basic.instrument = l2_meta.instrument.name
-    l3_meta.basic.telescope = l2_meta.telescope
+    l3_meta.telescope = l2_meta.telescope
     l3_meta.coordinates = l2_meta.coordinates
     l3_meta.program = l2_meta.program
 

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -451,7 +451,7 @@ def test_resampledata_do_drizzle_many_to_one_single_input_model(wfi_sca1):
 
     # Assert
     assert len(output_models) == 1
-    assert output_models[0].meta.basic.filename == resample_data.output_filename
+    assert output_models[0].meta.filename == resample_data.output_filename
     np.testing.assert_allclose(flat_1, flat_2)
 
 


### PR DESCRIPTION
The change in the L3 files to move some keywords from meta.basic.X to meta.X left some bits of the L3 pipeline in a broken state.  This is intended to resolve those.

**Checklist**
- [X] updated relevant tests
- [X] added relevant label(s)