### PR TITLE
Fix unit typo in docs

### DIFF
--- a/docs/roman/flux/main.rst
+++ b/docs/roman/flux/main.rst
@@ -23,7 +23,7 @@ The output product are ImageModels, but with the flux scale applied to all the d
 
 Flux Application
 ----------------
-If the input data is in :math:`electrons / second`, the flux scale factor, as
+If the input data is in :math:`DN / second`, the flux scale factor, as
 found in the meta ``meta.photometry.conversion_megajanskys``, is simply
 multiplied to the ``data`` and ``err`` arrays. The square of the scale factor is
 multiplied to all the variance arrays. The resultant units is in :math:`MJy/sr`.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
The `flux` step appears to assume the input units are DN/s, not e/s.


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
