### PR TITLE
only load patch table when needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+0.16.3 (unreleased)
+===================
+
+mosaic_pipeline
+---------------
+
+- Only load patch table when needed. [#1367]
+
 0.16.2 (2024-08-23)
 ===================
 

--- a/romancal/patch_match/patch_match.py
+++ b/romancal/patch_match/patch_match.py
@@ -84,6 +84,8 @@ def find_patch_matches(image_corners, image_shape=None):
     """
 
     if PATCH_TABLE is None:
+        load_patch_table()
+    if PATCH_TABLE is None:
         raise RuntimeError("No patch table has been loaded")
     if isinstance(image_corners, wcs.WCS):
         iwcs = image_corners
@@ -250,6 +252,3 @@ def veccoords_to_tangent_plane(vertices, tangent_point_vec):
     x_coords = np.dot(x_axis, avertices) * RAD_TO_ARCSEC
     y_coords = np.dot(y_axis, avertices) * RAD_TO_ARCSEC
     return x_coords, y_coords
-
-
-load_patch_table()

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -88,6 +88,10 @@ class MosaicPipeline(RomanPipeline):
 
             # if this is a valid skycell name load the database and get the skycell record
             if re.match(r"r\d{3}\w{2}\d{2}x\d{2}y\d{2}", skycell_name):
+                if patch_match.PATCH_TABLE is None:
+                    patch_match.load_patch_table()
+                if patch_match.PATCH_TABLE is None:
+                    raise RuntimeError("No patch table has been loaded")
                 skycell_record = patch_match.PATCH_TABLE[
                     np.where(patch_match.PATCH_TABLE["name"][:] == skycell_name)[0][0]
                 ]


### PR DESCRIPTION
This PR modifies the mosaic pipeline and patch match submodule to only load the patch table when required (instead of at import).

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/10404395165

Closes #1366

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
