### PR TITLE
`xfail` tests that are failing due to pixel differences

### DIFF
--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -170,6 +170,7 @@ def passfail(bool_expr):
 # Tests
 # #####
 @pytest.mark.bigdata
+@pytest.mark.xfail
 def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths):
     """Test rampfit result against various conditions"""
     requirement, model, expected_path, conditions = rampfit_result

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -170,6 +170,7 @@ def passfail(bool_expr):
 # Tests
 # #####
 @pytest.mark.bigdata
+# TODO when this test starts passing, remove this xfail
 @pytest.mark.xfail
 def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths):
     """Test rampfit result against various conditions"""

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -273,6 +273,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
+@pytest.mark.xfail
 @metrics_logger("DMS278", "DMS90", "DMS91", "DMS9", "DMS365")
 def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
     """Tests for flat field grism processing requirements DMS90, DMS91 and DMS 278"""

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -273,6 +273,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
+# TODO when this test starts passing, remove this xfail
 @pytest.mark.xfail
 @metrics_logger("DMS278", "DMS90", "DMS91", "DMS9", "DMS365")
 def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue encountered when regression testing via GitHub Actions; namely, comparison to truth files are one pixel off:
- `test_ramp_fitting.py` https://github.com/spacetelescope/RegressionTests/actions/runs/8331501808/job/22798584836#step:14:209
- `test_wfi_pipeline.py` https://github.com/spacetelescope/RegressionTests/actions/runs/8331504801/job/22798593883#step:14:224

**Checklist**
- [ ] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
