### PR TITLE
Revert "Bump actions/labeler from 4 to 5 (#1231)"

### DIFF
--- a/.github/workflows/label_pull_request.yml
+++ b/.github/workflows/label_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit 12b756ed501ebabf3e9dd30a842c7b4fb6e44021.

labeler v5 requires a different file format. See https://github.com/spacetelescope/jwst/pull/8117 for an example of migrating the configuration.

This PR reverts the version bump to v5 so we can continue to use the labeler CI (with version 4) until the configuration file can be updated.

Note that it is not expected that the labeler will run successfully with this PR since it is run as in a `pull_request_target` job which uses the configuration from the target (main) branch.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
