### PR TITLE
Also ignore version information in Table schema meta.

### DIFF
--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -614,7 +614,8 @@ class TableOperator(NDArrayTypeOperator):
                 level.t2.meta,
                 ignore_nan_inequality=self.equal_nan,
                 math_epsilon=self.atol,
-                exclude_paths=["root['date']"],
+                exclude_paths=["root['date']",
+                               "root['version']",],
                 # creation date sometimes stored here
             )
             if meta_difference:

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -614,8 +614,10 @@ class TableOperator(NDArrayTypeOperator):
                 level.t2.meta,
                 ignore_nan_inequality=self.equal_nan,
                 math_epsilon=self.atol,
-                exclude_paths=["root['date']",
-                               "root['version']",],
+                exclude_paths=[
+                    "root['date']",
+                    "root['version']",
+                ],
                 # creation date sometimes stored here
             )
             if meta_difference:


### PR DESCRIPTION
This PR ignores an additional Table metadata version field in compare_asdf.