### PR TITLE
Rcal 860 Allow roman datamodel as input to the exposure pipeline

### DIFF
--- a/romancal/datamodels/filetype.py
+++ b/romancal/datamodels/filetype.py
@@ -2,6 +2,8 @@ import io
 import os
 from pathlib import Path
 from typing import Union
+import roman_datamodels as rdm
+from romancal.datamodels import ModelContainer
 
 
 def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
@@ -17,7 +19,7 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
     Returns
     -------
     file_type: str
-        a string with the file type ("asdf" or "asn")
+        a string with the file type ("asdf", "asn", "DataModel", or "ModelContainer")
 
     """
 
@@ -41,6 +43,12 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
             return "asn"
 
         return ext
+    elif isinstance(init, rdm.DataModel):
+        return "DataModel"
+    
+    elif isinstance(init, ModelContainer):
+        return "ModelContainer"
+        
     elif hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)
         init.seek(0, 0)

--- a/romancal/datamodels/filetype.py
+++ b/romancal/datamodels/filetype.py
@@ -2,8 +2,6 @@ import io
 import os
 from pathlib import Path
 from typing import Union
-import roman_datamodels as rdm
-from romancal.datamodels import ModelContainer
 
 
 def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
@@ -19,7 +17,7 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
     Returns
     -------
     file_type: str
-        a string with the file type ("asdf", "asn", "DataModel", or "ModelContainer")
+        a string with the file type ("asdf" or "asn")
 
     """
 
@@ -43,12 +41,6 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
             return "asn"
 
         return ext
-    elif isinstance(init, rdm.DataModel):
-        return "DataModel"
-    
-    elif isinstance(init, ModelContainer):
-        return "ModelContainer"
-        
     elif hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)
         init.seek(0, 0)

--- a/romancal/datamodels/filetype.py
+++ b/romancal/datamodels/filetype.py
@@ -2,6 +2,8 @@ import io
 import os
 from pathlib import Path
 from typing import Union
+import roman_datamodels as rdm
+from romancal.datamodels import ModelContainer
 
 
 def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
@@ -17,11 +19,11 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
     Returns
     -------
     file_type: str
-        a string with the file type ("asdf" or "asn")
+        a string with the file type ("asdf", "asn", "DataModel", or "ModelContainer")
 
     """
 
-    supported = ("asdf", "json")
+    supported = ("asdf", "json", "DataModel")
 
     if isinstance(init, (str, os.PathLike, Path)):
         path, ext = os.path.splitext(init)
@@ -41,6 +43,12 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
             return "asn"
 
         return ext
+    elif isinstance(init, rdm.DataModel):
+        return "DataModel"
+    
+    elif isinstance(init, ModelContainer):
+        return "ModelContainer"
+        
     elif hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)
         init.seek(0, 0)

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import logging
 from os.path import basename
-import pdb
 
 import numpy as np
 from roman_datamodels import datamodels as rdm
@@ -76,7 +75,6 @@ class ExposurePipeline(RomanPipeline):
             input_filename = None
 
         # determine the input type
-        pdb.set_trace()
         file_type = filetype.check(input)
         if file_type == "asn":
             asn = ModelContainer.read_asn(input)
@@ -178,7 +176,6 @@ class ExposurePipeline(RomanPipeline):
             self.setup_output(result)
 
             self.output_use_model = True
-            pdb.set_trace()
             results.append(result)
 
         # Now that all the exposures are collated, run tweakreg

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import logging
 from os.path import basename
+import pdb
 
 import numpy as np
 from roman_datamodels import datamodels as rdm
@@ -74,12 +75,12 @@ class ExposurePipeline(RomanPipeline):
         else:
             input_filename = None
 
-        # open the input file
+        # determine the input type
+        pdb.set_trace()
         file_type = filetype.check(input)
         if file_type == "asn":
             asn = ModelContainer.read_asn(input)
-
-        if file_type == "asdf":
+        elif file_type == "asdf":
             try:
                 # set the product name based on the input filename
                 asn = asn_from_list([input], product_name=input_filename.split(".")[0])
@@ -92,23 +93,30 @@ class ExposurePipeline(RomanPipeline):
         expos_file = []
         n_members = 0
         # extract the members from the asn to run the files through the steps
-        for product in asn["products"]:
-            n_members = len(product["members"])
-            for member in product["members"]:
-                expos_file.append(member["expname"])
-
         results = ModelContainer()
         tweakreg_input = ModelContainer()
-        for in_file in expos_file:
-            if isinstance(in_file, str):
-                input_filename = basename(in_file)
-                log.info(f"Input file name: {input_filename}")
-            else:
-                input_filename = None
+        if file_type == 'asn':
+            for product in asn["products"]:
+                n_members = len(product["members"])
+                for member in product["members"]:
+                    expos_file.append(member["expname"])
 
-            # Open the file
-            input = rdm.open(in_file)
-            log.info(f"Processing a WFI exposure {in_file}")
+            #results = ModelContainer()
+            #tweakreg_input = ModelContainer()
+            for in_file in expos_file:
+                if isinstance(in_file, str):
+                    input_filename = basename(in_file)
+                    log.info(f"Input file name: {input_filename}")
+                else:
+                    input_filename = None
+        elif file_type == "DataModel":
+            in_file = input
+
+            # check to see if in_file is defined, if not assume we have a datamodel
+            if in_file is not None:
+                # Open the file 
+                input = rdm.open(in_file)
+                log.info(f"Processing a WFI exposure {in_file}")
 
             self.dq_init.suffix = "dq_init"
             result = self.dq_init(input)
@@ -170,6 +178,7 @@ class ExposurePipeline(RomanPipeline):
             self.setup_output(result)
 
             self.output_use_model = True
+            pdb.set_trace()
             results.append(result)
 
         # Now that all the exposures are collated, run tweakreg

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -1,6 +1,7 @@
 """ Roman tests for flat field correction """
 
 import copy
+import os
 
 import numpy as np
 import pytest
@@ -491,24 +492,28 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
     # Test Pipeline with input datamodel 
     output = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
     rtdata.output = output
-    ExposurePipeline.call(dm_input)
+    ExposurePipeline.call(dm_input, save_results = True)
     rtdata.get_truth(f"truth/WFI/image/{output}")
 
-    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    assert diff.identical, diff.report()
-
+    # check that the file exists ( don't duplicate checking contents done above)
+    pipeline = ExposurePipeline()
+    pipeline.log.info(
+        "Check that the output file exists   "
+        + passfail(os.path.isfile(rtdata.output))
+        )
+        
     # Ensure step completion is as expected
     model = rdm.open(rtdata.output)
 
     assert model.meta.cal_step.dq_init == "COMPLETE"
     assert model.meta.cal_step.saturation == "COMPLETE"
-    assert model.meta.cal_step.linearity == "SKIPPED"
-    assert model.meta.cal_step.dark == "SKIPPED"
-    assert model.meta.cal_step.jump == "SKIPPED"
-    assert model.meta.cal_step.ramp_fit == "SKIPPED"
-    assert model.meta.cal_step.assign_wcs == "SKIPPED"
-    assert model.meta.cal_step.flat_field == "SKIPPED"
-    assert model.meta.cal_step.photom == "SKIPPED"
+    assert model.meta.cal_step.linearity == "COMPLETE"
+    assert model.meta.cal_step.dark == "COMPLETE"
+    assert model.meta.cal_step.jump == "COMPLETE"
+    assert model.meta.cal_step.ramp_fit == "COMPLETE"
+    assert model.meta.cal_step.assign_wcs == "COMPLETE"
+    assert model.meta.cal_step.flat_field == "COMPLETE"
+    assert model.meta.cal_step.photom == "COMPLETE"
 
 
 @pytest.mark.bigdata

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -486,16 +486,12 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
     """Test for input roman Datamodel to exposure level pipeline"""
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
-    rtdata.input = rdm.open(input_data)
+    dm_input = rdm.open(rtdata.input)
 
-    # Test Pipeline
+    # Test Pipeline with input datamodel 
     output = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_cal.asdf"
     rtdata.output = output
-    args = [
-        "roman_elp",
-        rtdata.input,
-    ]
-    ExposurePipeline.from_cmdline(args)
+    ExposurePipeline.call(dm_input)
     rtdata.get_truth(f"truth/WFI/image/{output}")
 
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -489,7 +489,7 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
     dm_input = rdm.open(rtdata.input)
 
     # Test Pipeline with input datamodel 
-    output = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_cal.asdf"
+    output = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
     rtdata.output = output
     ExposurePipeline.call(dm_input)
     rtdata.get_truth(f"truth/WFI/image/{output}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-860](https://jira.stsci.edu/browse/RCAL-860)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1284 

<!-- describe the changes comprising this PR here -->
This PR allows the exposure pipeline to accept a roman datamodel as an input. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
The general regtests are failing at tweakreg (being worked on), https://github.com/spacetelescope/RegressionTests/actions/runs/9778658002/job/26996524484
But the test to see if the exposure pipeline accepts a roman data model is passing,
 https://github.com/spacetelescope/RegressionTests/actions/runs/9778307535

