### PR TITLE
Populate sky metadata with zero if matching is not possible.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,11 @@ tweakreg
 
 - Update default absolute separation for tweakreg.  [#1352]
 
+skymatch
+--------
+- Populate valid metadata even when then are no overlapping images to
+  match [#1360]
+
 
 0.15.1 (2024-05-15)
 ===================

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -181,7 +181,7 @@ class SkyMatchStep(RomanStep):
         image.meta.background.subtracted = self.subtract
         image.meta.background.level = sky
 
-        if step_status == 'COMPLETE' and self.subtract:
+        if step_status == "COMPLETE" and self.subtract:
             image.data[...] = sky_image.image[...]
 
         image.meta.cal_step.skymatch = step_status

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -174,13 +174,14 @@ class SkyMatchStep(RomanStep):
     def _set_sky_background(self, sky_image, step_status):
         image = sky_image.meta["image_model"]
         sky = sky_image.sky
+        if sky == 0 or sky is None:
+            sky = 0 * image.data.unit
 
-        if step_status == "COMPLETE":
-            image.meta.background.method = str(self.skymethod)
-            image.meta.background.level = sky
-            image.meta.background.subtracted = self.subtract
+        image.meta.background.method = str(self.skymethod)
+        image.meta.background.subtracted = self.subtract
+        image.meta.background.level = sky
 
-            if self.subtract:
-                image.data[...] = sky_image.image[...]
+        if step_status == 'COMPLETE' and self.subtract:
+            image.data[...] = sky_image.image[...]
 
         image.meta.cal_step.skymatch = step_status


### PR DESCRIPTION
Make sure that we send sensible metadata even when the L2 images don't overlap one another.  The existing code populates Nones here, which don't fit into the individual_image_metadata tables with the other numbers.

Regression tests are passing: https://github.com/spacetelescope/romancal/pull/1355