### PR TITLE
remove pytest asdf plugin configuration for non-existant schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,6 @@ norecursedirs = [
 filterwarnings = [
     "error::ResourceWarning",
 ]
-asdf_schema_tests_enabled = true
-asdf_schema_validate_default = false
-asdf_schema_root = "romancal/datamodels/schemas"
 junit_family = "xunit2"
 inputs_root = "roman-pipeline"
 results_root = "roman-pipeline-results"


### PR DESCRIPTION
The `pyproject.toml` file contains configuration for the pytest asdf plugin (for testing schemas):
https://github.com/spacetelescope/romancal/blob/459e8e345bbb1ba6bfd76d0d8a90f2058089791e/pyproject.toml#L135-L137
However there is no `romancal/datamodels/schemas` (the schemas exist and are tested in rad).

This PR removes the unnecessary configuration.

With this PR pytest finds 854 test items:
https://github.com/spacetelescope/romancal/actions/runs/9958232059/job/27512161042?pr=1305#step:10:154
the same number is found on main:
https://github.com/spacetelescope/romancal/actions/runs/9893953303/job/27330394884#step:10:154
verifying that no schemas are found for testing and that the configuration removed in this PR was doing nothing (but was adding an implicit dependency on the asdf pytest plugin).

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
