### PR TITLE
Update HLP regtest to use existing L1/L2 files

### DIFF
--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -23,9 +23,9 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     """Tests for level 3 processing requirements DMS356"""
 
     cal_files = [
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_cal.asdf",
+        "WFI/image/r0000101001001001001_01101_0002_WFI01_cal.asdf",
         "WFI/image/r0000101001001001001_01101_0003_WFI01_cal.asdf",
-        "WFI/image/r0000101001001001001_01101_0004_WFI01_cal.asdf",
-        "WFI/image/r0000101001001001001_01101_0005_WFI01_cal.asdf",
     ]
 
     for cal_file in cal_files:

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -157,3 +157,6 @@ strun roman_elp r0000101001001001001_01101_0004_WFI01_uncal.asdf
 strun roman_elp r0000201001001001001_01101_0004_WFI01_uncal.asdf
 cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
+
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_FI01_cal.asdf -o L3_regtest_asn.json --product-name r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5.
+strun --disable-crds-steppars roman_hlp L3_regtest_asn.json

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -46,6 +46,7 @@ do
     cp ${fn}_darkcurrent.asdf $outdir/roman-pipeline/dev/WFI/$dirname/
     cp ${fn}_rampfit.asdf $outdir/roman-pipeline/dev/truth/WFI/$dirname/
 done
+cp r0000101001001001001_01101_0003_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
 
 
 # second imaging exposure
@@ -158,5 +159,7 @@ strun roman_elp r0000201001001001001_01101_0004_WFI01_uncal.asdf
 cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
 
-asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_FI01_cal.asdf -o L3_regtest_asn.json --product-name r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5.
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5.
 strun --disable-crds-steppars roman_hlp L3_regtest_asn.json
+cp L3_regtest_asn.json $outdir/roman-pipeline/dev/WFI/image/
+cp r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/


### PR DESCRIPTION
This PR updates the HLP regtest to use existing L1/L2 files rather than add new ones.  This reduces the number of files we need to track.

It also adds the corresponding L3 image creation to the regtest file creation script.

**Checklist**
- [X] updated relevant tests
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below. https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/705/
