### PR TITLE
increase conda version

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -79,7 +79,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'romancal'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
+bc0.conda_ver = '24.5.'
 bc0.conda_packages = [
     "python=${python_version}",
     "freetds",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -77,7 +77,7 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'romancal'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
+bc0.conda_ver = '24.5.'
 bc0.conda_packages = [
     "python=${python_version}",
     "freetds",


### PR DESCRIPTION
Following the switch to microforge on jenkins the configurations in this repo look to have a conflicting conda version:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/833/pipeline
that's resulting in run failures after a few minutes (when an attempt is made to install conda).

This updates the conda version listed in the jenkins files in this repo to (try and) work around the conflict.

Regtests made it past the conflict and are now running at (I'll update this description when they finish but feel free to do the same if you see the run finished successfully).
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/834/pipeline

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
