### PR TITLE
attempt to fix `/grp/` access in regtests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -95,6 +95,7 @@ bc0.build_cmds = bc0.build_cmds + [
     "pip list"
 ]
 bc0.test_cmds = [
+    "stat /grp/roman 1>/dev/null",
     "pytest -r sxf -n auto --bigdata --slow --webbpsf \
     --cov --cov-report=xml:coverage.xml \
     --ddtrace \


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-153](https://jira.stsci.edu/browse/SCSB-153)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
run `stat` to touch `/grp/` mount (the issue is possibly that the mount is "asleep" at the time of attempted file access)

<!-- describe the changes comprising this PR here -->

**Checklist**
- [x] ~added entry in `CHANGES.rst` under the corresponding subsection~
- [x] ~updated relevant tests~
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
