### PR TITLE
Remove uses of `lazy_load=False`, update step input handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ general
 
 - Replace ModelContainer with ModelLibrary [#1241]
 
+- Refactor general step input handling to avoid early closing of
+  input files to allow using more lazy loading [#1342]
+
 
 source_catalog
 --------------

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -29,21 +29,25 @@ class AssignWcsStep(RomanStep):
 
     def process(self, input):
         reference_file_names = {}
-        with rdm.open(input) as input_model:
-            for reftype in self.reference_file_types:
-                log.info(f"reftype, {reftype}")
-                reffile = self.get_reference_file(input_model, reftype)
-                # Check for a valid reference file
-                if reffile == "N/A":
-                    self.log.warning("No DISTORTION reference file found")
-                    self.log.warning("Assign WCS step will be skipped")
-                    result = input_model.copy()
-                    result.meta.cal_step.assign_wcs = "SKIPPED"
-                    return result
+        if isinstance(input, rdm.DataModel):
+            input_model = input
+        else:
+            input_model = rdm.open(input)
 
-                reference_file_names[reftype] = reffile if reffile else ""
-            log.info("Using reference files: %s for assign_wcs", reference_file_names)
-            result = load_wcs(input_model, reference_file_names)
+        for reftype in self.reference_file_types:
+            log.info(f"reftype, {reftype}")
+            reffile = self.get_reference_file(input_model, reftype)
+            # Check for a valid reference file
+            if reffile == "N/A":
+                self.log.warning("No DISTORTION reference file found")
+                self.log.warning("Assign WCS step will be skipped")
+                result = input_model.copy()
+                result.meta.cal_step.assign_wcs = "SKIPPED"
+                return result
+
+            reference_file_names[reftype] = reffile if reffile else ""
+        log.info("Using reference files: %s for assign_wcs", reference_file_names)
+        result = load_wcs(input_model, reference_file_names)
 
         if self.save_results:
             try:

--- a/romancal/assign_wcs/assign_wcs_step.py
+++ b/romancal/assign_wcs/assign_wcs_step.py
@@ -29,7 +29,7 @@ class AssignWcsStep(RomanStep):
 
     def process(self, input):
         reference_file_names = {}
-        with rdm.open(input, lazy_load=False) as input_model:
+        with rdm.open(input) as input_model:
             for reftype in self.reference_file_types:
                 log.info(f"reftype, {reftype}")
                 reffile = self.get_reference_file(input_model, reftype)

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -21,7 +21,7 @@ class DarkCurrentStep(RomanStep):
 
     def process(self, input):
         # Open the input data model
-        with rdm.open(input, lazy_load=False) as input_model:
+        with rdm.open(input) as input_model:
             # Get the name of the dark reference file to use
             self.dark_name = self.get_reference_file(input_model, "dark")
             # Check for a valid reference file

--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -20,23 +20,26 @@ class DarkCurrentStep(RomanStep):
     reference_file_types = ["dark"]
 
     def process(self, input):
-        # Open the input data model
-        with rdm.open(input) as input_model:
-            # Get the name of the dark reference file to use
-            self.dark_name = self.get_reference_file(input_model, "dark")
-            # Check for a valid reference file
-            if self.dark_name == "N/A":
-                self.log.warning("No DARK reference file found")
-                self.log.warning("Dark current step will be skipped")
-                result = input_model
-                result.meta.cal_step.dark = "SKIPPED"
-                return result
+        if isinstance(input, rdm.DataModel):
+            input_model = input
+        else:
+            # Open the input data model
+            input_model = rdm.open(input)
 
-            self.log.info("Using DARK reference file: %s", self.dark_name)
+        # Get the name of the dark reference file to use
+        self.dark_name = self.get_reference_file(input_model, "dark")
+        # Check for a valid reference file
+        if self.dark_name == "N/A":
+            self.log.warning("No DARK reference file found")
+            self.log.warning("Dark current step will be skipped")
+            result = input_model
+            result.meta.cal_step.dark = "SKIPPED"
+            return result
 
-            # Open dark model
-            dark_model = rdm.open(self.dark_name)
+        self.log.info("Using DARK reference file: %s", self.dark_name)
 
+        # Open dark model
+        with rdm.open(self.dark_name) as dark_model:
             # Temporary patch to utilize stcal dark step until MA table support
             # is fully implemented
             if "ngroups" not in dark_model.meta.exposure:
@@ -59,11 +62,11 @@ class DarkCurrentStep(RomanStep):
             if self.dark_output is not None:
                 dark_model.save(self.dark_output)
                 # not clear to me that this makes any sense for Roman
-            dark_model.close()
 
         if self.save_results:
             try:
                 self.suffix = "darkcurrent"
             except AttributeError:
                 self["suffix"] = "darkcurrent"
+
         return out_model

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -38,7 +38,7 @@ class DQInitStep(RomanStep):
             result roman datamodel
         """
         # Open datamodel
-        input_model = rdm.open(input, lazy_load=False)
+        input_model = rdm.open(input)
 
         # Convert to RampModel
         output_model = RampModel.from_science_raw(input_model)

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -16,7 +16,7 @@ class FlatFieldStep(RomanStep):
     reference_file_types = ["flat"]
 
     def process(self, input_model):
-        input_model = rdm.open(input_model, lazy_load=False)
+        input_model = rdm.open(input_model)
 
         reference_file_name = self.get_reference_file(input_model, "flat")
 

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -16,7 +16,8 @@ class FlatFieldStep(RomanStep):
     reference_file_types = ["flat"]
 
     def process(self, input_model):
-        input_model = rdm.open(input_model)
+        if not isinstance(input_model, rdm.DataModel):
+            input_model = rdm.open(input_model)
 
         reference_file_name = self.get_reference_file(input_model, "flat")
 
@@ -39,12 +40,9 @@ class FlatFieldStep(RomanStep):
             reference_file_model,
         )
 
-        # Close the input and reference files
-        input_model.close()
-        try:
+        # Close reference file
+        if reference_file_model is not None:
             reference_file_model.close()
-        except AttributeError:
-            pass
 
         if self.save_results:
             try:

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -47,7 +47,7 @@ class JumpStep(RomanStep):
     def process(self, input):
         # Open input as a Roman DataModel (single integration; 3D arrays)
 
-        with rdd.open(input, lazy_load=False) as input_model:
+        with rdd.open(input) as input_model:
             # Extract the needed info from the Roman Data Model
             meta = input_model.meta
             r_data = input_model.data.value

--- a/romancal/jump/jump_step.py
+++ b/romancal/jump/jump_step.py
@@ -46,117 +46,120 @@ class JumpStep(RomanStep):
 
     def process(self, input):
         # Open input as a Roman DataModel (single integration; 3D arrays)
+        if isinstance(input, rdd.DataModel):
+            input_model = input
+        else:
+            input_model = rdd.open(input)
 
-        with rdd.open(input) as input_model:
-            # Extract the needed info from the Roman Data Model
-            meta = input_model.meta
-            r_data = input_model.data.value
-            r_gdq = input_model.groupdq
-            r_pdq = input_model.pixeldq
-            r_err = input_model.err.value
+        # Extract the needed info from the Roman Data Model
+        meta = input_model.meta
+        r_data = input_model.data.value
+        r_gdq = input_model.groupdq
+        r_pdq = input_model.pixeldq
+        r_err = input_model.err.value
+        result = input_model
+
+        # If the ramp fitting jump detection is enabled, then skip this step
+        if self.use_ramp_jump_detection:
+            result.meta.cal_step.jump = "SKIPPED"
+            return result
+
+        frames_per_group = meta.exposure.nframes
+
+        # Modify the arrays for input into the 'common' jump (4D)
+        data = np.copy(r_data[np.newaxis, :])
+        gdq = r_gdq[np.newaxis, :]
+        pdq = r_pdq[np.newaxis, :]
+        err = np.copy(r_err[np.newaxis, :])
+
+        tstart = time.time()
+
+        # Check for an input model with NGROUPS<=2
+        ngroups = data.shape[1]
+
+        if ngroups <= 2:
+            self.log.warning("Cannot apply jump detection as NGROUPS<=2;")
+            self.log.warning("Jump step will be skipped")
+
             result = input_model
 
-            # If the ramp fitting jump detection is enabled, then skip this step
-            if self.use_ramp_jump_detection:
-                result.meta.cal_step.jump = "SKIPPED"
-                return result
+            result.meta.cal_step.jump = "SKIPPED"
+            return result
 
-            frames_per_group = meta.exposure.nframes
+        # Retrieve the parameter values
+        rej_thresh = self.rejection_threshold
+        three_grp_rej_thresh = self.three_group_rejection_threshold
+        four_grp_rej_thresh = self.four_group_rejection_threshold
+        max_cores = self.maximum_cores
+        max_jump_to_flag_neighbors = self.max_jump_to_flag_neighbors
+        min_jump_to_flag_neighbors = self.min_jump_to_flag_neighbors
+        flag_4_neighbors = self.flag_4_neighbors
+        min_sat_area = self.min_sat_area
+        min_jump_area = self.min_jump_area
+        expand_factor = self.expand_factor
+        use_ellipses = self.use_ellipses
+        sat_required_snowball = self.sat_required_snowball
+        expand_large_events = self.expand_large_events
 
-            # Modify the arrays for input into the 'common' jump (4D)
-            data = np.copy(r_data[np.newaxis, :])
-            gdq = r_gdq[np.newaxis, :]
-            pdq = r_pdq[np.newaxis, :]
-            err = np.copy(r_err[np.newaxis, :])
+        self.log.info("CR rejection threshold = %g sigma", rej_thresh)
+        if self.maximum_cores != "none":
+            self.log.info("Maximum cores to use = %s", max_cores)
 
-            tstart = time.time()
+        # Get the gain and readnoise reference files
+        gain_filename = self.get_reference_file(input_model, "gain")
+        self.log.info("Using GAIN reference file: %s", gain_filename)
+        gain_model = rdd.GainRefModel(gain_filename)
+        gain_2d = gain_model.data.value
 
-            # Check for an input model with NGROUPS<=2
-            ngroups = data.shape[1]
+        readnoise_filename = self.get_reference_file(input_model, "readnoise")
+        self.log.info("Using READNOISE reference file: %s", readnoise_filename)
+        readnoise_model = rdd.ReadnoiseRefModel(readnoise_filename)
+        # This is to clear the WRITEABLE=False flag?
+        readnoise_2d = np.copy(readnoise_model.data.value)
 
-            if ngroups <= 2:
-                self.log.warning("Cannot apply jump detection as NGROUPS<=2;")
-                self.log.warning("Jump step will be skipped")
+        # DG 0810/21:  leave for now; make dqflags changes in a later,
+        #              separate PR
+        dqflags_d = {}  # Dict of DQ flags
+        dqflags_d = {
+            "GOOD": group.GOOD,
+            "DO_NOT_USE": group.DO_NOT_USE,
+            "SATURATED": group.SATURATED,
+            "JUMP_DET": group.JUMP_DET,
+            "NO_GAIN_VALUE": pixel.NO_GAIN_VALUE,
+        }
 
-                result = input_model
+        gdq, pdq, *_ = detect_jumps(
+            frames_per_group,
+            data,
+            gdq,
+            pdq,
+            err,
+            gain_2d,
+            readnoise_2d,
+            rej_thresh,
+            three_grp_rej_thresh,
+            four_grp_rej_thresh,
+            max_cores,
+            max_jump_to_flag_neighbors,
+            min_jump_to_flag_neighbors,
+            flag_4_neighbors,
+            dqflags_d,
+            min_sat_area=min_sat_area,
+            min_jump_area=min_jump_area,
+            expand_factor=expand_factor,
+            use_ellipses=use_ellipses,
+            sat_required_snowball=sat_required_snowball,
+            expand_large_events=expand_large_events,
+        )
 
-                result.meta.cal_step.jump = "SKIPPED"
-                return result
-
-            # Retrieve the parameter values
-            rej_thresh = self.rejection_threshold
-            three_grp_rej_thresh = self.three_group_rejection_threshold
-            four_grp_rej_thresh = self.four_group_rejection_threshold
-            max_cores = self.maximum_cores
-            max_jump_to_flag_neighbors = self.max_jump_to_flag_neighbors
-            min_jump_to_flag_neighbors = self.min_jump_to_flag_neighbors
-            flag_4_neighbors = self.flag_4_neighbors
-            min_sat_area = self.min_sat_area
-            min_jump_area = self.min_jump_area
-            expand_factor = self.expand_factor
-            use_ellipses = self.use_ellipses
-            sat_required_snowball = self.sat_required_snowball
-            expand_large_events = self.expand_large_events
-
-            self.log.info("CR rejection threshold = %g sigma", rej_thresh)
-            if self.maximum_cores != "none":
-                self.log.info("Maximum cores to use = %s", max_cores)
-
-            # Get the gain and readnoise reference files
-            gain_filename = self.get_reference_file(input_model, "gain")
-            self.log.info("Using GAIN reference file: %s", gain_filename)
-            gain_model = rdd.GainRefModel(gain_filename)
-            gain_2d = gain_model.data.value
-
-            readnoise_filename = self.get_reference_file(input_model, "readnoise")
-            self.log.info("Using READNOISE reference file: %s", readnoise_filename)
-            readnoise_model = rdd.ReadnoiseRefModel(readnoise_filename)
-            # This is to clear the WRITEABLE=False flag?
-            readnoise_2d = np.copy(readnoise_model.data.value)
-
-            # DG 0810/21:  leave for now; make dqflags changes in a later,
-            #              separate PR
-            dqflags_d = {}  # Dict of DQ flags
-            dqflags_d = {
-                "GOOD": group.GOOD,
-                "DO_NOT_USE": group.DO_NOT_USE,
-                "SATURATED": group.SATURATED,
-                "JUMP_DET": group.JUMP_DET,
-                "NO_GAIN_VALUE": pixel.NO_GAIN_VALUE,
-            }
-
-            gdq, pdq, *_ = detect_jumps(
-                frames_per_group,
-                data,
-                gdq,
-                pdq,
-                err,
-                gain_2d,
-                readnoise_2d,
-                rej_thresh,
-                three_grp_rej_thresh,
-                four_grp_rej_thresh,
-                max_cores,
-                max_jump_to_flag_neighbors,
-                min_jump_to_flag_neighbors,
-                flag_4_neighbors,
-                dqflags_d,
-                min_sat_area=min_sat_area,
-                min_jump_area=min_jump_area,
-                expand_factor=expand_factor,
-                use_ellipses=use_ellipses,
-                sat_required_snowball=sat_required_snowball,
-                expand_large_events=expand_large_events,
-            )
-
-            gdq = gdq[0, :, :, :]
-            pdq = pdq[0, :, :]
-            result.groupdq = gdq
-            result.pixeldq = pdq
-            gain_model.close()
-            readnoise_model.close()
-            tstop = time.time()
-            self.log.info("The execution time in seconds: %f", tstop - tstart)
+        gdq = gdq[0, :, :, :]
+        pdq = pdq[0, :, :]
+        result.groupdq = gdq
+        result.pixeldq = pdq
+        gain_model.close()
+        readnoise_model.close()
+        tstop = time.time()
+        self.log.info("The execution time in seconds: %f", tstop - tstart)
 
         result.meta.cal_step.jump = "COMPLETE"
 

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -23,7 +23,7 @@ class LinearityStep(RomanStep):
 
     def process(self, input):
         # Open the input data model
-        with rdd.open(input, lazy_load=False) as input_model:
+        with rdd.open(input) as input_model:
             # Get the name of the linearity reference file to use
             self.lin_name = self.get_reference_file(input_model, "linearity")
             self.log.info("Using LINEARITY reference file: %s", self.lin_name)

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -23,21 +23,24 @@ class LinearityStep(RomanStep):
 
     def process(self, input):
         # Open the input data model
-        with rdd.open(input) as input_model:
-            # Get the name of the linearity reference file to use
-            self.lin_name = self.get_reference_file(input_model, "linearity")
-            self.log.info("Using LINEARITY reference file: %s", self.lin_name)
+        if isinstance(input, rdd.DataModel):
+            input_model = input
+        else:
+            input_model = rdd.open(input)
 
-            # Check for a valid reference file
-            if self.lin_name == "N/A":
-                self.log.warning("No LINEARITY reference file found")
-                self.log.warning("Linearity step will be skipped")
-                input_model.meta.cal_step["linearity"] = "SKIPPED"
+        # Get the name of the linearity reference file to use
+        self.lin_name = self.get_reference_file(input_model, "linearity")
+        self.log.info("Using LINEARITY reference file: %s", self.lin_name)
 
-                return input_model
+        # Check for a valid reference file
+        if self.lin_name == "N/A":
+            self.log.warning("No LINEARITY reference file found")
+            self.log.warning("Linearity step will be skipped")
+            input_model.meta.cal_step["linearity"] = "SKIPPED"
 
-            lin_model = rdd.LinearityRefModel(self.lin_name, memmap=False)
+            return input_model
 
+        with rdd.LinearityRefModel(self.lin_name, memmap=False) as lin_model:
             # copy poly coeffs from linearity model so Nan's can be updated
             lin_coeffs = lin_model.coeffs
             lin_dq = lin_model.dq  # 2D pixeldq from linearity model
@@ -61,9 +64,8 @@ class LinearityStep(RomanStep):
             )
             input_model.pixeldq = new_pdq
 
-            # Close the reference file and update the step status
-            lin_model.close()
-            input_model.meta.cal_step["linearity"] = "COMPLETE"
+        # Update the step status
+        input_model.meta.cal_step["linearity"] = "COMPLETE"
 
         if self.save_results:
             try:

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -30,44 +30,43 @@ class PhotomStep(RomanStep):
             output roman datamodel
         """
 
-        # Open the input data model
-        with rdm.open(input) as input_model:
-            # Get reference file
-            reffile = self.get_reference_file(input_model, "photom")
+        if isinstance(input, rdm.DataModel):
+            input_model = input
+        else:
+            input_model = rdm.open(input)
 
-            # Open the relevant photom reference file as a datamodel
-            if reffile is not None and reffile != "N/A":
-                # If there is a reference file, perform photom application
-                photom_model = rdm.open(reffile)
-                self.log.debug(f"Using PHOTOM ref file: {reffile}")
+        # Get reference file
+        reffile = self.get_reference_file(input_model, "photom")
 
-                # Do the correction
-                if input_model.meta.exposure.type == "WFI_IMAGE":
-                    output_model = photom.apply_photom(input_model, photom_model)
-                    output_model.meta.cal_step.photom = "COMPLETE"
-                else:
-                    self.log.warning("No photometric corrections for spectral data")
-                    self.log.warning("Photom step will be skipped")
-                    input_model.meta.cal_step.photom = "SKIPPED"
-                    input_model.meta.photometry.pixelarea_arcsecsq = None
-                    input_model.meta.photometry.pixelarea_steradians = None
-                    input_model.meta.photometry.conversion_megajanskys = None
-                    input_model.meta.photometry.conversion_microjanskys = None
-                    input_model.meta.photometry.conversion_megajanskys_uncertainty = (
-                        None
-                    )
-                    input_model.meta.photometry.conversion_microjanskys_uncertainty = (
-                        None
-                    )
-                    output_model = input_model
-                photom_model.close()
+        # Open the relevant photom reference file as a datamodel
+        if reffile is not None and reffile != "N/A":
+            # If there is a reference file, perform photom application
+            photom_model = rdm.open(reffile)
+            self.log.debug(f"Using PHOTOM ref file: {reffile}")
 
+            # Do the correction
+            if input_model.meta.exposure.type == "WFI_IMAGE":
+                output_model = photom.apply_photom(input_model, photom_model)
+                output_model.meta.cal_step.photom = "COMPLETE"
             else:
-                # Skip Photom step if no photom file
-                self.log.warning("No PHOTOM reference file found")
+                self.log.warning("No photometric corrections for spectral data")
                 self.log.warning("Photom step will be skipped")
                 input_model.meta.cal_step.photom = "SKIPPED"
+                input_model.meta.photometry.pixelarea_arcsecsq = None
+                input_model.meta.photometry.pixelarea_steradians = None
+                input_model.meta.photometry.conversion_megajanskys = None
+                input_model.meta.photometry.conversion_microjanskys = None
+                input_model.meta.photometry.conversion_megajanskys_uncertainty = None
+                input_model.meta.photometry.conversion_microjanskys_uncertainty = None
                 output_model = input_model
+            photom_model.close()
+
+        else:
+            # Skip Photom step if no photom file
+            self.log.warning("No PHOTOM reference file found")
+            self.log.warning("Photom step will be skipped")
+            input_model.meta.cal_step.photom = "SKIPPED"
+            output_model = input_model
 
         if self.save_results:
             try:

--- a/romancal/photom/photom_step.py
+++ b/romancal/photom/photom_step.py
@@ -31,7 +31,7 @@ class PhotomStep(RomanStep):
         """
 
         # Open the input data model
-        with rdm.open(input, lazy_load=False) as input_model:
+        with rdm.open(input) as input_model:
             # Get reference file
             reffile = self.get_reference_file(input_model, "photom")
 

--- a/romancal/refpix/refpix_step.py
+++ b/romancal/refpix/refpix_step.py
@@ -37,7 +37,10 @@ class RefPixStep(RomanStep):
 
         # open the input data model
         log.debug(f"Opening the science data: {input}")
-        datamodel = rdm.open(input)
+        if isinstance(input, rdm.DataModel):
+            datamodel = input
+        else:
+            datamodel = rdm.open(input)
 
         # Get the reference file
         ref_file = self.get_reference_file(datamodel, "refpix")

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -754,7 +754,6 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
     # closed asdf file. To try and avoid that we disable
     # lazy loading and memmory mapping
     open_kwargs = {
-        "lazy_load": False,
         "memmap": False,
     }
     with (

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -68,7 +68,7 @@ def test_level3_mos_pipeline(rtdata, ignore_asdf_paths):
 
     # Perform DMS tests
     # Initial prep
-    model = rdm.open(rtdata.output, lazy_load=False)
+    model = rdm.open(rtdata.output)
     pipeline = MosaicPipeline()
 
     # DMS356 result is an ImageModel

--- a/romancal/regtest/test_wfi_16resultants.py
+++ b/romancal/regtest/test_wfi_16resultants.py
@@ -39,8 +39,8 @@ def test_16resultants_image_processing(rtdata, ignore_asdf_paths):
     # Initial prep
     pipeline = ExposurePipeline()
     # rtdata.get_data(f"WFI/image/{output}")
-    model = rdm.open(output, lazy_load=False)
-    uncal_data = rdm.open(input_data, lazy_load=False)
+    model = rdm.open(output)
+    uncal_data = rdm.open(input_data)
 
     # DMS280 result is an ImageModel
     pipeline.log.info(
@@ -95,8 +95,8 @@ def test_16resultants_spectral_processing(rtdata, ignore_asdf_paths):
     # Initial prep
     pipeline = ExposurePipeline()
     # rtdata.get_data(f"WFI/image/{output}")
-    model = rdm.open(output, lazy_load=False)
-    uncal_data = rdm.open(input_data, lazy_load=False)
+    model = rdm.open(output)
+    uncal_data = rdm.open(input_data)
 
     # DMS280 result is an ImageModel
     pipeline.log.info(

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -47,7 +47,7 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
 
     # Perform DMS tests
     # Initial prep
-    model = rdm.open(rtdata.output, lazy_load=False)
+    model = rdm.open(rtdata.output)
     pipeline = ExposurePipeline()
 
     # DMS280 result is an ImageModel
@@ -294,7 +294,7 @@ def test_level2_grism_processing_pipeline(rtdata, ignore_asdf_paths):
 
     # Perform DMS tests
     # Initial prep
-    model = rdm.open(rtdata.output, lazy_load=False)
+    model = rdm.open(rtdata.output)
     pipeline = ExposurePipeline()
 
     # DMS90 instrument artifact correction tests

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -17,35 +17,39 @@ class SaturationStep(RomanStep):
     reference_file_types = ["saturation"]
 
     def process(self, input):
-        # Open the input data model
-        with rdm.open(input) as input_model:
-            # Get the name of the saturation reference file
-            self.ref_name = self.get_reference_file(input_model, "saturation")
+        if isinstance(input, rdm.DataModel):
+            input_model = input
+        else:
+            # Open the input data model
+            input_model = rdm.open(input)
 
-            # Check for a valid reference file
-            if self.ref_name == "N/A":
-                self.log.warning("No SATURATION reference file found")
-                self.log.warning("Saturation step will be skipped")
-                result = input_model.copy()
-                result.meta.cal_step.saturation = "SKIPPED"
-                return result
+        # Get the name of the saturation reference file
+        self.ref_name = self.get_reference_file(input_model, "saturation")
 
-            # Open the reference file data model
-            # Test for reference file
-            self.log.info("Using SATURATION reference file: %s", self.ref_name)
-            ref_model = SaturationRefModel(self.ref_name)
+        # Check for a valid reference file
+        if self.ref_name == "N/A":
+            self.log.warning("No SATURATION reference file found")
+            self.log.warning("Saturation step will be skipped")
+            result = input_model.copy()
+            result.meta.cal_step.saturation = "SKIPPED"
+            return result
 
-            # Perform saturation check
-            sat = saturation.flag_saturation(input_model, ref_model)
+        # Open the reference file data model
+        # Test for reference file
+        self.log.info("Using SATURATION reference file: %s", self.ref_name)
+        ref_model = SaturationRefModel(self.ref_name)
 
-            # Close the reference file and update the step status
-            ref_model.close()
-            sat.meta.cal_step.saturation = "COMPLETE"
+        # Perform saturation check
+        sat = saturation.flag_saturation(input_model, ref_model)
 
-            if self.save_results:
-                try:
-                    self.suffix = "saturation"
-                except AttributeError:
-                    self["suffix"] = "saturation"
+        # Close the reference file and update the step status
+        ref_model.close()
+        sat.meta.cal_step.saturation = "COMPLETE"
+
+        if self.save_results:
+            try:
+                self.suffix = "saturation"
+            except AttributeError:
+                self["suffix"] = "saturation"
 
         return sat

--- a/romancal/saturation/saturation_step.py
+++ b/romancal/saturation/saturation_step.py
@@ -18,7 +18,7 @@ class SaturationStep(RomanStep):
 
     def process(self, input):
         # Open the input data model
-        with rdm.open(input, lazy_load=False) as input_model:
+        with rdm.open(input) as input_model:
             # Get the name of the saturation reference file
             self.ref_name = self.get_reference_file(input_model, "saturation")
 

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -72,7 +72,7 @@ class SourceDetectionStep(RomanStep):
     """
 
     def process(self, input):
-        with rdm.open(input, lazy_load=False) as input_model:
+        with rdm.open(input) as input_model:
             if input_model.meta.exposure.type != "WFI_IMAGE":
                 # Check to see if attempt to find sources in non-Image data
                 log.info("Skipping source detection for spectral exposure.")

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -72,168 +72,170 @@ class SourceDetectionStep(RomanStep):
     """
 
     def process(self, input):
-        with rdm.open(input) as input_model:
-            if input_model.meta.exposure.type != "WFI_IMAGE":
-                # Check to see if attempt to find sources in non-Image data
-                log.info("Skipping source detection for spectral exposure.")
-                input_model.meta.cal_step.source_detection = "SKIPPED"
-                return input_model
+        if isinstance(input, rdm.DataModel):
+            input_model = input
+        else:
+            input_model = rdm.open(input)
 
-            # remove units from data in this step.
-            # DAOStarFinder requires unitless input
-            if hasattr(input_model.data, "unit"):
-                self.data = input_model.data.value
-            else:
-                self.data = input_model.data
+        if input_model.meta.exposure.type != "WFI_IMAGE":
+            # Check to see if attempt to find sources in non-Image data
+            log.info("Skipping source detection for spectral exposure.")
+            input_model.meta.cal_step.source_detection = "SKIPPED"
+            return input_model
 
-            # mask DO_NOT_USE pixels
+        # remove units from data in this step.
+        # DAOStarFinder requires unitless input
+        if hasattr(input_model.data, "unit"):
+            self.data = input_model.data.value
+        else:
+            self.data = input_model.data
 
-            self.coverage_mask = ((pixel.DO_NOT_USE) & input_model.dq).astype(bool)
+        # mask DO_NOT_USE pixels
 
-            filt = input_model.meta.instrument["optical_element"]
+        self.coverage_mask = ((pixel.DO_NOT_USE) & input_model.dq).astype(bool)
 
-            # if a pre-determined threshold value for detection for the whole
-            # image is provided, use this
-            if self.scalar_threshold is not None:
-                threshold = float(self.scalar_threshold)
-                log.info(f"Using a detection threshold of {threshold}.")
+        filt = input_model.meta.instrument["optical_element"]
 
-            # otherwise, if specified, calculate a scalar threshold from the
-            # image by calculating a 2D background image, using this to create
-            # a 2d threshold image, and using the median of the 2d threshold
-            # image as the scalar detection threshold for the whole image
-            elif self.calc_threshold:
-                log.info("Determining detection threshold from image.")
-                bkg = self._calc_2D_background()
-                threshold_img = bkg.background + self.snr_threshold * bkg.background_rms
-                threshold = np.median(threshold_img)
-                log.info(f"Calculated a detection threshold of {threshold} from image.")
-            else:
-                threshold = np.median(self.data)
+        # if a pre-determined threshold value for detection for the whole
+        # image is provided, use this
+        if self.scalar_threshold is not None:
+            threshold = float(self.scalar_threshold)
+            log.info(f"Using a detection threshold of {threshold}.")
 
-            if self.kernel_fwhm is None:
-                # estimate the FWHM of the PSF using rough estimate
-                # from the diffraction limit:
-                central_wavelength = psf.filter_central_wavelengths[filt] * u.um
-                diffraction_limit = float(1.22 * central_wavelength / (2.4 * u.m))
-                assume_pixel_scale = 0.11 * u.arcsec / u.pix
-                expect_psf_pix = np.sqrt(
-                    ((diffraction_limit * u.rad).to(u.arcsec) / assume_pixel_scale) ** 2
-                    + 1 * u.pix**2
-                ).to_value(u.pix)
-                self.kernel_fwhm = expect_psf_pix
+        # otherwise, if specified, calculate a scalar threshold from the
+        # image by calculating a 2D background image, using this to create
+        # a 2d threshold image, and using the median of the 2d threshold
+        # image as the scalar detection threshold for the whole image
+        elif self.calc_threshold:
+            log.info("Determining detection threshold from image.")
+            bkg = self._calc_2D_background()
+            threshold_img = bkg.background + self.snr_threshold * bkg.background_rms
+            threshold = np.median(threshold_img)
+            log.info(f"Calculated a detection threshold of {threshold} from image.")
+        else:
+            threshold = np.median(self.data)
 
-            log.info("Detecting sources with DAOStarFinder, using entire image array.")
-            daofind = DAOStarFinder(
-                fwhm=self.kernel_fwhm,
-                threshold=threshold,
-                sharplo=self.sharplo,
-                sharphi=self.sharphi,
-                roundlo=self.roundlo,
-                roundhi=self.roundhi,
-                brightest=self.max_sources,
-                peakmax=self.peakmax,
-                min_separation=self.min_separation,
+        if self.kernel_fwhm is None:
+            # estimate the FWHM of the PSF using rough estimate
+            # from the diffraction limit:
+            central_wavelength = psf.filter_central_wavelengths[filt] * u.um
+            diffraction_limit = float(1.22 * central_wavelength / (2.4 * u.m))
+            assume_pixel_scale = 0.11 * u.arcsec / u.pix
+            expect_psf_pix = np.sqrt(
+                ((diffraction_limit * u.rad).to(u.arcsec) / assume_pixel_scale) ** 2
+                + 1 * u.pix**2
+            ).to_value(u.pix)
+            self.kernel_fwhm = expect_psf_pix
+
+        log.info("Detecting sources with DAOStarFinder, using entire image array.")
+        daofind = DAOStarFinder(
+            fwhm=self.kernel_fwhm,
+            threshold=threshold,
+            sharplo=self.sharplo,
+            sharphi=self.sharphi,
+            roundlo=self.roundlo,
+            roundhi=self.roundhi,
+            brightest=self.max_sources,
+            peakmax=self.peakmax,
+            min_separation=self.min_separation,
+        )
+
+        if self.scalar_threshold is not None:
+            # if absolute threshold is provided
+            sources = daofind(self.data, mask=self.coverage_mask)
+
+        elif self.calc_threshold is not None:
+            # subtract background from data if calculating abs. threshold
+            sources = daofind(self.data - bkg.background, mask=self.coverage_mask)
+        else:
+            sources = daofind(self.data, mask=self.coverage_mask)
+
+        # reduce table to minimal number of columns, just source ID,
+        # positions, and fluxes
+        columns = ["id", "xcentroid", "ycentroid", "flux"]
+
+        if sources:
+            catalog = sources[columns]
+            log.info(f"Found {len(catalog)} sources.")
+        else:
+            # if no sources were detected, return an empty table
+            self.log.warning("No sources detected, returning empty catalog.")
+            catalog = Table(
+                names=columns,
+                dtype=(int, np.float64, np.float64, np.float64),
             )
 
-            if self.scalar_threshold is not None:
-                # if absolute threshold is provided
-                sources = daofind(self.data, mask=self.coverage_mask)
+        if self.fit_psf and len(sources):
+            # refine astrometry by fitting PSF models to the detected sources
+            log.info("Constructing a gridded PSF model.")
+            detector = input_model.meta.instrument["detector"].replace("WFI", "SCA")
+            gridded_psf_model, _ = psf.create_gridded_psf_model(
+                filt=filt,
+                detector=detector,
+                logging_level="ERROR",
+            )
 
-            elif self.calc_threshold is not None:
-                # subtract background from data if calculating abs. threshold
-                sources = daofind(self.data - bkg.background, mask=self.coverage_mask)
+            log.info(
+                "Fitting a PSF model to sources for improved astrometric precision."
+            )
+            psf_photometry_table, photometry = psf.fit_psf_to_image_model(
+                image_model=input_model,
+                psf_model=gridded_psf_model,
+                x_init=catalog["xcentroid"],
+                y_init=catalog["ycentroid"],
+                exclude_out_of_bounds=True,
+            )
+
+        catalog_as_recarray = catalog.as_array()
+
+        # create meta.source detection section in file
+        # if save_catalogs is True, this will be updated with the
+        # attribute 'tweakreg_catalog_name' to point to the location
+        # of the catalog on disk. If save_catalogs is false, this section
+        # will be updated to contain the catalog to pass to TweakReg
+
+        # tweakreg_catalog_name will be saved to the final output file,
+        # while tweakreg_catalog is intended to be deleted by TweakRegStep
+        input_model.meta["source_detection"] = maker_utils.mk_source_detection()
+
+        # if 'save_catalogs'= True, also save the output catalog to a file
+        # (format specified by output_cat_filetype) and add an attribute
+        # to the file that contains the path to this file
+        if self.save_catalogs:
+            cat_filename = input_model.meta.filename.replace(".asdf", "")
+            cat_filename += f"_tweakreg_catalog.{self.output_cat_filetype}"
+            log.info(f"Saving catalog to file: {cat_filename}.")
+
+            if self.output_cat_filetype == "asdf":
+                tree = {"tweakreg_catalog": catalog_as_recarray}
+                ff = AsdfFile(tree)
+                ff.write_to(cat_filename)
             else:
-                sources = daofind(self.data, mask=self.coverage_mask)
+                catalog.write(cat_filename, format="ascii.ecsv", overwrite=True)
 
-            # reduce table to minimal number of columns, just source ID,
-            # positions, and fluxes
-            columns = ["id", "xcentroid", "ycentroid", "flux"]
+            input_model.meta.source_detection["tweakreg_catalog_name"] = cat_filename
+        else:
+            if self.fit_psf:
+                # PSF photometry centroid results are stored in an astropy table
+                # in columns "x_fit" and "y_fit", which we'll rename for
+                # compatibility with tweakreg:
+                catalog = psf_photometry_table.copy()
 
-            if sources:
-                catalog = sources[columns]
-                log.info(f"Found {len(catalog)} sources.")
+                # rename the PSF photometry table's columns to match the
+                # expectated columns in tweakreg:
+                for old_name, new_name in zip(
+                    ["x_fit", "y_fit"], ["xcentroid", "ycentroid"]
+                ):
+                    catalog.rename_column(old_name, new_name)
+
+                input_model.meta.source_detection["tweakreg_catalog"] = catalog
             else:
-                # if no sources were detected, return an empty table
-                self.log.warning("No sources detected, returning empty catalog.")
-                catalog = Table(
-                    names=columns,
-                    dtype=(int, np.float64, np.float64, np.float64),
+                # only attach catalog to file if its being passed to the next step
+                # and save_catalogs is false, since it is not in the schema
+                input_model.meta.source_detection["tweakreg_catalog"] = (
+                    catalog_as_recarray
                 )
-
-            if self.fit_psf and len(sources):
-                # refine astrometry by fitting PSF models to the detected sources
-                log.info("Constructing a gridded PSF model.")
-                detector = input_model.meta.instrument["detector"].replace("WFI", "SCA")
-                gridded_psf_model, _ = psf.create_gridded_psf_model(
-                    filt=filt,
-                    detector=detector,
-                    logging_level="ERROR",
-                )
-
-                log.info(
-                    "Fitting a PSF model to sources for improved astrometric precision."
-                )
-                psf_photometry_table, photometry = psf.fit_psf_to_image_model(
-                    image_model=input_model,
-                    psf_model=gridded_psf_model,
-                    x_init=catalog["xcentroid"],
-                    y_init=catalog["ycentroid"],
-                    exclude_out_of_bounds=True,
-                )
-
-            catalog_as_recarray = catalog.as_array()
-
-            # create meta.source detection section in file
-            # if save_catalogs is True, this will be updated with the
-            # attribute 'tweakreg_catalog_name' to point to the location
-            # of the catalog on disk. If save_catalogs is false, this section
-            # will be updated to contain the catalog to pass to TweakReg
-
-            # tweakreg_catalog_name will be saved to the final output file,
-            # while tweakreg_catalog is intended to be deleted by TweakRegStep
-            input_model.meta["source_detection"] = maker_utils.mk_source_detection()
-
-            # if 'save_catalogs'= True, also save the output catalog to a file
-            # (format specified by output_cat_filetype) and add an attribute
-            # to the file that contains the path to this file
-            if self.save_catalogs:
-                cat_filename = input_model.meta.filename.replace(".asdf", "")
-                cat_filename += f"_tweakreg_catalog.{self.output_cat_filetype}"
-                log.info(f"Saving catalog to file: {cat_filename}.")
-
-                if self.output_cat_filetype == "asdf":
-                    tree = {"tweakreg_catalog": catalog_as_recarray}
-                    ff = AsdfFile(tree)
-                    ff.write_to(cat_filename)
-                else:
-                    catalog.write(cat_filename, format="ascii.ecsv", overwrite=True)
-
-                input_model.meta.source_detection["tweakreg_catalog_name"] = (
-                    cat_filename
-                )
-            else:
-                if self.fit_psf:
-                    # PSF photometry centroid results are stored in an astropy table
-                    # in columns "x_fit" and "y_fit", which we'll rename for
-                    # compatibility with tweakreg:
-                    catalog = psf_photometry_table.copy()
-
-                    # rename the PSF photometry table's columns to match the
-                    # expectated columns in tweakreg:
-                    for old_name, new_name in zip(
-                        ["x_fit", "y_fit"], ["xcentroid", "ycentroid"]
-                    ):
-                        catalog.rename_column(old_name, new_name)
-
-                    input_model.meta.source_detection["tweakreg_catalog"] = catalog
-                else:
-                    # only attach catalog to file if its being passed to the next step
-                    # and save_catalogs is false, since it is not in the schema
-                    input_model.meta.source_detection["tweakreg_catalog"] = (
-                        catalog_as_recarray
-                    )
-            input_model.meta.cal_step["source_detection"] = "COMPLETE"
+        input_model.meta.cal_step["source_detection"] = "COMPLETE"
 
         # just pass input model to next step - catalog is stored in meta
         return input_model


### PR DESCRIPTION
This PR removes (almost) all uses of `lazy_load=False` (the ones in `make_regtestdata.sh` were left unchanged).

In several places this required changes to how steps handle input. The closed ticket (#1341) more details but briefly:
```python
def process(self, init):
    with rdm.open(init) as model:
        # update model in place
    return model
```
The above typical step process function results in returning a closed model for any step when run with a filename as an input due to:
- rdm.open opening the file
- the existing of the `with` statement closing the file

Any portion of `model` not modified or accessed during the `process` run can result in an error in a later step. For example if the step does not access `model.err`, the `err` array will not be loaded before the input file is closed. Any later step that attempts to access `err` will encounter a closed file and produce an exception.

This PR switch the pattern to:
```python
def process(self, init):
    if isinstance(init, rdm.DataModel):
        model = init
    else:
        model = rdm.open(init)
```
This fixes the issue mentioned above preventing lazy loading and has the added benefit of allowing the steps to run without producing an unnecessary shallow-copy (clone) of the input (when `rdm.open` is called on a `DataModel`).

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/10185037326

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1341 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
