### PR TITLE
replace deprecated stpipe configobj with astropy

### DIFF
--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -4,10 +4,10 @@ from copy import deepcopy
 
 import asdf
 import numpy as np
+from astropy.extern.configobj.configobj import ConfigObj
+from astropy.extern.configobj.validate import Validator
 from roman_datamodels import datamodels
 from stcal.alignment import util
-from stpipe.extern.configobj.configobj import ConfigObj
-from stpipe.extern.configobj.validate import Validator
 
 from ..datamodels import ModelContainer
 from ..stpipe import RomanStep


### PR DESCRIPTION
configobj use from stpipe is deprecated. This is causing [warnings in test runs](https://github.com/spacetelescope/romancal/actions/runs/9409925545/job/25920739724#step:10:262):
```
  /home/runner/work/romancal/romancal/.tox/py311-ddtrace-webbpsf/lib/python3.11/site-packages/ddtrace/internal/module.py:220: DeprecationWarning: stpipe.extern.configobj is deprecated in favor of astropy.extern.configobj, please use that instead.
```

This PR uses configobj from astropy similar to what is done in [jwst](https://github.com/spacetelescope/jwst/blob/e1b66cc4c8c8d2cafd2be4828de7de67184f56a6/jwst/resample/resample_step.py#L8).

With this PR the warning is no longer seen in the test runs:
https://github.com/spacetelescope/romancal/actions/runs/9418970328/job/25947683547?pr=1267#step:10:260

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
