### PR TITLE
provide formatter to log_records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "stcal>=1.7.3,<1.8.0",
     # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     #"stpipe >=0.5.0",
-    "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
+    "stpipe @ git+https://github.com/braingram/stpipe.git@log_records",
     "tweakwcs >=0.8.6",
     "spherical-geometry >= 1.2.22",
     "stsci.imagestats >= 1.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "stcal>=1.7.3,<1.8.0",
     # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     #"stpipe >=0.5.0",
-    "stpipe @ git+https://github.com/braingram/stpipe.git@log_records",
+    "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
     "tweakwcs >=0.8.6",
     "spherical-geometry >= 1.2.22",
     "stsci.imagestats >= 1.6.3",

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -35,6 +35,8 @@ class RomanStep(Step):
     output_ext =  string(default='.asdf')    # Default type of output
     """
 
+    _log_records_formatter = _LOG_FORMATTER
+
     @classmethod
     def _datamodels_open(cls, init, **kwargs):
         """
@@ -74,8 +76,8 @@ class RomanStep(Step):
         model.meta.calibration_software_version = importlib.metadata.version("romancal")
 
         if isinstance(model, (ImageModel, MosaicModel)):
-            for log_record in self.log_records:
-                model.cal_logs.append(_LOG_FORMATTER.format(log_record))
+            # convert to whatever type is model.mcal_logs to avoid validation errors
+            model.cal_logs = type(model.cal_logs)(self.log_records)
 
         if len(reference_files_used) > 0:
             for ref_name, ref_file in reference_files_used:

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -76,7 +76,7 @@ class RomanStep(Step):
         model.meta.calibration_software_version = importlib.metadata.version("romancal")
 
         if isinstance(model, (ImageModel, MosaicModel)):
-            # convert to whatever type is model.mcal_logs to avoid validation errors
+            # convert to model.cal_logs type to avoid validation errors
             model.cal_logs = type(model.cal_logs)(self.log_records)
 
         if len(reference_files_used) > 0:


### PR DESCRIPTION
Requires https://github.com/spacetelescope/stpipe/pull/171

Regression tests all pass:
https://github.com/spacetelescope/RegressionTests/actions/runs/10063338609/job/27821316132

See the above linked stpipe PR for more details.

During step runs, stpipe records log messages to `Step.log_records`. This can result in steady accumulation of memory as these are `LogRecord` instances that retain references to their arguments. That means that a log message like the following:
```python
log.info("Calibration array: %s", big_array)
```
Will prevent `big_array` from being garbage collected until the `Step` in which the log message occurred can be collected. One such problematic log message exists in stpipe (see the linked PR) which logs the input datamodel for a step.

Within the context of romancal, running the `elp` pipeline with romancal (and stpipe) main results on the `WFI/image/r0000101001001001001_01101_0001_WFI01_uncal.asdf` regression test file results in the following memory usage:
<img width="1100" alt="Screenshot 2024-07-23 at 4 01 20 PM" src="https://github.com/user-attachments/assets/66ef31c1-ea49-4e7c-93fc-3ac270f41073">
Note that the orange line has a steady upwards trend (with some steps resulting in transient memory peaks).
With this PR (and the stpipe PR) the memory usage peak is similar (this PR does nothing to reduce the memory for the high memory using steps) but the upward trend is removed:
<img width="1089" alt="Screenshot 2024-07-23 at 4 08 24 PM" src="https://github.com/user-attachments/assets/313a326b-6619-4577-b9a6-b8acb944470d">

Plan for merging
-----

Since romancal currently depends on stpipe main the merging of this PR and the stpipe PR https://github.com/spacetelescope/stpipe/pull/171 will require some coordination. One possible option is to update this PR to remove the dependency to my branch and then merge this PR immediately after the stpipe PR.

I've opened both PRs for review but please hold off merging until both PRs are ready to go.

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
