### PR TITLE
Remove unnecessary global variable and unit tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ mosaic_pipeline
 
 - Fix construction of skycell WCS.  [#1297]
 
+tweakreg
+--------
+- Remove unnecessary global variable ALIGN_TO_ABS_REFCAT. [#1314]
+
 
 
 0.15.1 (2024-05-15)

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -1038,21 +1038,6 @@ def test_fit_results_in_meta(tmp_path, base_image):
     ]
 
 
-def test_tweakreg_returns_skipped_for_one_file(tmp_path, base_image):
-    """
-    Test that TweakRegStep assigns meta.cal_step.tweakreg to "SKIPPED"
-    when one image is provided but no alignment to a reference catalog is desired.
-    """
-    img = base_image(shift_1=1000, shift_2=1000)
-    add_tweakreg_catalog_attribute(tmp_path, img)
-
-    # disable alignment to absolute reference catalog
-    trs.ALIGN_TO_ABS_REFCAT = False
-    res = trs.TweakRegStep.call([img])
-
-    assert all(x.meta.cal_step.tweakreg == "SKIPPED" for x in res)
-
-
 def test_tweakreg_handles_multiple_groups(tmp_path, base_image):
     """
     Test that TweakRegStep can perform relative alignment for all images in the groups
@@ -1079,25 +1064,6 @@ def test_tweakreg_handles_multiple_groups(tmp_path, base_image):
         )
         for r, i in zip(res, [img1, img2])
     )
-
-
-def test_tweakreg_multiple_groups_valueerror(tmp_path, base_image):
-    """
-    Test that TweakRegStep throws an error when too few input images or
-    groups of images with non-empty catalogs is provided.
-    """
-    img1 = base_image(shift_1=1000, shift_2=1000)
-    img2 = base_image(shift_1=1000, shift_2=1000)
-    add_tweakreg_catalog_attribute(tmp_path, img1, catalog_filename="img1")
-    add_tweakreg_catalog_attribute(tmp_path, img2, catalog_filename="img2")
-
-    img1.meta.observation["program"] = "-program_id1"
-    img2.meta.observation["program"] = "-program_id2"
-
-    trs.ALIGN_TO_ABS_REFCAT = False
-    res = trs.TweakRegStep.call([img1, img2])
-
-    assert all(x.meta.cal_step.tweakreg == "SKIPPED" for x in res)
 
 
 @pytest.mark.parametrize(

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -39,7 +39,6 @@ def _oxford_or_str_join(str_list):
 SINGLE_GROUP_REFCAT = ["GAIADR3", "GAIADR2", "GAIADR1"]
 _SINGLE_GROUP_REFCAT_STR = _oxford_or_str_join(SINGLE_GROUP_REFCAT)
 DEFAULT_ABS_REFCAT = SINGLE_GROUP_REFCAT[0]
-ALIGN_TO_ABS_REFCAT = True
 
 __all__ = ["TweakRegStep"]
 
@@ -270,21 +269,7 @@ class TweakRegStep(RomanStep):
         self.log.info(f"Number of image groups to be aligned: {len(grp_img):d}.")
         self.log.info("Image groups:")
 
-        if len(grp_img) == 1 and not ALIGN_TO_ABS_REFCAT:
-            self.log.info("* Images in GROUP 1:")
-            for im in grp_img[0]:
-                self.log.info(f"     {im.meta.filename}")
-            self.log.info("")
-
-            # we need at least two exposures to perform image alignment
-            self.log.warning("At least two exposures are required for image alignment.")
-            self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
-            self.skip = True
-            for model in images:
-                model.meta.cal_step["tweakreg"] = "SKIPPED"
-            return input
-
-        elif len(grp_img) == 1 and ALIGN_TO_ABS_REFCAT:
+        if len(grp_img) == 1:
             # create a list of WCS-Catalog-Images Info and/or their Groups:
             g = grp_img[0]
             if len(g) == 0:
@@ -364,9 +349,6 @@ class TweakRegStep(RomanStep):
                     self.log.warning("Nothing to do. Skipping 'TweakRegStep'...")
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
-                    if not ALIGN_TO_ABS_REFCAT:
-                        self.skip = True
-                        return images
                 else:
                     raise e
 
@@ -404,112 +386,106 @@ class TweakRegStep(RomanStep):
 
                     for model in images:
                         model.meta.cal_step["tweakreg"] = "SKIPPED"
-                    if ALIGN_TO_ABS_REFCAT:
                         self.log.warning("Skipping relative alignment (stage 1)...")
-                    else:
-                        self.log.warning("Skipping 'TweakRegStep'...")
-                        self.skip = True
-                        return images
 
-        if ALIGN_TO_ABS_REFCAT:
-            # Get catalog of GAIA sources for the field
-            #
-            # NOTE:  If desired, the pipeline can write out the reference
-            #        catalog as a separate product with a name based on
-            #        whatever convention is determined by the JWST Cal Working
-            #        Group.
-            if self.save_abs_catalog:
-                output_name = os.path.join(
-                    self.catalog_path, f"fit_{self.abs_refcat.lower()}_ref.ecsv"
+        # Get catalog of GAIA sources for the field
+        #
+        # NOTE:  If desired, the pipeline can write out the reference
+        #        catalog as a separate product with a name based on
+        #        whatever convention is determined by the JWST Cal Working
+        #        Group.
+        if self.save_abs_catalog:
+            output_name = os.path.join(
+                self.catalog_path, f"fit_{self.abs_refcat.lower()}_ref.ecsv"
+            )
+        else:
+            output_name = None
+
+        # initial shift to be used with absolute astrometry
+        self.abs_xoffset = 0
+        self.abs_yoffset = 0
+
+        self.abs_refcat = self.abs_refcat.strip()
+        gaia_cat_name = self.abs_refcat.upper()
+
+        if gaia_cat_name in SINGLE_GROUP_REFCAT:
+            try:
+                ref_cat = amutils.create_astrometric_catalog(
+                    images, gaia_cat_name, output=output_name
                 )
-            else:
-                output_name = None
-
-            # initial shift to be used with absolute astrometry
-            self.abs_xoffset = 0
-            self.abs_yoffset = 0
-
-            self.abs_refcat = self.abs_refcat.strip()
-            gaia_cat_name = self.abs_refcat.upper()
-
-            if gaia_cat_name in SINGLE_GROUP_REFCAT:
-                try:
-                    ref_cat = amutils.create_astrometric_catalog(
-                        images, gaia_cat_name, output=output_name
-                    )
-                except Exception as e:
-                    self.log.warning(
-                        "TweakRegStep cannot proceed because of an error that "
-                        "occurred while fetching data from the VO server. "
-                        f"Returned error message: '{e}'"
-                    )
-                    self.log.warning("Skipping 'TweakRegStep'...")
-                    self.skip = True
-                    for model in images:
-                        model.meta.cal_step["tweakreg"] = "SKIPPED"
-                    return images
-
-            elif os.path.isfile(self.abs_refcat):
-                ref_cat = Table.read(self.abs_refcat)
-
-            else:
-                raise ValueError(
-                    "'abs_refcat' must be a path to an "
-                    "existing file name or one of the supported "
-                    f"reference catalogs: {_SINGLE_GROUP_REFCAT_STR}."
-                )
-
-            # Check that there are enough GAIA sources for a reliable/valid fit
-            num_ref = len(ref_cat)
-            if num_ref < self.abs_minobj:
-                # Raise Exception here to avoid rest of code in this try block
+            except Exception as e:
                 self.log.warning(
-                    f"Not enough sources ({num_ref}) in the reference catalog "
-                    "for the single-group alignment step to perform a fit. "
-                    f"Skipping alignment to the {self.abs_refcat} reference "
-                    "catalog!"
+                    "TweakRegStep cannot proceed because of an error that "
+                    "occurred while fetching data from the VO server. "
+                    f"Returned error message: '{e}'"
                 )
-            else:
-                # align images:
-                # Update to separation needed to prevent confusion of sources
-                # from overlapping images where centering is not consistent or
-                # for the possibility that errors still exist in relative overlap.
-                xyxymatch_gaia = XYXYMatch(
-                    searchrad=self.abs_searchrad,
-                    separation=self.abs_separation,
-                    use2dhist=self.abs_use2dhist,
-                    tolerance=self.abs_tolerance,
-                    xoffset=self.abs_xoffset,
-                    yoffset=self.abs_yoffset,
-                )
+                self.log.warning("Skipping 'TweakRegStep'...")
+                self.skip = True
+                for model in images:
+                    model.meta.cal_step["tweakreg"] = "SKIPPED"
+                return images
 
-                # Set group_id to same value so all get fit as one observation
-                # The assigned value, 987654, has been hard-coded to make it
-                # easy to recognize when alignment to GAIA was being performed
-                # as opposed to the group_id values used for relative alignment
-                # earlier in this step.
-                for imcat in imcats:
-                    imcat.meta["group_id"] = 987654
-                    if (
-                        "fit_info" in imcat.meta
-                        and "REFERENCE" in imcat.meta["fit_info"]["status"]
-                    ):
-                        del imcat.meta["fit_info"]
+        elif os.path.isfile(self.abs_refcat):
+            ref_cat = Table.read(self.abs_refcat)
 
-                # Perform fit
-                align_wcs(
-                    imcats,
-                    refcat=ref_cat,
-                    enforce_user_order=True,
-                    expand_refcat=False,
-                    minobj=self.abs_minobj,
-                    match=xyxymatch_gaia,
-                    fitgeom=self.abs_fitgeometry,
-                    nclip=self.abs_nclip,
-                    sigma=(self.abs_sigma, "rmse"),
-                    ref_tpwcs=imcats[0],
-                    clip_accum=True,
-                )
+        else:
+            raise ValueError(
+                "'abs_refcat' must be a path to an "
+                "existing file name or one of the supported "
+                f"reference catalogs: {_SINGLE_GROUP_REFCAT_STR}."
+            )
+
+        # Check that there are enough GAIA sources for a reliable/valid fit
+        num_ref = len(ref_cat)
+        if num_ref < self.abs_minobj:
+            # Raise Exception here to avoid rest of code in this try block
+            self.log.warning(
+                f"Not enough sources ({num_ref}) in the reference catalog "
+                "for the single-group alignment step to perform a fit. "
+                f"Skipping alignment to the {self.abs_refcat} reference "
+                "catalog!"
+            )
+        else:
+            # align images:
+            # Update to separation needed to prevent confusion of sources
+            # from overlapping images where centering is not consistent or
+            # for the possibility that errors still exist in relative overlap.
+            xyxymatch_gaia = XYXYMatch(
+                searchrad=self.abs_searchrad,
+                separation=self.abs_separation,
+                use2dhist=self.abs_use2dhist,
+                tolerance=self.abs_tolerance,
+                xoffset=self.abs_xoffset,
+                yoffset=self.abs_yoffset,
+            )
+
+            # Set group_id to same value so all get fit as one observation
+            # The assigned value, 987654, has been hard-coded to make it
+            # easy to recognize when alignment to GAIA was being performed
+            # as opposed to the group_id values used for relative alignment
+            # earlier in this step.
+            for imcat in imcats:
+                imcat.meta["group_id"] = 987654
+                if (
+                    "fit_info" in imcat.meta
+                    and "REFERENCE" in imcat.meta["fit_info"]["status"]
+                ):
+                    del imcat.meta["fit_info"]
+
+            # Perform fit
+            align_wcs(
+                imcats,
+                refcat=ref_cat,
+                enforce_user_order=True,
+                expand_refcat=False,
+                minobj=self.abs_minobj,
+                match=xyxymatch_gaia,
+                fitgeom=self.abs_fitgeometry,
+                nclip=self.abs_nclip,
+                sigma=(self.abs_sigma, "rmse"),
+                ref_tpwcs=imcats[0],
+                clip_accum=True,
+            )
 
         for imcat in imcats:
             image_model = imcat.meta["image_model"]()
@@ -520,15 +496,15 @@ class TweakRegStep(RomanStep):
                 # Update/create the WCS .name attribute with information
                 # on this astrometric fit as the only record that it was
                 # successful:
-                if ALIGN_TO_ABS_REFCAT:
-                    # NOTE: This .name attrib agreed upon by the JWST Cal
-                    #       Working Group.
-                    #       Current value is merely a place-holder based
-                    #       on HST conventions. This value should also be
-                    #       translated to the FITS WCSNAME keyword
-                    #       IF that is what gets recorded in the archive
-                    #       for end-user searches.
-                    imcat.wcs.name = f"FIT-LVL2-{self.abs_refcat}"
+
+                # NOTE: This .name attrib agreed upon by the JWST Cal
+                #       Working Group.
+                #       Current value is merely a place-holder based
+                #       on HST conventions. This value should also be
+                #       translated to the FITS WCSNAME keyword
+                #       IF that is what gets recorded in the archive
+                #       for end-user searches.
+                imcat.wcs.name = f"FIT-LVL2-{self.abs_refcat}"
 
                 # serialize object from tweakwcs
                 # (typecasting numpy objects to python types so that it doesn't cause an


### PR DESCRIPTION
Closes #1306 

This PR eliminates the global variable `ALIGN_TO_ABS_REFCAT` from `TweakRegStep` and the two unit tests that used it. Since `TweakRegStep` is always used for absolute astrometry, there is no need to have that global variable with fixed value.

**Regression Tests**
All tests are passing:
- https://github.com/spacetelescope/RegressionTests/actions/runs/9983530132

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [X] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
