### PR TITLE
allow DQInitStep to pass through non-rampmodel keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ dq_init
 - Copy reference pixels during ``dq_init`` to avoid larger files in later
   processing steps [#1121]
 
+- Allow ``dq_init`` to pass through keys not defined in ``RampModel``
+  schema [#1151]
+
 resample
 --------
 

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -54,9 +54,11 @@ class DQInitStep(RomanStep):
                 # check for resultantdq if present copy this to the emp
                 # it to the ramp model, we don't want to carry this around
                 if key != "resultantdq":
-                    # If a dictionary (like meta), overwrite entires (but keep
-                    # required dummy entries that may not be in input_model)
-                    if isinstance(input_ramp[key], dict):
+                    if key not in input_ramp:
+                        input_ramp[key] = input_model.__getattr__(key)
+                    elif isinstance(input_ramp[key], dict):
+                        # If a dictionary (like meta), overwrite entires (but keep
+                        # required dummy entries that may not be in input_model)
                         input_ramp[key].update(input_model.__getattr__(key))
                     elif isinstance(input_ramp[key], np.ndarray):
                         # Cast input ndarray as RampModel dtype

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -187,6 +187,10 @@ def test_dqinit_step_interface(instrument, exptype):
     # Set test size
     shape = (2, 20, 20)
 
+    # include an extra item not defined in the schema
+    extra_key = "foo_extra"
+    extra_value = [1, 2, 3]
+
     # Create test science raw model
     wfi_sci_raw = maker_utils.mk_level1_science_raw(shape=shape)
     wfi_sci_raw.meta.instrument.name = instrument
@@ -198,6 +202,7 @@ def test_dqinit_step_interface(instrument, exptype):
     wfi_sci_raw.data = u.Quantity(
         np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
     )
+    wfi_sci_raw[extra_key] = extra_value
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Create mask model
@@ -222,6 +227,8 @@ def test_dqinit_step_interface(instrument, exptype):
     assert result.err.dtype == np.float32
     assert result.pixeldq.dtype == np.uint32
     assert result.groupdq.dtype == np.uint8
+    # check that extra value came through
+    assert result[extra_key] == extra_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1150

During transfer of attributes from the input model during `DQInitStep`, the presence of attribute not defined in `RampModel` will lead to an error (see above issue).

This PR checks if the attribute exists in `RampModel` and if not creates it.

Regtests running at: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/682/

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
