### PR TITLE
Do not set conda version in Jenkinsfile(s)

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -79,7 +79,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'romancal'
 bc0.name = 'stable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
 bc0.conda_packages = [
     "python=${python_version}",
     "freetds",

--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -77,7 +77,6 @@ bc0 = new BuildConfig()
 bc0.nodetype = 'romancal'
 bc0.name = 'unstable-deps'
 bc0.env_vars = env_vars
-bc0.conda_ver = '22.11.1'
 bc0.conda_packages = [
     "python=${python_version}",
     "freetds",


### PR DESCRIPTION
* The version (24.x) installed by miniforge is sufficient. 22.x is too old.

Ref: https://github.com/spacetelescope/jenkins_shared_ci_utils/pull/94
Ref: https://github.com/spacetelescope/jwst/pull/8585