### PR TITLE
unpin webbpsf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "spherical-geometry >= 1.2.22",
     "stsci.imagestats >= 1.6.3",
     "drizzle >= 1.14.0",
-    "webbpsf == 1.2.1",
+    "webbpsf >= 1.2.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
This PR removes the exact pin for webbpsf. The pinned version is not numpy 2.0 compatible and is one of the limitations preventing romancal from using numpy 2.0:
https://github.com/spacetelescope/romancal/issues/1280

I pinged @bmorris3 to see if he recalls the reason for the exact pin in: https://github.com/spacetelescope/romancal/pull/841

This PR will test if removing the pin causes test failures.

Regression tests run with no errors at:
https://github.com/spacetelescope/RegressionTests/actions/runs/9652327358

Fixes https://github.com/spacetelescope/romancal/issues/1280

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
