### PR TITLE
RCAL-620: allow ModelContainer to work with context manager.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ tweakreg
 general
 -------
 
+- Allow ``ModelContainer`` to work properly with context manager. [#1147]
+
 - Update the ``dqflags`` to use the ones stored in
   ``roman_datamodels`` [#1099]
 - Add script for creating regtest files; consolidate files used for

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -93,6 +93,7 @@ class ModelContainer(Sequence):
         asn_file = "/path/to/asn_file.json"
         container = ModelContainer(asn_file)
 
+
     In any of the cases above, the content of each file in a `ModelContainer` can
     be accessed by iterating over its elements. For example, to print out the filename
     of each file, we can run:
@@ -101,6 +102,14 @@ class ModelContainer(Sequence):
 
         for model in container:
             print(model.meta.filename)
+
+
+    Additionally, `ModelContainer` can be used with context manager:
+
+    .. code-block:: python
+
+        with ModelContainer(asn_file) as asn:
+            # do stuff
 
 
     Notes
@@ -225,6 +234,14 @@ class ModelContainer(Sequence):
             if not isinstance(model, rdm.DataModel) and self._return_open:
                 model = rdm.open(model, memmap=self._memmap)
             yield model
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            print(f"\nAn exception occurred in ModelContainer: {exc_val}")
+            print(f"\nTraceback:\n{exc_tb}")
 
     def insert(self, index, model):
         if isinstance(model, rdm.DataModel):

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -239,9 +239,8 @@ class ModelContainer(Sequence):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is not None:
-            print(f"\nAn exception occurred in ModelContainer: {exc_val}")
-            print(f"\nTraceback:\n{exc_tb}")
+        # exceptions will be propagated out of the context
+        return False
 
     def insert(self, index, model):
         if isinstance(model, rdm.DataModel):

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -239,6 +239,10 @@ class ModelContainer(Sequence):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        # clean up
+        for model in self._models:
+            if isinstance(model, rdm.DataModel):
+                model.close()
         # exceptions will be propagated out of the context
         return False
 

--- a/romancal/datamodels/tests/test_datamodels.py
+++ b/romancal/datamodels/tests/test_datamodels.py
@@ -10,6 +10,12 @@ from roman_datamodels import maker_utils as utils
 from romancal.datamodels.container import ModelContainer, make_file_with_index
 
 
+@pytest.fixture
+def mock_print(mocker):
+    # Mocking the print function to capture outputs for assertions
+    return mocker.patch("builtins.print")
+
+
 @pytest.fixture()
 def test_data_dir():
     return Path.joinpath(Path(__file__).parent, "data")
@@ -504,3 +510,81 @@ def test_make_file_with_index(filename, idx, expected_filename_result, tmp_path)
     result = make_file_with_index(file_path=filepath, idx=idx)
 
     assert result == str(tmp_path / expected_filename_result)
+
+
+def test_modelcontainer_works_properly_with_context_manager(tmp_path):
+    """Test that ModelContainer works correctly with context manager."""
+
+    filename1 = tmp_path / "img_1.asdf"
+    filename2 = tmp_path / "img_2.asdf"
+    # create ImageModel
+    img1 = utils.mk_level2_image()
+    img2 = utils.mk_level2_image()
+    img1.meta.filename = filename1
+    img2.meta.filename = filename2
+    # create datamodels from ImageModel
+    dm1 = rdm.ImageModel(img1)
+    dm2 = rdm.ImageModel(img2)
+    # save datamodels
+    dm1.save(filename1)
+    dm2.save(filename2)
+
+    # create ASN file that points to the ASDF files
+    asn_filepath = create_asn_file(tmp_path)
+
+    result_filenames = []
+
+    with ModelContainer(asn_filepath) as asn1:
+        result_filenames.extend(
+            tmp_path / datamodel.meta.filename for datamodel in asn1
+        )
+
+    expected_filenames = [filename1, filename2]
+    expected_filenames.sort()
+    result_filenames.sort()
+
+    assert all(e == r for e, r in zip(expected_filenames, result_filenames))
+    assert type(asn1) is ModelContainer
+
+
+# Parametrized test for various realistic, edge, and error cases
+@pytest.mark.parametrize(
+    "exc_type, exc_val, exc_tb, expected_output",
+    [
+        # Happy path tests with various realistic test values
+        (
+            ValueError,
+            "Value error occurred",
+            "Traceback (most recent call last): ...",
+            "Value error occurred",
+        ),
+        (
+            TypeError,
+            "Type error occurred",
+            "Traceback (most recent call last): ...",
+            "Type error occurred",
+        ),
+        # Edge case: NoneType exception, which should not trigger the custom message
+        (None, None, None, None),
+        # Error case: Custom exception
+        (
+            Exception,
+            "Custom exception occurred",
+            "Traceback (most recent call last): ...",
+            "Custom exception occurred",
+        ),
+    ],
+    ids=["value_error", "type_error", "none_type_exception", "custom_exception"],
+)
+def test_modelcontainer_exit(mock_print, exc_type, exc_val, exc_tb, expected_output):
+    container = ModelContainer()
+
+    container.__exit__(exc_type, exc_val, exc_tb)
+
+    if exc_type is not None:
+        mock_print.assert_any_call(
+            f"\nAn exception occurred in ModelContainer: {exc_val}"
+        )
+        mock_print.assert_any_call(f"\nTraceback:\n{exc_tb}")
+    else:
+        mock_print.assert_not_called()


### PR DESCRIPTION
Resolves [RCAL-620](https://jira.stsci.edu/browse/RCAL-620)

This PR implements two magic methods (`.__enter__()` and `.__exit__()`) that allows `ModelContainer` to work properly with a context manager.

Two unit tests have been added to test the new implementation.

**Regression test**
No errors/failures reported:
~https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/661/~
~https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/683/~
~https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/690/~
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/691/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [X] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
