### PR TITLE
rcal-859 Update okify script to use GA directories on artifactory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ general
 -------
 
 - Update okify script to use GA directory structure [#1282]
-  
+
 - pin numpy to <2 [#1275]
 
 - refactor exposure level pipeline to use asn's and ModelContainer [#1271]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Documentation
 general
 -------
 
+- Update okify script to use GA directory structure [#]
+  
 - pin numpy to <2 [#1275]
 
 - refactor exposure level pipeline to use asn's and ModelContainer [#1271]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Documentation
 general
 -------
 
-- Update okify script to use GA directory structure [#]
+- Update okify script to use GA directory structure [#1282]
   
 - pin numpy to <2 [#1275]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-859](https://jira.stsci.edu/browse/RCAL-859)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1281 

<!-- describe the changes comprising this PR here -->
This PR updates the okify script to use the GA directories in artifactory.

**Checklist**
- [X] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [X] updated relevant milestone(s)
- [X] added relevant label(s)
- [N/a] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
