### PR TITLE
update calibration_software_version when a step is run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,12 @@ flux
 
 - Set flux step status for each input. [#1160]
 
+stpipe
+------
+
+- Update ``meta.calibration_software_version`` for results of ``Step`` runs to
+  record the version of romancal used to produce the result. [#1194]
+
 resample
 --------
 

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -199,8 +199,9 @@ def ignore_asdf_paths():
         # and other things that will almost certainly change in every case
         "asdf_library",
         "history",
-        "roman.meta.ref_file.crds.sw_version",
         # roman-specific stuff to ignore
+        "roman.meta.ref_file.crds.sw_version",
+        "roman.meta.calibration_software_version",
         "roman.cal_logs",
         "roman.meta.date",
         # roman.meta.filename is used by the ExposurePipeline so should likely

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -2,6 +2,7 @@
 Roman Calibration Pipeline base class
 """
 
+import importlib.metadata
 import logging
 import time
 
@@ -50,6 +51,8 @@ class RomanStep(Step):
             List of reference files used.  The first element of each tuple
             is the reftype code, the second element is the filename.
         """
+
+        model.meta.calibration_software_version = importlib.metadata.version("romancal")
 
         if isinstance(model, ImageModel):
             for log_record in self.log_records:

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -5,6 +5,7 @@ from roman_datamodels.datamodels import FlatRefModel, ImageModel
 from roman_datamodels.maker_utils import mk_level2_image
 from stpipe import crds_client
 
+import romancal
 from romancal.stpipe import RomanPipeline, RomanStep
 
 
@@ -96,3 +97,18 @@ def test_crds_meta():
     assert result.meta.ref_file.crds.context_used == crds_client.get_context_used(
         result.crds_observatory
     )
+
+
+def test_calibration_software_version():
+    """Test that calibration_software_version is updated when a step is run"""
+
+    class NullStep(RomanStep):
+        def process(self, input):
+            return input
+
+    im = ImageModel(mk_level2_image(shape=(20, 20)))
+    im.meta.calibration_software_version = "junkversion"
+
+    result = NullStep.call(im)
+
+    assert result.meta.calibration_software_version == romancal.__version__


### PR DESCRIPTION
This PR updates `meta.calibration_software_version` in models returned from step runs. This is set to the current romancal version (instead of using the default [9.9.0](https://github.com/spacetelescope/roman_datamodels/blob/bb788f4c39d8d62e78f62b239d0d769c16dbcf85/src/roman_datamodels/maker_utils/_basic_meta.py#L16) which appears in many if not all files).

`meta.calibration_software_version` is also added to the "ignores" used for compare_asdf for regression tests.

Regression tests show 2 unrelated failures (which are also occurring on main):
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/713/tests
The unrelated failure is helpful here as the failing test produced [mosaic_resamplestep.asdf](https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/2024-04-24_jenkins-RT-Roman-Developers-Pull-Requests-713_0/test_resample_single_file/mosaic_resamplestep.asdf) with the following:
```yaml
    calibration_software_version: !<asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0> 0.10.1.dev629+gc868a5b
```
compared to the failing file [on main](https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/2024-04-24_jenkins-RT-romancal-1304_0/test_resample_single_file/mosaic_resamplestep.asdf) which contains the default `9.9.0` value and does not contain the actual romancal version:
```yaml
    calibration_software_version: !<asdf://stsci.edu/datamodels/roman/tags/calibration_software_version-1.0.0> 9.9.0
```

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
