### PR TITLE
RCAL-816: add function to populate L3 mosaic meta.basic.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ resample
 
 - Fix bug that prevented properly update of the resampled output weight and context arrays. [#1181]
 
+- Update Level 3 output ``basic`` attribute. [#1188]
+
 outlier_detection
 -----------------
 

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 import numpy as np
 from astropy import units as u
@@ -7,7 +8,6 @@ from roman_datamodels import datamodels, maker_utils
 
 from ..datamodels import ModelContainer
 from . import gwcs_drizzle, resample_utils
-from typing import List
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -796,12 +796,6 @@ def populate_mosaic_basic(
     output_model.meta.basic.time_mean_mjd = np.mean(
         [x.exposure.mid_time.mjd for x in input_meta]
     )
-    output_model.meta.basic.max_exposure_time = np.max(
-        [x.exposure.exposure_time for x in input_meta]
-    )
-    output_model.meta.basic.mean_exposure_time = np.mean(
-        [x.exposure.exposure_time for x in input_meta]
-    )
 
     # observation data
     output_model.meta.basic.visit = (

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -7,11 +7,11 @@ from astropy.time import Time
 from gwcs import WCS
 from gwcs import coordinate_frames as cf
 from roman_datamodels import datamodels, maker_utils
+from roman_datamodels.maker_utils import mk_common_meta, mk_level2_image
 
 from romancal.datamodels import ModelContainer
 from romancal.resample import gwcs_drizzle, resample_utils
 from romancal.resample.resample import ResampleData, populate_mosaic_basic
-from roman_datamodels.maker_utils import mk_common_meta, mk_level2_image
 
 
 # Helper function to create a mock input model with specified metadata


### PR DESCRIPTION
Resolves [RCAL-816](https://jira.stsci.edu/browse/RCAL-816)

This PR adds a function to populate the L3 mosaic output from resample with basic info about times, observation setup, and others. A unit test was also implemented to test the new function.

**Regression tests**
~https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/711/~
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/712/

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
