### PR TITLE
fix incorrect boolean comparison within `isfile()`

### DIFF
--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -85,12 +85,12 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     # DMS356 Test that the thumbnail image exists
     pipeline.log.info(
         "Status of the step:             thumbnail image    "
-        + passfail(os.path.isfile(thumbnail_file is True))
+        + passfail(os.path.isfile(thumbnail_file))
     )
     # DMS356 Test that the preview image exists
     pipeline.log.info(
         "Status of the step:             preview image    "
-        + passfail(os.path.isfile(preview_file is True))
+        + passfail(os.path.isfile(preview_file))
     )
     pipeline.log.info(
         "DMS86 MSG: Testing completion of skymatch in the Level 3  output......."


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses problems brought by `sonarqube`: https://plsonarqube.stsci.edu/project/issues?resolved=false&inNewCodePeriod=true&types=BUG&id=romancal&open=AY8c5NNYlU1kwdd-S5_H

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
