### PR TITLE
Put real file names in meta.resample.meta.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ resample
 
 - Include logs of individual L2 products [#1207]
 
+- Resample members should use actual file names from association file [#1209]
+
 outlier_detection
 -----------------
 

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -153,6 +153,7 @@ class ModelContainer(Sequence):
         self.asn_table = {}
         self.asn_table_name = None
         self.asn_pool_name = None
+        self.filepaths = None
 
         try:
             init = Path(init)
@@ -179,6 +180,10 @@ class ModelContainer(Sequence):
                         "Input must be an ASN file or a list of either strings "
                         "(full path to ASDF files) or Roman datamodels."
                     )
+                if is_all_string or is_all_path:
+                    self.filepaths = [op.basename(m) for m in self._models]
+                else:
+                    self.filepaths = getattr(init, 'filepaths', None)
         else:
             if is_association(init):
                 self.from_asn(init)
@@ -336,9 +341,11 @@ class ModelContainer(Sequence):
         asn_dir = op.dirname(asn_file_path) if asn_file_path else ""
         # Only handle the specified number of members.
         sublist = infiles[: self.asn_n_members] if self.asn_n_members else infiles
+        self.filepaths = []
         try:
             for member in sublist:
                 filepath = op.join(asn_dir, member["expname"])
+                self.filepaths.append(op.basename(filepath))
                 update_model = any(attr in member for attr in RECOGNIZED_MEMBER_FIELDS)
                 if update_model or self._save_open:
                     m = rdm.open(filepath, memmap=self._memmap)

--- a/romancal/datamodels/container.py
+++ b/romancal/datamodels/container.py
@@ -183,7 +183,7 @@ class ModelContainer(Sequence):
                 if is_all_string or is_all_path:
                     self.filepaths = [op.basename(m) for m in self._models]
                 else:
-                    self.filepaths = getattr(init, 'filepaths', None)
+                    self.filepaths = getattr(init, "filepaths", None)
         else:
             if is_association(init):
                 self.from_asn(init)

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -296,6 +296,7 @@ class ResampleData:
         )
 
         log.info("Resampling science data")
+        members = []
         for img in self.input_models:
             inwht = resample_utils.build_driz_weight(
                 img,
@@ -324,11 +325,11 @@ class ResampleData:
                 ymax=ymax,
             )
             del data, inwht
-            try:
-                filename = os.path.basename(img._asdf._fname)
-            except:
-                filename = img.meta.filename
-            output_model.meta.resample.members.append(str(filename))
+            members.append(str(img.meta.filename))
+
+        members = (members if self.input_models.filepaths is None
+                   else self.input_models.filepaths)
+        output_model.meta.resample.members = members
 
         # Resample variances array in self.input_models to output_model
         self.resample_variance_array("var_rnoise", output_model)

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -1,6 +1,6 @@
 import logging
-from typing import List
 import os
+from typing import List
 
 import numpy as np
 from astropy import units as u

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+import os
 
 import numpy as np
 from astropy import units as u
@@ -323,7 +324,11 @@ class ResampleData:
                 ymax=ymax,
             )
             del data, inwht
-            output_model.meta.resample.members.append(str(img.meta.filename))
+            try:
+                filename = os.path.basename(img._asdf._fname)
+            except:
+                filename = img.meta.filename
+            output_model.meta.resample.members.append(str(filename))
 
         # Resample variances array in self.input_models to output_model
         self.resample_variance_array("var_rnoise", output_model)

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import List
 
 import numpy as np
@@ -327,8 +326,11 @@ class ResampleData:
             del data, inwht
             members.append(str(img.meta.filename))
 
-        members = (members if self.input_models.filepaths is None
-                   else self.input_models.filepaths)
+        members = (
+            members
+            if self.input_models.filepaths is None
+            else self.input_models.filepaths
+        )
         output_model.meta.resample.members = members
 
         # Resample variances array in self.input_models to output_model


### PR DESCRIPTION
This PR puts the real file names in meta.resample.members rather than the individual file name meta.filename attributes.  This is intended to address https://github.com/spacetelescope/romancal/issues/1154 , but is rather awkward.

The challenge is that the ModelContainer passed to resample doesn't know about the original file names.  This PR digs around the private contents of the datamodel to grab the input file name, and if that fails, falls back to img.meta.filename.  But relying on img._asdf._fname is clearly asking for trouble.

The alternative would be to teach ModelContainer about the input file names if it's read from an association.  That would add a new filenames member to ModelContainer that defaults to None, and sets the new filenames to be equal to _models if everything is a string.  Then resample would check that attribute and use it if it's not None.

Thoughts on what the preferred approach is here?  @ddavis-stsci , @mairanteodoro , you may have thoughts here?

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [X] updated relevant milestone(s)
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below. https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/727/
