### PR TITLE
RCAL-795: fix incorrect weight maps returned by resampling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ resample
 
 - Updated Level 3 ``cal_step`` attribute creation. [#1165]
 
+- Fix bug that prevented properly update of the resampled output weight and context arrays. [#1181]
+
 outlier_detection
 -----------------
 

--- a/romancal/resample/gwcs_drizzle.py
+++ b/romancal/resample/gwcs_drizzle.py
@@ -84,7 +84,7 @@ class GWCSDrizzle:
 
         self.outsci = product.data
         self.outwcs = outwcs or product.meta.wcs
-        self.outwht = np.zeros(self.outsci.shape, dtype=np.float32)
+        self.outwht = product.weight
         self.outcon = np.zeros(self.outcon.shape, dtype=np.int32)
 
         if self.outcon.ndim == 2:

--- a/romancal/resample/gwcs_drizzle.py
+++ b/romancal/resample/gwcs_drizzle.py
@@ -85,7 +85,7 @@ class GWCSDrizzle:
         self.outsci = product.data
         self.outwcs = outwcs or product.meta.wcs
         self.outwht = product.weight
-        self.outcon = np.zeros(self.outcon.shape, dtype=np.int32)
+        self.outcon = product.context.astype(np.int32)
 
         if self.outcon.ndim == 2:
             self.outcon = np.reshape(

--- a/romancal/resample/tests/test_gwcs_drizzle.py
+++ b/romancal/resample/tests/test_gwcs_drizzle.py
@@ -1,0 +1,105 @@
+import pytest
+import numpy as np
+from ..gwcs_drizzle import GWCSDrizzle
+from unittest.mock import MagicMock
+
+
+@pytest.mark.parametrize(
+    "product, outwcs, wt_scl, pixfrac, kernel, fillval, expected_exception",
+    [
+        (
+            MagicMock(
+                data=np.array([[1, 2], [3, 4]]),
+                weight=np.array([[0.5, 0.5], [0.5, 0.5]]),
+                meta=MagicMock(
+                    wcs="WCS", resample=MagicMock(product_exposure_time=1.0)
+                ),
+                context=np.zeros((1, 2, 2), dtype=np.int32),
+            ),
+            None,
+            None,
+            1.0,
+            "square",
+            "INDEF",
+            None,
+        ),
+        (
+            MagicMock(
+                data=np.array([[1, 2], [3, 4]]),
+                weight=np.array([[1, 1], [1, 1]]),
+                meta=MagicMock(
+                    wcs="WCS", resample=MagicMock(product_exposure_time=2.0)
+                ),
+                context=np.zeros((1, 2, 2), dtype=np.int32),
+            ),
+            "CustomWCS",
+            "exptime",
+            0.5,
+            "gaussian",
+            "0",
+            None,
+        ),
+        (
+            MagicMock(
+                data=np.array([[0, 1], [2, 3]]),
+                weight=np.array([[1, 0], [0, 1]]),
+                meta=MagicMock(
+                    wcs="WCS", resample=MagicMock(product_exposure_time=0.5)
+                ),
+                context=np.zeros((1, 2, 2), dtype=np.int32),
+            ),
+            None,
+            "expsq",
+            0.8,
+            "lanczos3",
+            "NaN",
+            None,
+        ),
+    ],
+)
+def test_gwcs_drizzle_init_happy_path(
+    product, outwcs, wt_scl, pixfrac, kernel, fillval, expected_exception
+):
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            GWCSDrizzle(product, outwcs, wt_scl, pixfrac, kernel, fillval)
+    else:
+        drizzle = GWCSDrizzle(product, outwcs, wt_scl, pixfrac, kernel, fillval)
+
+    if not expected_exception:
+        assert drizzle.outwcs == (outwcs or product.meta.wcs)
+        assert drizzle.wt_scl == ("" if wt_scl is None else wt_scl)
+        assert drizzle.pixfrac == pixfrac
+        assert drizzle.kernel == kernel
+        assert drizzle.fillval == fillval
+
+
+@pytest.mark.parametrize(
+    "pixfrac, kernel, expected_pixfrac, expected_kernel",
+    [
+        (0, "square", 0, "square"),
+        (
+            2.0,
+            "nonexistent",
+            2.0,
+            "nonexistent",
+        ),  # Invalid kernel, but no validation in __init__
+    ],
+)
+def test_gwcs_drizzle_init_edge_cases(
+    pixfrac, kernel, expected_pixfrac, expected_kernel
+):
+    # Arrange
+    product = MagicMock(
+        data=np.array([[1, 2], [3, 4]]),
+        weight=np.array([[1, 1], [1, 1]]),
+        meta=MagicMock(wcs="WCS", resample=MagicMock(product_exposure_time=1.0)),
+        context=np.zeros((1, 2, 2), dtype=np.int32),
+    )
+
+    # Act
+    drizzle = GWCSDrizzle(product, pixfrac=pixfrac, kernel=kernel)
+
+    # Assert
+    assert drizzle.pixfrac == expected_pixfrac
+    assert drizzle.kernel == expected_kernel

--- a/romancal/resample/tests/test_gwcs_drizzle.py
+++ b/romancal/resample/tests/test_gwcs_drizzle.py
@@ -1,7 +1,9 @@
-import pytest
-import numpy as np
-from ..gwcs_drizzle import GWCSDrizzle
 from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from ..gwcs_drizzle import GWCSDrizzle
 
 
 @pytest.mark.parametrize(

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -603,3 +603,20 @@ def test_custom_wcs_input_entire_field_no_rotation(multiple_exposures):
 
     np.testing.assert_allclose(output_min_value, expected_min_value)
     np.testing.assert_allclose(output_max_value, expected_max_value)
+
+
+@pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
+def test_resampledata_do_drizzle_default_single_exposure_weight_array(
+    exposure_1,
+    weight_type,
+):
+    """Test that resample methods return non-empty weight arrays."""
+
+    input_models = ModelContainer(exposure_1)
+    resample_data = ResampleData(input_models, wht_type=weight_type)
+
+    output_models_many_to_one = resample_data.resample_many_to_one()
+    output_models_many_to_many = resample_data.resample_many_to_many()
+
+    assert np.any(output_models_many_to_one[0].weight > 0)
+    assert np.any(output_models_many_to_many[0].weight > 0)

--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -355,12 +355,11 @@ def test_set_good_bits_in_resample_meta(base_image, good_bits):
 
 @pytest.mark.parametrize("weight_type", ["ivm", "exptime", None])
 def test_build_driz_weight_different_weight_type(base_image, weight_type):
+    rng = np.random.default_rng()
     img1 = base_image()
     # update attributes that will be used in building the weight array
     img1.meta.exposure.exposure_time = 10
-    img1.var_rnoise = Quantity(
-        np.random.normal(1, 0.1, size=img1.shape), unit="DN2 / s2"
-    )
+    img1.var_rnoise = Quantity(rng.normal(1, 0.1, size=img1.shape), unit="DN2 / s2")
     # build the drizzle weight array
     result = resample_utils.build_driz_weight(
         img1, weight_type=weight_type, good_bits="~DO_NOT_USE+NON_SCIENCE"

--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -351,3 +351,26 @@ def test_set_good_bits_in_resample_meta(base_image, good_bits):
     res = step.call(img, good_bits=good_bits)
 
     assert res.meta.resample.good_bits == good_bits
+
+
+@pytest.mark.parametrize("weight_type", ["ivm", "exptime", None])
+def test_build_driz_weight_different_weight_type(base_image, weight_type):
+    img1 = base_image()
+    # update attributes that will be used in building the weight array
+    img1.meta.exposure.exposure_time = 10
+    img1.var_rnoise = Quantity(
+        np.random.normal(1, 0.1, size=img1.shape), unit="DN2 / s2"
+    )
+    # build the drizzle weight array
+    result = resample_utils.build_driz_weight(
+        img1, weight_type=weight_type, good_bits="~DO_NOT_USE+NON_SCIENCE"
+    )
+
+    expected_results = {
+        "ivm": img1.var_rnoise.value**-1,
+        "exptime": np.ones(img1.shape, dtype=img1.data.dtype)
+        * img1.meta.exposure.exposure_time,
+        None: np.ones(img1.shape, dtype=img1.data.dtype),
+    }
+
+    np.testing.assert_array_almost_equal(expected_results.get(weight_type), result)


### PR DESCRIPTION
Resolves [RCAL-795](https://jira.stsci.edu/browse/RCAL-795)

This PR fixes a bug in the resample step in which the output weight and context arrays were being reset to zero every time a new image was added to the drizzle object.

**Regression tests**
No issues due to the changes in this PR.
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/706/

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
