### PR TITLE
use monkeypatch in tweakreg tests to prevent global setting change that causes other tests to fail

### DIFF
--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -1038,7 +1038,7 @@ def test_fit_results_in_meta(tmp_path, base_image):
     ]
 
 
-def test_tweakreg_returns_skipped_for_one_file(tmp_path, base_image):
+def test_tweakreg_returns_skipped_for_one_file(tmp_path, base_image, monkeypatch):
     """
     Test that TweakRegStep assigns meta.cal_step.tweakreg to "SKIPPED"
     when one image is provided but no alignment to a reference catalog is desired.
@@ -1047,7 +1047,7 @@ def test_tweakreg_returns_skipped_for_one_file(tmp_path, base_image):
     add_tweakreg_catalog_attribute(tmp_path, img)
 
     # disable alignment to absolute reference catalog
-    trs.ALIGN_TO_ABS_REFCAT = False
+    monkeypatch.setattr(trs, "ALIGN_TO_ABS_REFCAT", False)
     res = trs.TweakRegStep.call([img])
 
     assert all(x.meta.cal_step.tweakreg == "SKIPPED" for x in res)
@@ -1081,7 +1081,7 @@ def test_tweakreg_handles_multiple_groups(tmp_path, base_image):
     )
 
 
-def test_tweakreg_multiple_groups_valueerror(tmp_path, base_image):
+def test_tweakreg_multiple_groups_valueerror(tmp_path, base_image, monkeypatch):
     """
     Test that TweakRegStep throws an error when too few input images or
     groups of images with non-empty catalogs is provided.
@@ -1094,7 +1094,7 @@ def test_tweakreg_multiple_groups_valueerror(tmp_path, base_image):
     img1.meta.observation["program"] = "-program_id1"
     img2.meta.observation["program"] = "-program_id2"
 
-    trs.ALIGN_TO_ABS_REFCAT = False
+    monkeypatch.setattr(trs, "ALIGN_TO_ABS_REFCAT", False)
     res = trs.TweakRegStep.call([img1, img2])
 
     assert all(x.meta.cal_step.tweakreg == "SKIPPED" for x in res)


### PR DESCRIPTION
2 tests in tweakreg change the global "ALIGN_TO_ABS_REFCAT" flag. This can cause later tests run in the same process to fail when those tests expect absolute alignment to occur.
Here's an example run (using romancal main) with 1 of the offending tests and 1 dependent test showing the failure (tweakreg skip) caused by the global change:
https://github.com/spacetelescope/RegressionTests/actions/runs/9911986940

This PR uses `monkeypatch` to avoid changing the global state.

Here is a similar run as above (the 2 tests) with this PR:
https://github.com/spacetelescope/RegressionTests/actions/runs/9912169607
and a full regtest (with this PR) run with no errors:
https://github.com/spacetelescope/RegressionTests/actions/runs/9912060014

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
