### PR TITLE
Fix issue in constructing skycell WCS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,12 @@ stpipe
 - Add ``ModelContainer`` support to ``Step._datamodels_open`` to allow
   loading "pars-*" files from CRDS. [#1270]
 
+mosaic_pipeline
+---------------
+
+- Fix construction of skycell WCS.  [#1297]
+
+
 
 0.15.1 (2024-05-15)
 ===================

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -148,19 +148,19 @@ class MosaicPipeline(RomanPipeline):
         return result
 
 
-def generate_tan_wcs(skycell_record, shiftx=0, shifty=0):
+def generate_tan_wcs(skycell_record):
     # extract the wcs info from the record for generate_tan_wcs
     # we need the scale, ra, dec, bounding_box
 
     scale = float(skycell_record["pixel_scale"])
-    ra_center = float(skycell_record["ra_center"])
-    dec_center = float(skycell_record["dec_center"])
+    ra_center = float(skycell_record["ra_projection_center"])
+    dec_center = float(skycell_record["dec_projection_center"])
+    shiftx = float(skycell_record["x0_projection"])
+    shifty = float(skycell_record["y0_projection"])
     bounding_box = (
-        (-0.5, float(skycell_record["x_center"]) + 0.5),
-        (-0.5, float(skycell_record["y_center"]) + 0.5),
+        (-0.5, -0.5 + skycell_record['nx']),
+        (-0.5, -0.5 + skycell_record['ny']),
     )
-    shiftx = bounding_box[0][1]
-    shifty = bounding_box[1][1]
 
     # components of the model
     # shift = models.Shift(shiftx) & models.Shift(shifty)


### PR DESCRIPTION
This PR fixes some issues in the of the skycell WCS.

Formerly, the code used the center pixel of the WCS to mark the edge of the bounding box.  That meant that the bounding box only covered a quarter of the image, leading to issues.

The "shift" used to move from the projection center was also using the edge of the bounding box.  We now use the projection center in x/y coordinates.

This is intended to address an issue that @snbianco raised.  I've placed a new example L3 image at
/grp/roman/eschlafly/misc/r0099101001001001001_F158_visit_r274dp63x31y81_i2d.asdf
that should have this issue fixed, but please check!