### PR TITLE
rcal-818 Add preview images tp hlp regtest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ tweakreg
 general
 -------
 
-- Add preview files to HLP tests [#]
+- Add preview files to HLP tests [#1199]
 
 - Allow ``ModelContainer`` to work properly with context manager. [#1147]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ tweakreg
 general
 -------
 
+- Add preview files to HLP tests [#]
+
 - Allow ``ModelContainer`` to work properly with context manager. [#1147]
 
 - Update the ``dqflags`` to use the ones stored in

--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -1,7 +1,8 @@
 """ Roman tests for the High Level Pipeline """
 
-import pytest
 import os
+
+import pytest
 import roman_datamodels as rdm
 from metrics_logger.decorators import metrics_logger
 
@@ -51,15 +52,19 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
 
     # Generate thumbnail image
     input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
-    thumbnail_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_thumb.png"
+    thumbnail_file = (
+        "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_thumb.png"
+    )
     preview_cmd = f"stpreview to {input_file} {thumbnail_file} 256 256 roman"
-    os.system(preview_cmd) #nosec
+    os.system(preview_cmd)  # nosec
 
     # Generate preview image
     input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
-    preview_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_preview.png"
+    preview_file = (
+        "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_preview.png"
+    )
     preview_cmd = f"stpreview to {input_file} {preview_file} 1080 1080 roman"
-    os.system(preview_cmd) #nosec
+    os.system(preview_cmd)  # nosec
 
     # Perform DMS tests
     # Initial prep

--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -1,6 +1,7 @@
 """ Roman tests for the High Level Pipeline """
 
 import pytest
+import os
 import roman_datamodels as rdm
 from metrics_logger.decorators import metrics_logger
 
@@ -48,6 +49,18 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
+    # Generate thumbnail image
+    input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    thumbnail_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_thumb.png"
+    preview_cmd = f"stpreview to {input_file} {thumbnail_file} 256 256 roman"
+    os.system(preview_cmd)
+
+    # Generate preview image
+    input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    preview_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_preview.png"
+    preview_cmd = f"stpreview to {input_file} {preview_file} 1080 1080 roman"
+    os.system(preview_cmd)
+
     # Perform DMS tests
     # Initial prep
     model = rdm.open(rtdata.output, lazy_load=False)
@@ -63,6 +76,16 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     pipeline.log.info(
         "Status of the step:             skymatch    "
         + str(model.meta.cal_step.skymatch)
+    )
+    # DMS356 Test that the thumbnail image exists
+    pipeline.log.info(
+        "Status of the step:             thumbnail image    "
+        + passfail(os.path.isfile(thumbnail_file) == True)
+    )
+    # DMS356 Test that the preview image exists
+    pipeline.log.info(
+        "Status of the step:             preview image    "
+        + passfail(os.path.isfile(preview_file) == True)
     )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of skymatch in the Level 3  output......."

--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -53,13 +53,13 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
     thumbnail_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_thumb.png"
     preview_cmd = f"stpreview to {input_file} {thumbnail_file} 256 256 roman"
-    os.system(preview_cmd)
+    os.system(preview_cmd) #nosec
 
     # Generate preview image
     input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
     preview_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_preview.png"
     preview_cmd = f"stpreview to {input_file} {preview_file} 1080 1080 roman"
-    os.system(preview_cmd)
+    os.system(preview_cmd) #nosec
 
     # Perform DMS tests
     # Initial prep
@@ -80,12 +80,12 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     # DMS356 Test that the thumbnail image exists
     pipeline.log.info(
         "Status of the step:             thumbnail image    "
-        + passfail(os.path.isfile(thumbnail_file) == True)
+        + passfail(os.path.isfile(thumbnail_file is True))
     )
     # DMS356 Test that the preview image exists
     pipeline.log.info(
         "Status of the step:             preview image    "
-        + passfail(os.path.isfile(preview_file) == True)
+        + passfail(os.path.isfile(preview_file is True))
     )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of skymatch in the Level 3  output......."


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-818](https://jira.stsci.edu/browse/RCAL-818)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds a check for the creation of preview images to the hlp regtest. Here is the log entries for that portion,
```
2024-04-26 08:29:29,672 - stpipe.HighLevelPipeline - INFO - Status of the step:             thumbnail image    Pass
INFO     stpipe.HighLevelPipeline:log_config.py:142 Status of the step:             thumbnail image    Pass
2024-04-26 08:29:29,673 - stpipe.HighLevelPipeline - INFO - Status of the step:             preview image    Pass
INFO     stpipe.HighLevelPipeline:log_config.py:142 Status of the step:             preview image    Pass
```


**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/718/
This only shows the two errors in the resample step that is being worked on. The log for the preview tests are passing and are shown above. 