### PR TITLE
fix n_diffs in compare_asdf

### DIFF
--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -583,12 +583,14 @@ class NDArrayTypeOperator(BaseOperator):
                 }
                 difference["abs_diff"] = np.nansum(np.abs(a - b))
                 difference["n_diffs"] = np.count_nonzero(
-                    np.isclose(
-                        a,
-                        b,
-                        rtol=self.rtol,
-                        atol=self.atol,
-                        equal_nan=self.equal_nan,
+                    np.logical_not(
+                        np.isclose(
+                            a,
+                            b,
+                            rtol=self.rtol,
+                            atol=self.atol,
+                            equal_nan=self.equal_nan,
+                        )
                     )
                 )
         return difference

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -105,3 +105,19 @@ def test_model_difference(tmp_path):
         """'type_changes': {"root['roman']": {'new_type': <class 'roman_datamodels.stnode.DistortionRef'>"""
         in diff.report()
     )
+
+
+@pytest.mark.parametrize("n_diffs", [1, 3, 7])
+def test_n_diffs(tmp_path, n_diffs):
+    fn0 = tmp_path / "test0.asdf"
+    fn1 = tmp_path / "test1.asdf"
+    v0 = np.zeros(10, dtype="int32")
+    v1 = np.zeros(10, dtype="int32")
+    v1[:n_diffs] = 1
+    asdf.AsdfFile({"v": v0}).write_to(fn0)
+    asdf.AsdfFile({"v": v1}).write_to(fn1)
+    diff = compare_asdf(fn0, fn1)
+    assert not diff.identical, diff.report()
+    assert "arrays_differ" in diff.diff
+    assert "root['v']" in diff.diff["arrays_differ"]
+    assert n_diffs == diff.diff["arrays_differ"]["root['v']"]["n_diffs"]


### PR DESCRIPTION
While looking into unrelated regtest failures I noticed the `n_diffs` calculation in `compare_asdf` counts the number of matching not differing values. This PR adds a test for the calculation and fixes the issue.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
