### PR TITLE
pin stpipe < 0.6.1 on 0.15.x release branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "scipy >=1.11",
     "stcal>=1.7.3,<1.8.0",
     # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
-    "stpipe >=0.5.0",
+    "stpipe >=0.5.0,<0.6.1",
     "tweakwcs >=0.8.6",
     "spherical-geometry >= 1.2.22",
     "stsci.imagestats >= 1.6.3",


### PR DESCRIPTION
See https://github.com/spacetelescope/stpipe/pull/174 for details about the stpipe 0.6.1 release.

The tldr is that it contains breaking changes to fix a memory leak. The changes are compatible with romancal main following https://github.com/spacetelescope/romancal/pull/1327 but as #1327 will not be backported to the released 0.15.x branch this PR adds an upper pin to allow the released versions of romancal to not use stpipe 0.6.1.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
