### PR TITLE
make crs bigger for new pars file for jump unit tests

### DIFF
--- a/romancal/jump/tests/test_jump_step.py
+++ b/romancal/jump/tests/test_jump_step.py
@@ -162,7 +162,7 @@ def test_one_CR(generate_wfi_reffiles, max_cores, setup_inputs):
         CR_group = next(CR_pool)
         model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = (
             model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]]
-            + 500.0 * model1.data.unit
+            + 5000.0 * model1.data.unit
         )
 
     out_model = JumpStep.call(
@@ -215,7 +215,7 @@ def test_two_CRs(generate_wfi_reffiles, max_cores, setup_inputs):
         CR_group = next(CR_pool)
 
         model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] = (
-            model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] + 500 * model1.data.unit
+            model1.data[CR_group:, CR_y_locs[i], CR_x_locs[i]] + 5000 * model1.data.unit
         )
         model1.data[CR_group + 8 :, CR_y_locs[i], CR_x_locs[i]] = (
             model1.data[CR_group + 8 :, CR_y_locs[i], CR_x_locs[i]]


### PR DESCRIPTION
Make CRs bigger than the threshold used for the new pars files.

Fixes the unit test failures seen in:
https://github.com/spacetelescope/romancal/pull/1355
due to the new pars file:
 https://roman-crds.stsci.edu/browse/roman_wfi_pars-jumpstep_0001.asdf

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/10308257135

show only expected differences due to the new crds context:
```
E         {'values_changed': {"root['roman']['meta']['ref_file']['crds']['context_used']": {'new_value': 'roman_0063.pmap',
E                                                                                           'old_value': 'roman_0061.pmap'}}}
```

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
