### PR TITLE
increase asdf minimum required version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf >=3.1.0",
+    "asdf >=3.3.0",
     "asdf-astropy >=0.5.0",
     "astropy >=5.3.0",
     "crds >=11.16.16",


### PR DESCRIPTION
https://github.com/spacetelescope/roman_datamodels/pull/358 increased the minimum required asdf version for roman_datamodels to 3.1.0.

This PR updates the asdf requirement in romancal to match (to allow the oldest deps job to run).

I marked this as `no-changelog-entry-needed` but please let me know if an entry is preferred.

Given the regtests ran with https://github.com/spacetelescope/roman_datamodels/pull/358 I did not start a run with this PR. Please let me know if I should.

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
