### PR TITLE
remove clean_up_after_test

### DIFF
--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -7,32 +6,6 @@ from astropy.units import Quantity
 
 from romancal.datamodels import ModelContainer
 from romancal.outlier_detection import OutlierDetectionStep, outlier_detection
-
-
-@pytest.fixture()
-def clean_up_after_test():
-    """
-    Clean up working directory after test.
-    """
-
-    def _clean_up_working_directory(pattern="*.asdf"):
-        """
-        Clean up the working directory by removing files matching the specified pattern.
-        Parameters
-        ----------
-        pattern : str, optional
-            The pattern of the file pattern to match (default is "*.asdf")
-
-        Returns
-        -------
-        None
-
-        """
-        for x in (Path(os.getcwd())).glob(pattern):
-            if x.exists():
-                x.unlink()
-
-    return _clean_up_working_directory
 
 
 @pytest.mark.parametrize(
@@ -167,9 +140,7 @@ def test_outlier_init_default_parameters(pars, base_image):
     assert step.resample_suffix == f"_outlier_{pars['resample_suffix']}.asdf"
 
 
-def test_outlier_do_detection_write_files_to_custom_location(
-    tmp_path, base_image, clean_up_after_test
-):
+def test_outlier_do_detection_write_files_to_custom_location(tmp_path, base_image):
     """
     Test that OutlierDetection can create files on disk in a custom location.
     """
@@ -219,10 +190,8 @@ def test_outlier_do_detection_write_files_to_custom_location(
 
     assert all(x.exists() for x in outlier_files_path)
 
-    clean_up_after_test("*.asdf")
 
-
-def test_outlier_do_detection_find_outliers(tmp_path, base_image, clean_up_after_test):
+def test_outlier_do_detection_find_outliers(tmp_path, base_image):
     """
     Test that OutlierDetection can find outliers.
     """
@@ -295,11 +264,9 @@ def test_outlier_do_detection_find_outliers(tmp_path, base_image, clean_up_after
     # assert all(outliers_input_coords == outliers_output_coords) doesn't work with python 3.9
     assert all(o == i for i, o in zip(outliers_input_coords, outliers_output_coords))
 
-    clean_up_after_test("*.asdf")
-
 
 def test_outlier_do_detection_do_not_find_outliers_in_identical_images(
-    tmp_path, base_image, clean_up_after_test, caplog
+    tmp_path, base_image, caplog
 ):
     """
     Test that OutlierDetection does not flag any outliers in the DQ array if images are identical.


### PR DESCRIPTION
The `clean_up_after_test` fixture usage in the outlier detection tests deletes all asdf files in the working directory (even if they were not created by the tests). The tests that use this fixture also do not change the working directory. This can (and did result) result in deletion of user files (unrelated to the unit or regression tests) with no warnings.

This resulted in deletion of a large number of files (which were not generated by the tests and are now lost) when I ran the outlier detection tests.

This PR removes the fixture. It could later be replaced with a more specific cleanup.

Fixes: https://github.com/spacetelescope/romancal/issues/1244

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)

Regression tests run with no errors:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/776/pipeline/245
