### PR TITLE
fix number of context planes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,11 @@ tweakreg
 --------
 - Integration with ``SourceCatalogStep``: allow usage of results from ``SourceCatalogStep``. [#1276]
 
+resample
+--------
+
+- Fix incorrect number of starting planes for context image. [#1355]
+
 mosaic_pipeline
 ---------------
 

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -153,8 +153,10 @@ class ResampleData:
         # NOTE: wait for William to fix bug in datamodels' init and then
         # use datamodels.ImageModel(shape=(nx, ny)) instead of mk_datamodel()
 
+        # n_images sets the number of context image planes.
+        # This should be 1 to start (not the default of 2).
         self.blank_output = maker_utils.mk_datamodel(
-            datamodels.MosaicModel, shape=tuple(self.output_wcs.array_shape)
+            datamodels.MosaicModel, n_images=1, shape=tuple(self.output_wcs.array_shape)
         )
 
         with self.input_models:


### PR DESCRIPTION
roman_datamodels defaults the context plane of the mosaic model to start with 2 planes:
https://github.com/spacetelescope/roman_datamodels/blob/5e996c37648bac7fa0ac3c4d5e0ce5b8ddaeb69a/src/roman_datamodels/maker_utils/_datamodels.py#L155

This is causing an extra context plane. This PR fixes the issue by setting n_images to 1.

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/romancal/issues/1264

Regression tests show 2 expected failures (which shows the issue is fixed): https://github.com/spacetelescope/RegressionTests/actions/runs/10303608077

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
