### PR TITLE
RCAL-800: Set flux step status for each input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ dq_init
 - Allow ``dq_init`` to pass through keys not defined in ``RampModel``
   schema [#1151]
 
+flux
+----
+
+- Set flux step status for each input. [#1160]
+
 resample
 --------
 

--- a/romancal/flux/flux_step.py
+++ b/romancal/flux/flux_step.py
@@ -72,9 +72,9 @@ class FluxStep(RomanStep):
         for model in input_models:
             try:
                 apply_flux_correction(model)
-                model.meta.cal_step.flux = 'COMPLETE'
+                model.meta.cal_step.flux = "COMPLETE"
             except ValueError:
-                model.meta.cal_step.flux = 'SKIPPED'
+                model.meta.cal_step.flux = "SKIPPED"
 
         if single_model:
             return input_models[0]
@@ -105,7 +105,7 @@ def apply_flux_correction(model):
     # Check for units. Must be election/second. Otherwise, it is unknown how to
     # convert.
     if model.data.unit != LV2_UNITS:
-        message = f'Input data units {model.data.unit} is not the expected units of %s. Flux correction will not be done.'
+        message = f"Input data units {model.data.unit} is not the expected units of %s. Flux correction will not be done."
         log.debug(message)
         raise ValueError(message)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-800](https://jira.stsci.edu/browse/RCAL-800)

Related PRs:
- [roman_datamodel#332](https://github.com/spacetelescope/roman_datamodels/pull/332)
- [rad#395](https://github.com/spacetelescope/rad/pull/395)

<!-- describe the changes comprising this PR here -->
This PR sets the step completion status for each input model to FluxStep.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
