### PR TITLE
Regtest / integration fixes for B14

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0056.pmap",
+    "CRDS_CONTEXT=roman_0058.pmap",
     "CRDS_SERVER_URL=https://roman-serverless",
     'CRDS_PATH=/grp/crds/roman/test/',
     'DD_ENV=ci',

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -52,7 +52,7 @@ def pip_install_args = "--index-url ${pip_index} --progress-bar=off"
 // Define environment variables needed for the regression tests
 env_vars = [
     "TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory",
-    "CRDS_CONTEXT=roman_0056.pmap",
+    "CRDS_CONTEXT=roman_0058.pmap",
     "CRDS_SERVER_URL=https://roman-serverless",
     'CRDS_PATH=/grp/crds/roman/test/',
     'WEBBPSF_PATH=/grp/jwst/ote/webbpsf-data',

--- a/requirements-sdp.txt
+++ b/requirements-sdp.txt
@@ -5,5 +5,5 @@
 #
 # Add a CRDS context number for the delivery as a record here
 #
-# CRDS_CONTEXT = roman_0056.pmap
+# CRDS_CONTEXT = roman_0058.pmap
 #

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -205,6 +205,9 @@ def ignore_asdf_paths():
         "roman.cal_logs",
         "roman.meta.date",
         "roman.individual_image_cal_logs",
+        "roman.meta.individual_image_meta",
+        # individual image meta includes string arrays, not supported by
+        # compare_asdf at present.
         # roman.meta.filename is used by the ExposurePipeline so should likely
         # not be ignored here
         # "roman.meta.filename",

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -614,6 +614,8 @@ class TableOperator(NDArrayTypeOperator):
                 level.t2.meta,
                 ignore_nan_inequality=self.equal_nan,
                 math_epsilon=self.atol,
+                exclude_paths=["root['date']"],
+                # creation date sometimes stored here
             )
             if meta_difference:
                 difference["metas_differ"] = meta_difference

--- a/romancal/regtest/test_catalog.py
+++ b/romancal/regtest/test_catalog.py
@@ -55,7 +55,7 @@ def test_catalog_l3(rtdata, ignore_asdf_paths):
     # DMS376: type of source
     # DMS386: flux uncertainties
     # DMS387: DQ flags
-    inputfn = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    inputfn = "r0099101001001001001_F158_visit_nocell_i2d.asdf"
     outputfn = inputfn.replace("_i2d", "_cat")
     rtdata.get_data(f"WFI/image/{inputfn}")
     rtdata.input = inputfn

--- a/romancal/regtest/test_hlp_pipeline.py
+++ b/romancal/regtest/test_hlp_pipeline.py
@@ -38,7 +38,7 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     rtdata.input = input_asn
 
     # Test Pipeline
-    output = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    output = "r0099101001001001001_F158_visit_nocell_i2d.asdf"
     rtdata.output = output
     args = [
         "--disable-crds-steppars",
@@ -51,17 +51,17 @@ def test_level3_hlp_pipeline(rtdata, ignore_asdf_paths):
     assert diff.identical, diff.report()
 
     # Generate thumbnail image
-    input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    input_file = "r0099101001001001001_F158_visit_nocell_i2d.asdf"
     thumbnail_file = (
-        "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_thumb.png"
+        "r0099101001001001001_F158_visit_nocell_thumb.png"
     )
     preview_cmd = f"stpreview to {input_file} {thumbnail_file} 256 256 roman"
     os.system(preview_cmd)  # nosec
 
     # Generate preview image
-    input_file = "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_i2d.asdf"
+    input_file = "r0099101001001001001_F158_visit_nocell_i2d.asdf"
     preview_file = (
-        "r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5_preview.png"
+        "r0099101001001001001_F158_visit_nocell_preview.png"
     )
     preview_cmd = f"stpreview to {input_file} {preview_file} 1080 1080 roman"
     os.system(preview_cmd)  # nosec

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -172,9 +172,8 @@ strun roman_elp r0000201001001001001_01101_0004_WFI01_uncal.asdf
 cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
 
-l3name="r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5"
-asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name.
-# trailing . needed to avoid some filename parsing bug?
+l3name="r0099101001001001001_F158_visit_nocell"
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name
 strun --disable-crds-steppars roman_hlp L3_regtest_asn.json
 cp L3_regtest_asn.json $outdir/roman-pipeline/dev/WFI/image/
 cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/WFI/image/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -154,7 +154,7 @@ import roman_datamodels as rdm
 from roman_datamodels import stnode
 from romancal.assign_wcs.assign_wcs_step import AssignWcsStep
 model = rdm.open('${basename}_cal.asdf', lazy_load=False)
-model.meta.filename = stnode.Filename(f'{basename}_shift_cal.asdf')
+model.meta.filename = stnode.Filename(f'${basename}_shift_cal.asdf')
 delta = [1 / 3600., 1 / 3600.]
 wcsinfo = model.meta.wcsinfo
 wcsinfo.ra_ref += delta[0]
@@ -162,7 +162,7 @@ wcsinfo.dec_ref += delta[1]
 model = AssignWcsStep.call(model)
 model.to_asdf(f'${basename}_shift_cal.asdf')"
     strun romancal.step.TweakRegStep ${basename}_shift_cal.asdf
-    cp ${basename}_shift_cal.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+    cp ${basename}_shift_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
     cp ${basename}_shift_tweakregstep.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 done
 
@@ -173,9 +173,11 @@ cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/W
 cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
 
 l3name="r0099101001001001001_F158_visit_0.900.0.50_178199.5_-0.5"
-asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name
+asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name.
+# trailing . needed to avoid some filename parsing bug?
 strun --disable-crds-steppars roman_hlp L3_regtest_asn.json
 cp L3_regtest_asn.json $outdir/roman-pipeline/dev/WFI/image/
+cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 # L3 catalog
@@ -185,3 +187,8 @@ cp ${l3name}_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 # L2 catalog
 strun romancal.step.SourceCatalogStep r0000101001001001001_01101_0001_WFI01_cal.asdf
 cp r0000101001001001001_01101_0001_WFI01_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+l3name="r0099101001001001001_F158_visit_r274dp63x31y81"
+asn_from_list --product-name=$l3name r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0001_WFI02_cal.asdf r0000101001001001001_01101_0001_WFI03_cal.asdf -o L3_m1_asn.json
+strun --disable-crds-steppars roman_hlp L3_m1_asn.json
+cp ${l3}_i2d.asdf $outdir/roman-pipeline/dev/truth/image/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -190,4 +190,4 @@ cp r0000101001001001001_01101_0001_WFI01_cat.asdf $outdir/roman-pipeline/dev/tru
 l3name="r0099101001001001001_F158_visit_r274dp63x31y81"
 asn_from_list --product-name=$l3name r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_m1_asn.json
 strun --disable-crds-steppars roman_hlp L3_m1_asn.json
-cp ${l3}_i2d.asdf $outdir/roman-pipeline/dev/truth/image/
+cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -188,6 +188,6 @@ strun romancal.step.SourceCatalogStep r0000101001001001001_01101_0001_WFI01_cal.
 cp r0000101001001001001_01101_0001_WFI01_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 l3name="r0099101001001001001_F158_visit_r274dp63x31y81"
-asn_from_list --product-name=$l3name r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0001_WFI02_cal.asdf r0000101001001001001_01101_0001_WFI03_cal.asdf -o L3_m1_asn.json
+asn_from_list --product-name=$l3name r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_m1_asn.json
 strun --disable-crds-steppars roman_hlp L3_m1_asn.json
 cp ${l3}_i2d.asdf $outdir/roman-pipeline/dev/truth/image/


### PR DESCRIPTION
This PR makes a handful of minor changes in order to get things integrated for B14.  In combination with https://github.com/spacetelescope/roman_datamodels/pull/349 and the new regtest files in /grp/roman/eschlafly/romanisim/20240503 we pass tests, etc..  Some bits of this PR:

* Update context to 58.
* Ignore individual_image_metadata in compare_asdf because compare_asdf doesn't currently handle non-numeric array types (i.e., it barfs when told to compare two numpy arrays of strings)
* Ignore the 'date' meta keyword in astropy tables, since this keyword gets updated with the table creation date in the PSF catalog module.
* Update the file names of the L3 regtest files without skycells.
* Update the regtest creation script to have the right file names.