### PR TITLE
RCAL-786: update default DQ flags in romancal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ general
 
 - Update the high level pipeline to use updates in Outlier_detection and tweakreg [#1143]
 
+- Update the default DQ flags to '``~DO_NOT_USE+NON_SCIENCE+DEAD``' in
+  ``resample_step``, ``outlier_detection_step``, and ``skymatch_step``. [#1170]
+
 documentation
 -------------
 

--- a/docs/roman/outlier_detection/arguments.rst
+++ b/docs/roman/outlier_detection/arguments.rst
@@ -104,10 +104,11 @@ behavior of the processing:
   Specifies whether or not to resample the input images when performing outlier
   detection.
 
-``--good_bits`` (string, default=0)
+``--good_bits`` (string, default='~DO_NOT_USE+NON_SCIENCE+DEAD')
   The DQ bit values from the input image DQ arrays that should be considered 'good'
   when creating masks of bad pixels during outlier detection when resampling the data.
-  See `Roman's Data Quality Flags
+  The default value is to exclude pixels flagged with ``DO_NOT_USE``, ``NON_SCIENCE``,
+  and ``DEAD``. See `Roman's Data Quality Flags
   <https://github.com/spacetelescope/romancal/blob/main/romancal/lib/dqflags.py>`_
   for details.
 

--- a/docs/roman/resample/arguments.rst
+++ b/docs/roman/resample/arguments.rst
@@ -103,13 +103,13 @@ image.
 ``--in_memory`` (bool, default=True)
     If set to `False`, write output datamodel to disk.
 
-``--good_bits`` (str, default='~DO_NOT_USE+NON_SCIENCE')
+``--good_bits`` (str, default='~DO_NOT_USE+NON_SCIENCE+DEAD')
     Specifies the bits to use when creating the resampling mask.
     Either a single bit value or a combination of them can be provided.
     If the string starts with a tilde (`~`), then the provided bit(s)
     will be excluded when creating the resampling mask.
-    The default value is to exclude pixels flagged with ``DO_NOT_USE``
-    and ``NON_SCIENCE``.
+    The default value is to exclude pixels flagged with ``DO_NOT_USE``,
+    ``NON_SCIENCE``, and ``DEAD``.
 
     The bit value can be provided in a few different ways, but always as
     a string type. For example, if the user deems OK to use pixels with

--- a/docs/roman/skymatch/arguments.rst
+++ b/docs/roman/skymatch/arguments.rst
@@ -37,12 +37,12 @@ The ``skymatch`` step uses the following optional arguments:
   computations. Supported values are: `mean`, `mode`, `midpt`,
   and `median`.
 
-``dqbits`` (str, default='~DO_NOT_USE+NON_SCIENCE')
+``dqbits`` (str, default='~DO_NOT_USE+NON_SCIENCE+DEAD')
   The DQ bit values from the input images' DQ arrays that
   should be considered "good" when building masks for sky computations. See
   DQ flag :ref:`dq_init_step` for details. The default value
-  rejects pixels flagged as either 'DO_NOT_USE' or 'NON_SCIENCE' and considers
-  all others to be good.
+  rejects pixels flagged as either 'DO_NOT_USE', 'NON_SCIENCE', or 'DEAD'
+  and considers all others to be good.
 
 ``lower`` (float, default=None)
   An optional value indicating the lower limit of usable pixel

--- a/romancal/outlier_detection/outlier_detection_step.py
+++ b/romancal/outlier_detection/outlier_detection_step.py
@@ -44,7 +44,7 @@ class OutlierDetectionStep(RomanStep):
         kernel_size = string(default='7 7') # Size of kernel to be used during resampling of the data
         save_intermediate_results = boolean(default=False) # Specifies whether or not to write out intermediate products to disk
         resample_data = boolean(default=True) # Specifies whether or not to resample the input images when performing outlier detection
-        good_bits = string(default="~DO_NOT_USE+NON_SCIENCE")  # DQ bit value to be considered 'good'
+        good_bits = string(default="~DO_NOT_USE+NON_SCIENCE+DEAD")  # DQ bit value to be considered 'good'
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image
         in_memory = boolean(default=False) # Specifies whether or not to keep all intermediate products and datamodels in memory
     """  # noqa: E501

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -61,7 +61,7 @@ class ResampleStep(RomanStep):
         blendheaders = boolean(default=True)
         allowed_memory = float(default=None)  # Fraction of memory to use for the combined image.
         in_memory = boolean(default=True)
-        good_bits = string(default='~DO_NOT_USE+NON_SCIENCE')  # The good bits to use for building the resampling mask.
+        good_bits = string(default='~DO_NOT_USE+NON_SCIENCE+DEAD')  # The good bits to use for building the resampling mask.
     """  # noqa: E501
 
     reference_file_types = []

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -39,7 +39,7 @@ class SkyMatchStep(RomanStep):
 
         # Sky statistics parameters:
         skystat = option('median', 'midpt', 'mean', 'mode', default='mode') # sky statistics
-        dqbits = string(default='~DO_NOT_USE+NON_SCIENCE') # "good" DQ bits
+        dqbits = string(default='~DO_NOT_USE+NON_SCIENCE+DEAD') # "good" DQ bits
         lower = float(default=None) # Lower limit of "good" pixel values
         upper = float(default=None) # Upper limit of "good" pixel values
         nclip = integer(min=0, default=5) # number of sky clipping iterations


### PR DESCRIPTION
Resolves [RCAL-786](https://jira.stsci.edu/browse/RCAL-786)

This PR updates the default DQ flags used in `resample_step`, `outlier_detection_step`, and `skymatch_step` to also include the `DEAD` flag. The default is now `DO_NOT_USE+NON_SCIENCE+DEAD`.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [X] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
