### PR TITLE
RCAL-725: fix outlier detection step issues.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ outlier_detection
 
 - Allow `ModelContainer` as input. [#1092]
 - Update location of ``basic`` attributes. [#1131]
+- Set ``single=False`` in the call to resample to properly create a median image. [#1146]
 
 ramp_fitting
 ------------

--- a/romancal/outlier_detection/outlier_detection.py
+++ b/romancal/outlier_detection/outlier_detection.py
@@ -84,7 +84,7 @@ class OutlierDetection:
             # Start by creating resampled/mosaic images for
             # each group of exposures
             resamp = resample.ResampleData(
-                self.input_models, single=True, blendheaders=False, **pars
+                self.input_models, single=False, blendheaders=False, **pars
             )
             drizzled_models = resamp.do_drizzle()
 

--- a/romancal/outlier_detection/outlier_detection.py
+++ b/romancal/outlier_detection/outlier_detection.py
@@ -90,14 +90,13 @@ class OutlierDetection:
 
         else:
             # for non-dithered data, the resampled image is just the original image
-            drizzled_models = ModelContainer()
-            for i, model in enumerate(self.input_models):
-                model["weight"] = build_driz_weight(
-                    self.input_models[i],
+            drizzled_models = self.input_models
+            for model in drizzled_models:
+                model.weight = build_driz_weight(
+                    model,
                     weight_type="ivm",
                     good_bits=pars["good_bits"],
                 )
-                drizzled_models.append(model)
 
         # Initialize intermediate products used in the outlier detection
         median_model = (
@@ -235,8 +234,6 @@ class OutlierDetection:
 
         log.info("Blotting median")
         for model in self.input_models:
-            # TODO: fix dtype conflict
-            model.dq = model.dq.astype("uint32")
             blotted_median = model.copy()
 
             # clean out extra data not related to blot result

--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -295,7 +295,7 @@ def test_outlier_do_detection_find_outliers(tmp_path, base_image, clean_up_after
     clean_up_after_test("*.asdf")
 
 
-def test_outlier_do_detection_find_outliers_identical_images(
+def test_outlier_do_detection_do_not_find_outliers_in_identical_images(
     tmp_path, base_image, clean_up_after_test, caplog
 ):
     """


### PR DESCRIPTION
Resolves [RCAL-725](https://jira.stsci.edu/browse/RCAL-725)

This PR fixes a bug with the outlier detection step in which the algorithm was still detecting outliers even if the input models were identical. Additionally, the median image was not being properly created, which was being caused by wrongly setting the `single` parameter in the call to resample.

A unit test for identical input datamodels was added.

**Regression tests**
No errors/failures were reported:
- https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/655/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
