### PR TITLE
Rcal 854 Tweakreg step listed as skipped when run & refactor exposure pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Documentation
 general
 -------
 
-- refactor expsosure level pipeline to use asn's and ModelContainer [#]
+- refactor expsosure level pipeline to use asn's and ModelContainer [#1271]
 
 - Add catalog source step to the mosaic pipeline [#1266]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Documentation
 general
 -------
 
+- refactor expsosure level pipeline to use asn's and ModelContainer [#]
+
 - Add catalog source step to the mosaic pipeline [#1266]
 
 - Rename highlevelpipeline to mosaic pipeline [#1249]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Documentation
 general
 -------
 
-- refactor expsosure level pipeline to use asn's and ModelContainer [#1271]
+- refactor exposure level pipeline to use asn's and ModelContainer [#1271]
 
 - Add catalog source step to the mosaic pipeline [#1266]
 

--- a/docs/roman/pipeline/exposure_pipeline.rst
+++ b/docs/roman/pipeline/exposure_pipeline.rst
@@ -61,10 +61,15 @@ Inputs
 :Data model: `~romancal.datamodels.RampModel`
 :File suffix: _uncal
 
-The input to the ``ExposurePipeline`` is a single raw exposure,
+The input to the ``ExposurePipeline`` can be a single raw exposure,
 e.g. "r0008308002010007027_06311_0019_WFI01_uncal.asdf", which contains the
 original raw data from all of the detector readouts in the exposure
-( ngroups x ncols x nrows ).
+( ngroups x ncols x nrows ). The raw data may also be input using an association file.
+
+If the ``ExposurePipeline`` is given a single file the final alignment to Gaia will be done
+with the sources found in the exposure. If multiple exposures exist in the association file
+then the final alignment will use all the sources found in the exposures
+(see :ref:`tweakreg <tweakreg_step>`).
 
 Note that in the operational environment, the
 input will be in the form of a `~romancal.datamodels.RawScienceModel`, which only

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -121,10 +121,8 @@ class ExposurePipeline(RomanPipeline):
 
             # Test for fully saturated data
             if is_fully_saturated(result):
-                log.info("All pixels are saturated. Returning a zeroed-out image.")
                 # Return fully saturated image file (stopping pipeline)
-                #self.suffix = 'cal'
-                #return result
+                log.info("All pixels are saturated. Returning a zeroed-out image.")
 
                 #    if is_fully_saturated(result):
                 # Set all subsequent steps to skipped
@@ -185,7 +183,6 @@ class ExposurePipeline(RomanPipeline):
         # Now that all the exposures are collated, run tweakreg
         # Note: this does not cover the case where the asn mixes imaging and spectral
         #          observations. This should not occur on-prem
-#        if file_type == "asn":
         result = self.tweakreg(results)
 
         log.info("Roman exposure calibration pipeline ending...")

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -83,7 +83,7 @@ class ExposurePipeline(RomanPipeline):
             
         if file_type == "asdf":
             try:
-                asn = ModelContainer(None)
+                #asn = ModelContainer(None)
                 #set the product name based on the input filename
                 asn = asn_from_list([input], product_name = input_filename.split('.')[0])
                 file_type = "asn"
@@ -155,15 +155,10 @@ class ExposurePipeline(RomanPipeline):
                 result = self.flatfield(result)
                 result = self.photom(result)
                 result = self.source_detection(result)
-                if file_type == "asdf":
-                    result = self.tweakreg(result)
-                if file_type == "asn":
-                    result.meta.cal_step.tweakreg = "SKIPPED"
-                    self.suffix = "sourcedetection"
-                    tweakreg_input.append(result)
-                    log.info(
-                        f"Number of models to tweakreg:   {len(tweakreg_input._models), n_members}"
-                    )
+                tweakreg_input.append(result)
+                log.info(
+                    f"Number of models to tweakreg:   {len(tweakreg_input._models), n_members}"
+                )
             else:
                 log.info("Flat Field step is being SKIPPED")
                 log.info("Photom step is being SKIPPED")

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -83,7 +83,6 @@ class ExposurePipeline(RomanPipeline):
             
         if file_type == "asdf":
             try:
-                #asn = ModelContainer(None)
                 #set the product name based on the input filename
                 asn = asn_from_list([input], product_name = input_filename.split('.')[0])
                 file_type = "asn"

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -128,8 +128,8 @@ class ExposurePipeline(RomanPipeline):
             if is_fully_saturated(result):
                 log.info("All pixels are saturated. Returning a zeroed-out image.")
                 # Return fully saturated image file (stopping pipeline)
-                self.suffix = 'cal'
-                return result
+                #self.suffix = 'cal'
+                #return result
 
                 #    if is_fully_saturated(result):
                 # Set all subsequent steps to skipped
@@ -147,10 +147,10 @@ class ExposurePipeline(RomanPipeline):
                 ]:
                     result.meta.cal_step[step_str] = "SKIPPED"
 
-                # Set suffix for proper output naming
-                self.suffix = 'cal'
-                results.append(result)
-                return results
+            # Set suffix for proper output naming
+            self.suffix = 'cal'
+            results.append(result)
+            return results
 
             result = self.refpix(result)
             result = self.linearity(result)

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -10,8 +10,6 @@ import romancal.datamodels.filetype as filetype
 
 # step imports
 from romancal.assign_wcs import AssignWcsStep
-
-from romancal.associations import Association
 from romancal.associations.asn_from_list import asn_from_list
 from romancal.dark_current import DarkCurrentStep
 from romancal.datamodels import ModelContainer
@@ -80,11 +78,11 @@ class ExposurePipeline(RomanPipeline):
         file_type = filetype.check(input)
         if file_type == "asn":
             asn = ModelContainer.read_asn(input)
-            
+
         if file_type == "asdf":
             try:
-                #set the product name based on the input filename
-                asn = asn_from_list([input], product_name = input_filename.split('.')[0])
+                # set the product name based on the input filename
+                asn = asn_from_list([input], product_name=input_filename.split(".")[0])
                 file_type = "asn"
             except TypeError:
                 log.debug("Error opening file:")
@@ -140,7 +138,7 @@ class ExposurePipeline(RomanPipeline):
                     result.meta.cal_step[step_str] = "SKIPPED"
 
                 # Set suffix for proper output naming
-                self.suffix = 'cal'
+                self.suffix = "cal"
                 results.append(result)
                 return results
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import logging
 from os.path import basename
-import pdb
 
 import numpy as np
 from roman_datamodels import datamodels as rdm
@@ -84,7 +83,6 @@ class ExposurePipeline(RomanPipeline):
             
         if file_type == "asdf":
             try:
-                #input = rdm.open(input)
                 asn = ModelContainer(None)
                 #set the product name based on the input filename
                 asn = asn_from_list([input], product_name = input_filename.split('.')[0])
@@ -96,9 +94,6 @@ class ExposurePipeline(RomanPipeline):
         # Build a list of observations to process
         expos_file = []
         n_members = 0
-#        if file_type == "asdf":
-#            expos_file = [input]
-#        elif file_type == "asn":
         # extract the members from the asn to run the files through the steps
         for product in asn["products"]:
             n_members = len(product["members"])
@@ -125,7 +120,6 @@ class ExposurePipeline(RomanPipeline):
             result = self.saturation(result)
 
             # Test for fully saturated data
-            #pdb.set_trace()
             if is_fully_saturated(result):
                 log.info("All pixels are saturated. Returning a zeroed-out image.")
                 # Return fully saturated image file (stopping pipeline)
@@ -191,8 +185,8 @@ class ExposurePipeline(RomanPipeline):
         # Now that all the exposures are collated, run tweakreg
         # Note: this does not cover the case where the asn mixes imaging and spectral
         #          observations. This should not occur on-prem
-        if file_type == "asn":
-            result = self.tweakreg(results)
+#        if file_type == "asn":
+        result = self.tweakreg(results)
 
         log.info("Roman exposure calibration pipeline ending...")
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -128,6 +128,7 @@ class ExposurePipeline(RomanPipeline):
             if is_fully_saturated(result):
                 log.info("All pixels are saturated. Returning a zeroed-out image.")
                 # Return fully saturated image file (stopping pipeline)
+                self.suffix = 'cal'
                 return result
 
                 #    if is_fully_saturated(result):
@@ -147,7 +148,7 @@ class ExposurePipeline(RomanPipeline):
                     result.meta.cal_step[step_str] = "SKIPPED"
 
                 # Set suffix for proper output naming
-                self.suffix = "cal"
+                self.suffix = 'cal'
                 results.append(result)
                 return results
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -125,6 +125,7 @@ class ExposurePipeline(RomanPipeline):
             result = self.saturation(result)
 
             # Test for fully saturated data
+            #pdb.set_trace()
             if is_fully_saturated(result):
                 log.info("All pixels are saturated. Returning a zeroed-out image.")
                 # Return fully saturated image file (stopping pipeline)
@@ -147,10 +148,10 @@ class ExposurePipeline(RomanPipeline):
                 ]:
                     result.meta.cal_step[step_str] = "SKIPPED"
 
-            # Set suffix for proper output naming
-            self.suffix = 'cal'
-            results.append(result)
-            return results
+                # Set suffix for proper output naming
+                self.suffix = 'cal'
+                results.append(result)
+                return results
 
             result = self.refpix(result)
             result = self.linearity(result)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-854](https://jira.stsci.edu/browse/RCAL-854)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1263

<!-- describe the changes comprising this PR here -->
This PR fixes the error that the tweakreg step is listed as skipped when it is run. This PR also refactors the
exposure level pipeline to take advantage of the model container and associations. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/828/
The regression test truth data will need updating to fix the tests ( cal_step SKIPPED --> COMPLETE)