### PR TITLE
use `towncrier` to handle changelog entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,31 +11,32 @@ This PR addresses ...
 **Checklist**
 - [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>
 
-    - ``changes/<PR#>.docs.rst``: documentation change
     - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
-    - ``changes/<PR#>.scripts.rst``: change to scripts
-    - ``changes/<PR#>.stpipe.rst``: change to `stpipe` interface
+    - ``changes/<PR#>.docs.rst``
+    - ``changes/<PR#>.stpipe.rst``
+    - ``changes/<PR#>.associations.rst``
+    - ``changes/<PR#>.scripts.rst``
+    - ``changes/<PR#>.mosaic_pipeline.rst``
+    - ``changes/<PR#>.patch_match.rst``
 
     ## steps
-    - ``changes/<PR#>.associations.rst``
-    - ``changes/<PR#>.dark_current.rst``
     - ``changes/<PR#>.dq_init.rst``
-    - ``changes/<PR#>.flux.rst``
-    - ``changes/<PR#>.flatfield.rst``
-    - ``changes/<PR#>.jump_detection.rst``
-    - ``changes/<PR#>.linearity.rst``
-    - ``changes/<PR#>.mosaic_pipeline.rst``
-    - ``changes/<PR#>.outlier_detection.rst``
-    - ``changes/<PR#>.patch_match.rst``
-    - ``changes/<PR#>.photom.rst``
-    - ``changes/<PR#>.ramp_fitting.rst``
-    - ``changes/<PR#>.refpix.rst``
-    - ``changes/<PR#>.refpix.rst``
-    - ``changes/<PR#>.resample.rst``
     - ``changes/<PR#>.saturation.rst``
-    - ``changes/<PR#>.skymatch.rst``
-    - ``changes/<PR#>.source_catalog.rst``
+    - ``changes/<PR#>.refpix.rst``
+    - ``changes/<PR#>.linearity.rst``
+    - ``changes/<PR#>.dark_current.rst``
+    - ``changes/<PR#>.jump_detection.rst``
+    - ``changes/<PR#>.ramp_fitting.rst``
+    - ``changes/<PR#>.assign_wcs.rst``
+    - ``changes/<PR#>.flatfield.rst``
+    - ``changes/<PR#>.photom.rst``
+    - ``changes/<PR#>.flux.rst``
+    - ``changes/<PR#>.source_detection.rst``
     - ``changes/<PR#>.tweakreg.rst``
+    - ``changes/<PR#>.skymatch.rst``
+    - ``changes/<PR#>.outlier_detection.rst``
+    - ``changes/<PR#>.resample.rst``
+    - ``changes/<PR#>.source_catalog.rst``
   </details>
 - [ ] updated relevant tests
 - [ ] updated relevant documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,34 @@ Closes #
 This PR addresses ...
 
 **Checklist**
-- [ ] added entry in `CHANGES.rst` under the corresponding subsection
+- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>
+
+    - ``changes/<PR#>.docs.rst``: documentation change
+    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
+    - ``changes/<PR#>.scripts.rst``: change to scripts
+    - ``changes/<PR#>.stpipe.rst``: change to `stpipe` interface
+
+    ## steps
+    - ``changes/<PR#>.associations.rst``
+    - ``changes/<PR#>.dark_current.rst``
+    - ``changes/<PR#>.dq_init.rst``
+    - ``changes/<PR#>.flux.rst``
+    - ``changes/<PR#>.flatfield.rst``
+    - ``changes/<PR#>.jump_detection.rst``
+    - ``changes/<PR#>.linearity.rst``
+    - ``changes/<PR#>.mosaic_pipeline.rst``
+    - ``changes/<PR#>.outlier_detection.rst``
+    - ``changes/<PR#>.patch_match.rst``
+    - ``changes/<PR#>.photom.rst``
+    - ``changes/<PR#>.ramp_fitting.rst``
+    - ``changes/<PR#>.refpix.rst``
+    - ``changes/<PR#>.refpix.rst``
+    - ``changes/<PR#>.resample.rst``
+    - ``changes/<PR#>.saturation.rst``
+    - ``changes/<PR#>.skymatch.rst``
+    - ``changes/<PR#>.source_catalog.rst``
+    - ``changes/<PR#>.tweakreg.rst``
+  </details>
 - [ ] updated relevant tests
 - [ ] updated relevant documentation
 - [ ] updated relevant milestone(s)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Closes #
 This PR addresses ...
 
 **Checklist**
-- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>
+- [ ] for a public change, added a towncrier news fragment in `changes/` <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>
 
     - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
     - ``changes/<PR#>.docs.rst``

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,4 +27,4 @@ jobs:
       - run: pip install .
       - run: pip install towncrier
       - run: towncrier check
-      - run: towncrier build --draft | grep -P '[\(\[][^\)\]]*#${{ github.event.number }}[,\)\]]'
+      - run: towncrier build --draft | grep -P '#${{ github.event.number }}'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,25 +1,30 @@
-name: Changelog
+name: changelog
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - synchronize
+      - reopened
 
-# Only cancel in-progress jobs or runs for the current workflow
-#   This cancels the already triggered workflows for a specific PR without canceling
-#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
-#   within that PR re-triggers this CI
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  changelog:
-    name: Confirm changelog entry
+  check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}
     runs-on: ubuntu-latest
     steps:
-    - name: Check change log entry
-      uses: scientific-python/action-check-changelogfile@1fc669db9618167166d5a16c10282044f51805c0  # 0.3
-      env:
-        CHANGELOG_FILENAME: CHANGES.rst
-        CHECK_MILESTONE: false
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: pip install .
+      - run: pip install towncrier
+      - run: towncrier check
+      - run: towncrier build --draft | grep -P '[\(\[][^\)\]]*#${{ github.event.number }}[,\)\]]'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,6 +36,8 @@ build:
       - ./git-lfs fetch
       # Make local files to have the real content on them
       - ./git-lfs checkout
+    post_install:
+      - towncrier build --keep
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,3 @@
-0.16.4dev
-=========
-
-mosaic_pipeline
----------------
-
-- Allow asn product name to be the output product [#1394]
-
-
-
-
 0.16.3 (2024-08-29)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,7 +88,7 @@ stpipe
 ------
 
 - Add ``ModelContainer`` support to ``Step._datamodels_open`` to allow
-  loading "pars-*" files from CRDS. [#1270]
+  loading ``pars-*`` files from CRDS. [#1270]
 
 
 tweakreg
@@ -738,7 +738,7 @@ linearity
 
 -  Linearity correction now supports NaN's in the reference file. [#484]
 
-  photom
+photom
 ------
 
 - Photom updated to skip updating photometric converstions for spectral data [#498]

--- a/changes/1375.docs.rst
+++ b/changes/1375.docs.rst
@@ -1,0 +1,1 @@
+handle changelog entries with `towncrier`

--- a/changes/1375.docs.rst
+++ b/changes/1375.docs.rst
@@ -1,1 +1,1 @@
-handle changelog entries with `towncrier`
+handle changelog entries with ``towncrier``

--- a/changes/1394.mosaic_pipeline.rst
+++ b/changes/1394.mosaic_pipeline.rst
@@ -1,0 +1,1 @@
+Allow asn product name to be the output product

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,3 +69,4 @@ desk at `Roman Help Desk <https://stsci.service-now.com/roman>`_.
    :maxdepth: 1
 
    roman/pipeline_static_preview.rst
+   roman/changes.rst

--- a/docs/roman/changes.rst
+++ b/docs/roman/changes.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: roman
+
+***********
+Change  Log
+***********
+
+.. include:: ../../CHANGES.rst

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -7,3 +7,4 @@ dependencies:
  - pip
  - graphviz
  - sphinx_rtd_theme>1.2.0
+ - towncrier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ package = "romancal"
 title_format = "{version} ({project_date})"
 ignore = [".gitkeep"]
 wrap = true
-issue_format = "`#{issue} <https://github.com/spacetelescope/romancal/{issue}>`_"
+issue_format = "`#{issue} <https://github.com/spacetelescope/romancal/issues/{issue}>`_"
 
 [[tool.towncrier.type]]
 directory = "general"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,66 +237,124 @@ ignore = [".gitkeep"]
 wrap = true
 issue_format = "`#{issue} <https://github.com/spacetelescope/romancal/{issue}>`_"
 
-[tool.towncrier.fragment.associations]
-name = "`associations`"
+[[tool.towncrier.type]]
+directory = "general"
+name = "General"
+showcontent = true
 
-[tool.towncrier.fragment.dark_current]
-name = "`dark_current`"
-
-[tool.towncrier.fragment.docs]
+[[tool.towncrier.type]]
+directory = "docs"
 name = "Documentation"
+showcontent = true
 
-[tool.towncrier.fragment.dq_init]
-name = "`dq_init`"
+[[tool.towncrier.type]]
+directory = "stpipe"
+name = "``stpipe``"
+showcontent = true
 
-[tool.towncrier.fragment.flux]
-name = "`flux`"
+[[tool.towncrier.type]]
+directory = "associations"
+name = "Associations"
+showcontent = true
 
-[tool.towncrier.fragment.flatfield]
-name = "`flatfield`"
+[[tool.towncrier.type]]
+directory = "scripts"
+name = "Scripts"
+showcontent = true
 
-[tool.towncrier.fragment.general]
+[[tool.towncrier.type]]
+directory = "mosaic_pipeline"
+name = "``mosaic_pipeline``"
+showcontent = true
 
-[tool.towncrier.fragment.jump_detection]
-name = "`jump_detection`"
+[[tool.towncrier.type]]
+directory = "patch_match"
+name = "``patch_match``"
+showcontent = true
 
-[tool.towncrier.fragment.linearity]
-name = "`linearity`"
+# steps
 
-[tool.towncrier.fragment.mosaic_pipeline]
-name = "`mosaic_pipeline`"
+[[tool.towncrier.type]]
+directory = "dq_init"
+name = "``dq_init`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.outlier]
-name = "`outlier_detection`"
+[[tool.towncrier.type]]
+directory = "saturation"
+name = "``saturation`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.patch_match]
-name = "`patch_match`"
+[[tool.towncrier.type]]
+directory = "refpix"
+name = "``refpix`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.photom]
-name = "`photom`"
+[[tool.towncrier.type]]
+directory = "linearity"
+name = "``linearity`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.ramp]
-name = "`ramp_fitting`"
+[[tool.towncrier.type]]
+directory = "dark_current"
+name = "``dark_current`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.refpix]
-name = "`refpix`"
+[[tool.towncrier.type]]
+directory = "jump_detection"
+name = "``jump_detection``"
+showcontent = true
 
-[tool.towncrier.fragment.resample]
-name = "`resample`"
+[[tool.towncrier.type]]
+directory = "ramp_fitting"
+name = "``ramp_fitting`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.saturation]
-name = "`saturation`"
+[[tool.towncrier.type]]
+directory = "assign_wcs"
+name = "``assign_wcs`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
 
-[tool.towncrier.fragment.scripts]
+[[tool.towncrier.type]]
+directory = "flatfield"
+name = "``flatfield`` (WFI-Image)"
+showcontent = true
 
-[tool.towncrier.fragment.skymatch]
-name = "`skymatch`"
+[[tool.towncrier.type]]
+directory = "photom"
+name = "``photom`` (WFI-Image)"
+showcontent = true
 
-[tool.towncrier.fragment.source_catalog]
-name = "`source_catalog`"
+[[tool.towncrier.type]]
+directory = "flux"
+name = "``flux``"
+showcontent = true
 
-[tool.towncrier.fragment.stpipe]
-name = "`stpipe`"
+[[tool.towncrier.type]]
+directory = "source_detection"
+name = "``source_detection`` (WFI-Image)"
+showcontent = true
 
-[tool.towncrier.fragment.tweakreg]
-name = "`tweakreg`"
+[[tool.towncrier.type]]
+directory = "tweakreg"
+name = "``tweakreg`` (WFI-Image)"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "skymatch"
+name = "``skymatch``"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "outlier_detection"
+name = "``outlier_detection``"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "resample"
+name = "``resample``"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "source_catalog"
+name = "``source_catalog``"
+showcontent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,3 +227,76 @@ archs = [
     "auto",
     "aarch64",
 ]
+
+[tool.towncrier]
+filename = "CHANGES.rst"
+directory = "changes"
+package = "romancal"
+title_format = "{version} ({project_date})"
+ignore = [".gitkeep"]
+wrap = true
+issue_format = "`#{issue} <https://github.com/spacetelescope/romancal/{issue}>`_"
+
+[tool.towncrier.fragment.associations]
+name = "`associations`"
+
+[tool.towncrier.fragment.dark_current]
+name = "`dark_current`"
+
+[tool.towncrier.fragment.docs]
+name = "Documentation"
+
+[tool.towncrier.fragment.dq_init]
+name = "`dq_init`"
+
+[tool.towncrier.fragment.flux]
+name = "`flux`"
+
+[tool.towncrier.fragment.flatfield]
+name = "`flatfield`"
+
+[tool.towncrier.fragment.general]
+
+[tool.towncrier.fragment.jump_detection]
+name = "`jump_detection`"
+
+[tool.towncrier.fragment.linearity]
+name = "`linearity`"
+
+[tool.towncrier.fragment.mosaic_pipeline]
+name = "`mosaic_pipeline`"
+
+[tool.towncrier.fragment.outlier]
+name = "`outlier_detection`"
+
+[tool.towncrier.fragment.patch_match]
+name = "`patch_match`"
+
+[tool.towncrier.fragment.photom]
+name = "`photom`"
+
+[tool.towncrier.fragment.ramp]
+name = "`ramp_fitting`"
+
+[tool.towncrier.fragment.refpix]
+name = "`refpix`"
+
+[tool.towncrier.fragment.resample]
+name = "`resample`"
+
+[tool.towncrier.fragment.saturation]
+name = "`saturation`"
+
+[tool.towncrier.fragment.scripts]
+
+[tool.towncrier.fragment.skymatch]
+name = "`skymatch`"
+
+[tool.towncrier.fragment.source_catalog]
+name = "`source_catalog`"
+
+[tool.towncrier.fragment.stpipe]
+name = "`stpipe`"
+
+[tool.towncrier.fragment.tweakreg]
+name = "`tweakreg`"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
using `towncrier` to handle changelog entries will
- drastically reduce (or even eliminate) branch conflicts in `CHANGES.rst` we currently experience with PRs
- keep the sections in `CHANGES.rst` consistent and eliminate duplicate sections
- allow automatic links to be generated in the changelog entries

[<img width="1152" alt="image" src="https://github.com/user-attachments/assets/a6775dd3-7656-43da-9293-09e2b93090c7">](https://roman-pipeline--1375.org.readthedocs.build/en/1375/roman/changes.html)

`towncrier` expects "news fragment" files (text files in the `changes/` directory with filenames in the format `<PR#>.<changetype>.rst`, i.e. for this PR it would be `changes/1375.docs.rst`). See docs at https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments

when ready to make a release, run `towncrier build` to ingest the news fragments and generate a changelog section in `CHANGES.rst` with all the new change log entries for that release (this clears the `changes/` directory of all news fragment files). This step should either be done before making a release, or could probably be added to a GitHub workflow triggered on release (to insert a commit and remake the tag).

After merging this PR the `Release Process` wiki page will need to be updated to include a step to run `towncrier build` instead of manually editing `CHANGES.rst`

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] ~updated relevant tests~
- [x] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [N/A] ~ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)~
