### PR TITLE
make rotation matrix 2d for schema validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ resample
 
 - Populate the Level 3 wcsinfo [#1182]
 
+- Make rotation matrix 2d for schema validation [#1205]
+
 outlier_detection
 -----------------
 

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -458,4 +458,4 @@ def list_1d_to_2d(l, n):
     l2d : list of lists
         The 2D form
     """
-    return [l[i:i+n] for i in range(0, len(l), n)]
+    return [l[i : i + n] for i in range(0, len(l), n)]

--- a/romancal/assign_wcs/utils.py
+++ b/romancal/assign_wcs/utils.py
@@ -440,3 +440,22 @@ def update_s_region_keyword(model, footprint):
     else:
         model.meta.wcsinfo.s_region = s_region
         log.info(f"Update S_REGION to {model.meta.wcsinfo.s_region}")
+
+
+def list_1d_to_2d(l, n):
+    """Convert 1-dimensional list to 2-dimensional
+
+    Parameters
+    ----------
+    l : list
+        The list to convert.
+
+    n : int
+       The length of the x dimension, or the length of the inner lists.
+
+    Returns
+    -------
+    l2d : list of lists
+        The 2D form
+    """
+    return [l[i:i+n] for i in range(0, len(l), n)]

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -789,9 +789,7 @@ def gwcs_into_l3(model, wcs):
         log.warning(
             "WCS has no clear rotation matrix defined by pc_rotation_matrix. Calculating one."
         )
-        rotation_matrix = utils.calc_rotation_matrix(
-            l3_wcsinfo.orientat, 0.0
-        )
+        rotation_matrix = utils.calc_rotation_matrix(l3_wcsinfo.orientat, 0.0)
         l3_wcsinfo.rotation_matrix = utils.list_1d_to_2d(rotation_matrix, 2)
 
 

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -789,9 +789,10 @@ def gwcs_into_l3(model, wcs):
         log.warning(
             "WCS has no clear rotation matrix defined by pc_rotation_matrix. Calculating one."
         )
-        l3_wcsinfo.rotation_matrix = utils.calc_rotation_matrix(
+        rotation_matrix = utils.calc_rotation_matrix(
             l3_wcsinfo.orientat, 0.0
         )
+        l3_wcsinfo.rotation_matrix = utils.list_1d_to_2d(rotation_matrix, 2)
 
 
 def calc_pa(wcs, ra, dec):


### PR DESCRIPTION
This PR addresses an issue found during HLP development. If a rotation matrix needs to be calculated, in order to populate the wcsinfo block, the resultant form was not compatible with the schema. This PR fixes that formatting.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
