### PR TITLE
fix regtest teardown for fixture updates

### DIFF
--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -92,11 +92,11 @@ def generate_artifactory_json(request, artifactory_repos):
     rtdata = postmortem(request, "rtdata") or postmortem(request, "rtdata_module")
     if rtdata:
         try:
-            # The _jail fixture from ci_watson sets tmp_path
+            # The function_jail fixture uses tmp_path
             cwd = str(request.node.funcargs["tmp_path"])
         except KeyError:
-            # The jail fixture (module-scoped) returns the path
-            cwd = str(request.node.funcargs["jail"])
+            # The module_jail fixture (module-scoped) returns the path
+            cwd = str(request.node.funcargs["module_jail"])
         rtdata.remote_results_path = artifactory_result_path()
         rtdata.test_name = request.node.name
         # Dump the failed test traceback into rtdata


### PR DESCRIPTION
https://github.com/spacetelescope/romancal/pull/1117 missed that the `_jail` and `jail` fixtures were indirectly used in the regtest teardown postmortem. The impact can be seen in a recent regtest run of romancal main (that includes unrelated failures):
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/644/
where `test_rampfit_step[spec_full]` fails and then fails to generate a postmortem with the error:
```
ailed on teardown with "KeyError: 'jail'"
```
This PR fixes the indirect usage.

Regtests with this PR show the unrelated failures:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/646/tests
with the `test_rampfit_step[spec_full]` failure now showing the more helpful:
```
asdf._jsonschema.exceptions.ValidationError: 'electron / s' is not one of ['DN / s', 'MJy.sr**-1']
```

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
