### PR TITLE
remove creation of stray fits file

### DIFF
--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -2,8 +2,6 @@
  Unit tests for the Roman source detection step code
 """
 
-import os
-import tempfile
 from copy import deepcopy
 
 import numpy as np
@@ -64,18 +62,12 @@ def setup_inputs(
         fov_pixels=15,
     )
 
-    dir_path = tempfile.gettempdir()
-    filename_prefix = f"psf_model_{webbpsf_config['filt']}"
-    file_path = os.path.join(dir_path, filename_prefix)
-
     # compute gridded PSF model:
     psf_model, centroids = create_gridded_psf_model(
-        file_path,
         webbpsf_config["filt"],
         webbpsf_config["detector"],
         oversample=webbpsf_config["oversample"],
         fov_pixels=webbpsf_config["fov_pixels"],
-        overwrite=True,
         logging_level="ERROR",
     )
 

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -4,7 +4,6 @@ Module to calculate the source catalog.
 
 import logging
 import warnings
-from pathlib import Path
 from typing import List
 
 import astropy.units as u
@@ -1172,12 +1171,9 @@ class RomanSourceCatalog:
             filt = self.model.meta.basic.optical_element
             detector = "SCA02"
         # prefix of the temporary FITS file that will contain the gridded PSF model
-        path_prefix = "tmp"
         gridded_psf_model, _ = psf.create_gridded_psf_model(
-            path_prefix=path_prefix,
             filt=filt,
             detector=detector,
-            overwrite=True,
             logging_level="ERROR",
         )
 
@@ -1199,11 +1195,6 @@ class RomanSourceCatalog:
         # append PSF results to the class instance with the proper column name
         for old_name, new_name in old_name_to_new_name_mapping.items():
             setattr(self, new_name, psf_photometry_table[old_name])
-
-        # remove temporary file containing gridded_psf_model
-        filepath = Path().cwd().glob(f"{path_prefix}*{detector.lower()}*.fits")
-        for filename in filepath:
-            filename.unlink(missing_ok=True)
 
     @lazyproperty
     def catalog(self):

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -166,10 +166,8 @@ class SourceDetectionStep(RomanStep):
                 log.info("Constructing a gridded PSF model.")
                 detector = input_model.meta.instrument["detector"].replace("WFI", "SCA")
                 gridded_psf_model, _ = psf.create_gridded_psf_model(
-                    path_prefix="tmp",
                     filt=filt,
                     detector=detector,
-                    overwrite=True,
                     logging_level="ERROR",
                 )
 


### PR DESCRIPTION
Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/10165236470

This PR removes the creation of a `fits` file during `create_gridded_psf_model`.

Closes #1328

Local testing running `roman_elp` (which previously produced a `tmp_sca01.fits`) shows that the stray `fits` file is no longer produced with this PR.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
