### PR TITLE
show logs on failed tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ doctest_rst = "enabled"
 text_file_format = "rst"
 log_cli_level = "info"
 addopts = [
-    "--show-capture=no",
     "--doctest-ignore-import-errors",
     "--color=yes",
 ]


### PR DESCRIPTION
This PR allows pytest to show captured log messages for failed tests by removing `--show-capture=no` from the pytest options.

Regtests passed with no errors: https://github.com/spacetelescope/RegressionTests/actions/runs/9959656242

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
