### PR TITLE
release metadata for `0.16.1` + update `stpipe` to use `ModelLibrary` + `stcal` to use outlier detection functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
-0.16.1 (unreleased)
+0.16.2 (unreleased)
 ===================
 
 -
+
+0.16.1 (2024-08-13)
+===================
+
+- update ``stcal`` and ``stpipe`` versions to use ``ModelLibrary`` [#1364]
 
 0.16.0 (2024-08-13)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@
 0.16.1 (2024-08-13)
 ===================
 
-- update ``stcal`` and ``stpipe`` versions to use ``ModelLibrary`` [#1364]
+- update ``stpipe`` to use ``ModelLibrary`` [#1364]
+- update ``stcal`` to use outlier detection [#1364]
 
 0.16.0 (2024-08-13)
 ===================

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ an [issue](https://github.com/spacetelescope/romancal/issues).
 | 0.15.0    | 24Q3_B14  | 058          | May 2024  | Release for Build 24Q3_B14 (Build 14) |
 | 0.15.1    | 24Q3_B14  | 058          | May 2024  | Release for Build 24Q3_B14 (Build 14) |
 | 0.16.0    | 24Q4_B15  | 063          | Aug 2024  | Release for Build 24Q3_B15 (Build 15) |
+| 0.16.1    | 24Q4_B15  | 063          | Aug 2024  | Release for Build 24Q3_B15 (Build 15) |
 
 
 Note: CRDS_CONTEXT values flagged with an asterisk in the above table are estimates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "scipy >=1.11",
     "stcal>=1.7.3,<1.8.0",
     # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
-    "stpipe >=0.6.0,<0.7.0",
+    "stpipe >=0.7.0,<0.8.0",
     # "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
     "tweakwcs >=0.8.8",
     "spherical-geometry >= 1.2.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "roman_datamodels>=0.21.0,<0.22.0",
     # "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
     "scipy >=1.11",
-    "stcal>=1.7.3,<1.8.0",
+    "stcal>=1.8.0,<1.9.0",
     # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe >=0.7.0,<0.8.0",
     # "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",


### PR DESCRIPTION
waitiing on
- [x] `stpipe 0.7.0`
- [x] `stcal 1.8.0`