### PR TITLE
RCAL-801: update skymatch to return updated models if the input is an asn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.14.1 (unreleased)
 ==================
 
+skymatch
+--------
+- Update step to always return a ``ModelContainer``. [#1208]
+
 patch_match
 -----------
 

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -113,7 +113,22 @@ class TestDescriptionPlugin:
 
 @pytest.fixture(scope="function")
 def create_mock_asn_file():
-    def _create_asn_file(tmp_path, members_mapping=None):
+    def _create_asn_file(tmp_path: str, members_mapping: dict = None) -> str:
+        """
+        Create a mock association file with the provided members mapping.
+
+        Parameters
+        ----------
+        tmp_path : str
+            Path to the temporary directory to store the association file.
+        members_mapping : list, optional
+            Mapping of members to include in the association file (default: None).
+
+        Returns
+        -------
+        str
+            Path to the created association file.
+        """
         asn_content = """
             {
                 "asn_type": "None",
@@ -143,7 +158,7 @@ def create_mock_asn_file():
                 ]
             }
         """
-        if members_mapping is not None:
+        if members_mapping:
             asn_dict = json.loads(asn_content)
             asn_dict["products"][0]["members"] = []
             for x in members_mapping:

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -97,7 +97,7 @@ class SkyMatchStep(RomanStep):
                         gim, "COMPLETE" if gim.is_sky_valid else "SKIPPED"
                     )
 
-        return input if self._is_asn else img
+        return ModelContainer([x.meta["image_model"] for x in images])
 
     def _imodel2skyim(self, image_model):
         input_image_model = image_model

--- a/romancal/skymatch/tests/test_skymatch.py
+++ b/romancal/skymatch/tests/test_skymatch.py
@@ -1,3 +1,4 @@
+import os
 from itertools import product
 
 import astropy.units as u
@@ -13,7 +14,6 @@ from roman_datamodels.maker_utils import mk_level2_image
 
 from romancal.datamodels.container import ModelContainer
 from romancal.skymatch import SkyMatchStep
-import os
 
 
 def mk_gwcs(shape, sky_offset=[0, 0] * u.arcsec, rotate=0 * u.deg):

--- a/romancal/skymatch/tests/test_skymatch.py
+++ b/romancal/skymatch/tests/test_skymatch.py
@@ -13,6 +13,7 @@ from roman_datamodels.maker_utils import mk_level2_image
 
 from romancal.datamodels.container import ModelContainer
 from romancal.skymatch import SkyMatchStep
+import os
 
 
 def mk_gwcs(shape, sky_offset=[0, 0] * u.arcsec, rotate=0 * u.deg):
@@ -370,3 +371,58 @@ def test_skymatch_2x(wfi_rate, skymethod, subtract):
             assert abs(np.mean(im.data[dq_mask]).value - slev) < 0.01
         else:
             assert abs(np.mean(im.data[dq_mask]).value - lev) < 0.01
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        "ModelContainer",
+        "ASNFile",
+        "DataModelList",
+        "ASDFFilenameList",
+    ],
+)
+def test_skymatch_always_returns_modelcontainer_with_updated_datamodels(
+    input_type,
+    mk_sky_match_image_models,
+    tmp_path,
+    create_mock_asn_file,
+):
+    """Test that the SkyMatchStep always returns a ModelContainer
+    with updated data models after processing different input types."""
+
+    os.chdir(tmp_path)
+    [im1a, im1b, im2a, im2b, im3], dq_mask = mk_sky_match_image_models
+
+    im1a.meta.filename = "im1a.asdf"
+    im1b.meta.filename = "im1b.asdf"
+    im2a.meta.filename = "im2a.asdf"
+    im2b.meta.filename = "im2b.asdf"
+    im3.meta.filename = "im3.asdf"
+
+    mc = ModelContainer([im1a, im1b, im2a, im2b, im3])
+    mc.save(dir_path=tmp_path)
+
+    step_input_map = {
+        "ModelContainer": mc,
+        "ASNFile": create_mock_asn_file(
+            tmp_path,
+            members_mapping=[
+                {"expname": im1a.meta.filename, "exptype": "science"},
+                {"expname": im1b.meta.filename, "exptype": "science"},
+                {"expname": im2a.meta.filename, "exptype": "science"},
+                {"expname": im2b.meta.filename, "exptype": "science"},
+                {"expname": im3.meta.filename, "exptype": "science"},
+            ],
+        ),
+        "DataModelList": [im1a, im1b],
+        "ASDFFilenameList": [im1a.meta.filename, im1b.meta.filename],
+    }
+
+    step_input = step_input_map.get(input_type)
+
+    res = SkyMatchStep.call(step_input)
+
+    assert isinstance(res, ModelContainer)
+    assert all(x.meta.cal_step.skymatch == "COMPLETE" for x in res)
+    assert all(hasattr(x.meta, "background") for x in res)


### PR DESCRIPTION
Resolves [RCAL-801](https://jira.stsci.edu/browse/RCAL-801)

This PR ensures that `SkyMatchStep` always returns a `ModelContainer` with the updated datamodel.

I believe `SkyMatchStep` is due some refactoring (specifically regarding the intended use of memory management, as seen in JWST's `SkyMatchStep`), but I think that it should be done separately from the current PR.

**Regression Tests**
- https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/721/

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
