### PR TITLE
rcal-827 Add reg test for DMS373

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Documentation
 general
 -------
 
-- Add regression test for DMS373, mosaic pipeline [#]
+- Add regression test for DMS373, mosaic pipeline [#1348]
 
 - Update the exposure pipeline to accept a roman datamodel as input [#1296]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Documentation
 general
 -------
 
+- Add regression test for DMS373, mosaic pipeline [#]
+
 - Update the exposure pipeline to accept a roman datamodel as input [#1296]
 
 - Update okify script to use GA directory structure [#1282]

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -168,5 +168,3 @@ def test_hlp_mosaic_pipeline(rtdata, ignore_asdf_paths):
         "DMS373 MSG: Testing the creation of a Level 3 mosaic image resampled to a skycell"
         + passfail(model.meta.cal_step.resample == "COMPLETE")
     )
-    
-    

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -165,7 +165,7 @@ def test_hlp_mosaic_pipeline(rtdata, ignore_asdf_paths):
     model = rdm.open(rtdata.output, lazy_load=False)
 
     pipeline.log.info(
-        "DMS373 MSG: Testing the creation of a Level 3 mosaic image"
+        "DMS373 MSG: Testing the creation of a Level 3 mosaic image resampled to a skycell"
         + passfail(model.meta.cal_step.resample == "COMPLETE")
     )
     

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -7,8 +7,6 @@ import roman_datamodels as rdm
 from metrics_logger.decorators import metrics_logger
 
 from romancal.pipeline.mosaic_pipeline import MosaicPipeline
-from romancal.associations import Association
-from romancal.associations.asn_from_list import asn_from_list
 
 from .regtestdata import compare_asdf
 

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -7,6 +7,8 @@ import roman_datamodels as rdm
 from metrics_logger.decorators import metrics_logger
 
 from romancal.pipeline.mosaic_pipeline import MosaicPipeline
+from romancal.associations import Association
+from romancal.associations.asn_from_list import asn_from_list
 
 from .regtestdata import compare_asdf
 
@@ -128,3 +130,45 @@ def test_level3_mos_pipeline(rtdata, ignore_asdf_paths):
         "DMS86 MSG: Testing completion of resample in the Level 3 image output......."
         + passfail(model.meta.cal_step.resample == "COMPLETE")
     )
+
+
+@pytest.mark.bigdata
+@pytest.mark.soctests
+@metrics_logger("DMS373")
+def test_hlp_mosaic_pipeline(rtdata, ignore_asdf_paths):
+    """Tests for level 3 mosaic requirements DMS373"""
+
+    cal_files = [
+        "WFI/image/r0000101001001001001_01101_0001_WFI01_cal.asdf",
+        "WFI/image/r0000101001001001001_01101_0002_WFI01_cal.asdf",
+        "WFI/image/r0000101001001001001_01101_0003_WFI01_cal.asdf",
+    ]
+
+    for cal_file in cal_files:
+        rtdata.get_data(cal_file)
+
+    input_asn = "L3_mosaic_asn.json"
+    rtdata.get_data(f"WFI/image/{input_asn}")
+    rtdata.input = input_asn
+
+    # Test Pipeline
+    output = "r0099101001001001001_r274dp63x31y81_prompt_F158_i2d.asdf"
+    rtdata.output = output
+    args = [
+        "roman_mos",
+        rtdata.input,
+    ]
+    MosaicPipeline.from_cmdline(args)
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    pipeline = MosaicPipeline()
+    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+    assert diff.identical, diff.report()
+
+    model = rdm.open(rtdata.output, lazy_load=False)
+
+    pipeline.log.info(
+        "DMS373 MSG: Testing the creation of a Level 3 mosaic image"
+        + passfail(model.meta.cal_step.resample == "COMPLETE")
+    )
+    
+    


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-827](https://jira.stsci.edu/browse/RCAL-827)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1218 

<!-- describe the changes comprising this PR here -->
This PR adds a regression test for resampling data to a skycell (DMS 373). Currently it uses the SCSB skycell definitions but will be changed to the RTB definitions once available. 

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)

The passing regression tests are at
https://github.com/spacetelescope/RegressionTests/actions/runs/10219749253
and
https://github.com/spacetelescope/RegressionTests/actions/runs/10220085169

The only issue is that we will need to have 
PATCH_TABLE_PATH=/grp/roman/scsb/tesselation/patches.asdf
added to the romancal.yml file for GitHub actions (https://github.com/spacetelescope/RegressionTests/pull/112) before merging. 