### PR TITLE
Make sure logs get included in L3 products.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ stpipe
 - Update ``stpipe.core.finalize_results`` to record the CRDS information
   only if a step uses reference files. [#1201]
 
+- Populate logs for L3 files in addition to L2 files [#1207]
+
 resample
 --------
 
@@ -72,6 +74,8 @@ resample
 - Populate the Level 3 wcsinfo [#1182]
 
 - Make rotation matrix 2d for schema validation [#1205]
+
+- Include logs of individual L2 products [#1207]
 
 outlier_detection
 -----------------

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -204,6 +204,7 @@ def ignore_asdf_paths():
         "roman.meta.calibration_software_version",
         "roman.cal_logs",
         "roman.meta.date",
+        "roman.individual_image_cal_logs",
         # roman.meta.filename is used by the ExposurePipeline so should likely
         # not be ignored here
         # "roman.meta.filename",

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -178,8 +178,9 @@ class ResampleData:
         self.blank_output.meta.wcs = self.output_wcs
         gwcs_into_l3(self.blank_output, self.output_wcs)
         self.blank_output.cal_logs = stnode.CalLogs()
-        self.blank_output['individual_image_cal_logs'] = (
-            [model.cal_logs for model in input_models])
+        self.blank_output["individual_image_cal_logs"] = [
+            model.cal_logs for model in input_models
+        ]
 
         self.output_models = ModelContainer()
 

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from drizzle import cdrizzle, util
-from roman_datamodels import datamodels, maker_utils
+from roman_datamodels import datamodels, maker_utils, stnode
 from stcal.alignment.util import compute_scale
 
 from ..assign_wcs import utils
@@ -177,6 +177,9 @@ class ResampleData:
         l2_into_l3_meta(self.blank_output.meta, input_model_0.meta)
         self.blank_output.meta.wcs = self.output_wcs
         gwcs_into_l3(self.blank_output, self.output_wcs)
+        self.blank_output.cal_logs = stnode.CalLogs()
+        self.blank_output['individual_image_cal_logs'] = (
+            [model.cal_logs for model in input_models])
 
         self.output_models = ModelContainer()
 

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -7,7 +7,7 @@ import logging
 import time
 
 import roman_datamodels as rdm
-from roman_datamodels.datamodels import ImageModel
+from roman_datamodels.datamodels import ImageModel, MosaicModel
 from stpipe import Pipeline, Step, crds_client
 
 from ..lib.suffix import remove_suffix
@@ -58,7 +58,7 @@ class RomanStep(Step):
 
         model.meta.calibration_software_version = importlib.metadata.version("romancal")
 
-        if isinstance(model, ImageModel):
+        if isinstance(model, (ImageModel, MosaicModel)):
             for log_record in self.log_records:
                 model.cal_logs.append(_LOG_FORMATTER.format(log_record))
 


### PR DESCRIPTION
This PR leads HLP products to have their "cal_logs" attribute filled out.

Previously these were not being populated because stpipe.core was explicitly checking that the output datamodel was an ImageModel.  This PR changes that to check if it's either an ImageModel or a MosaicModel.  It also clears the CalLogs when making a new output model to avoid some initial filler values.

Finally, a big portion of the HLP is processing the input L2s; flux calibration, sky matching, outlier detection.  Those logs go into the L2 products which we do not save.  This adds a new individual_image_cal_logs extension parallel to cal_logs that houses the individual L2 log messages.  We probably want that?

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant milestone(s)
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below. https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/725/
