### PR TITLE
pass exclude/ignore options to table meta comparison

### DIFF
--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -609,11 +609,20 @@ class TableOperator(NDArrayTypeOperator):
         difference = self._compare_arrays(a, b)
         # also compare meta  for tables
         if level.t1.meta != level.t2.meta:
+            kwargs = {}
+            if diff_instance.exclude_paths:
+                meta_path = level.path() + "['meta']"
+                kwargs["exclude_paths"] = [
+                    f"root{path.removeprefix(meta_path)}"
+                    for path in diff_instance.exclude_paths
+                    if path.startswith(meta_path)
+                ]
             meta_difference = deepdiff.DeepDiff(
                 level.t1.meta,
                 level.t2.meta,
                 ignore_nan_inequality=self.equal_nan,
                 math_epsilon=self.atol,
+                **kwargs,
             )
             if meta_difference:
                 difference["metas_differ"] = meta_difference

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -56,6 +56,7 @@ def test_compare_asdf(tmp_path, modification):
         "large_values",
         "small_meta",
         "large_meta",
+        "ignore_meta",
     ],
 )
 def test_compare_asdf_tables(tmp_path, modification):
@@ -82,10 +83,16 @@ def test_compare_asdf_tables(tmp_path, modification):
         t1.meta["value"] += atol / 2
     if modification == "large_meta":
         t1.meta["value"] += atol * 2
+    if modification == "ignore_meta":
+        t1.meta["value"] += atol * 2
     asdf.AsdfFile({"t": t0}).write_to(fn0)
     asdf.AsdfFile({"t": t1}).write_to(fn1)
-    diff = compare_asdf(fn0, fn1, atol=atol)
-    if modification in (None, "small_values", "small_meta"):
+    if modification == "ignore_meta":
+        kwargs = {"ignore": ["t.meta.value"]}
+    else:
+        kwargs = {}
+    diff = compare_asdf(fn0, fn1, atol=atol, **kwargs)
+    if modification in (None, "small_values", "small_meta", "ignore_meta"):
         assert diff.identical, diff.report()
     else:
         assert not diff.identical, diff.report()


### PR DESCRIPTION
This PR allows passing `ignore` paths that include items in `astropy.Table` metadata by parsing the `exclude_paths` handled by `DeepDiff` and passing them through to the diff called on the table metadata. A test is added for the new feature.

@schlafly would you try this with the table date metadata issue you mentioned? Thanks!

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
