### PR TITLE
remove MultilineLogger, split logs with `\n` into multiple messages

### DIFF
--- a/romancal/associations/association.py
+++ b/romancal/associations/association.py
@@ -197,7 +197,8 @@ class Association(MutableMapping):
         try:
             jsonschema.validate(asn_data, asn_schema)
         except (AttributeError, jsonschema.ValidationError) as err:
-            logger.debug("Validation failed:\n%s", err)
+            logger.debug("Validation failed:")
+            logger.debug("%s", err)
             raise AssociationNotValidError("Validation failed") from err
         return True
 

--- a/romancal/associations/generate.py
+++ b/romancal/associations/generate.py
@@ -94,7 +94,7 @@ def generate(pool, rules, version_id=None, finalize=True):
         logger.debug("New process lists: %d", total_reprocess)
         logger.debug("Updated process queue: %s", process_queue)
         logger.debug("# associations: %d", len(associations))
-        logger.debug("Seconds to process: %.2f\n", timer() - time_start)
+        logger.debug("Seconds to process: %.2f", timer() - time_start)
 
     # Finalize found associations
     logger.debug("# associations before finalization: %d", len(associations))

--- a/romancal/associations/lib/log_config.py
+++ b/romancal/associations/lib/log_config.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from collections import defaultdict
-from functools import partialmethod
 from logging.config import dictConfig
 
 __all__ = ["log_config"]
@@ -128,28 +127,6 @@ DMS_config = {
         },
     }
 }
-
-
-class MultilineLogger(logging.getLoggerClass()):
-    """Split multilines so that each line is logged separately"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def log(self, level, msg, *args, **kwargs):
-        if self.isEnabledFor(level):
-            for line in msg.split("\n"):
-                self._log(level, line, args, **kwargs)
-
-    debug = partialmethod(log, logging.DEBUG)
-    info = partialmethod(log, logging.INFO)
-    warning = partialmethod(log, logging.WARNING)
-    error = partialmethod(log, logging.ERROR)
-    critical = partialmethod(log, logging.CRITICAL)
-    fatal = critical
-
-
-logging.setLoggerClass(MultilineLogger)
 
 
 def log_config(name=None, user_name=None, logger_config=None, config=None, merge=True):

--- a/romancal/flux/flux_step.py
+++ b/romancal/flux/flux_step.py
@@ -105,11 +105,10 @@ def apply_flux_correction(model):
     VARIANCES = ("var_rnoise", "var_poisson", "var_flat")
 
     if model.data.unit == model.meta.photometry.conversion_megajanskys.unit:
-        message = (
+        log.info(
             f"Input data is already in flux units of {model.meta.photometry.conversion_megajanskys.unit}."
-            "\nFlux correction already applied."
         )
-        log.info(message)
+        log.info("Flux correction already applied.")
         return
 
     if model.data.unit != LV2_UNITS:
@@ -117,7 +116,7 @@ def apply_flux_correction(model):
             f"Input data units {model.data.unit} are not in the expected units of {LV2_UNITS}"
             "\nAborting flux correction"
         )
-        log.error(message)
+        [log.error(line) for line in message.splitlines()]
         raise ValueError(message)
 
     # Apply the correction.


### PR DESCRIPTION
I marked this PR as `no-changelog-entry-needed` as I don't believe it changes any public API.

The use of `MultilineLogger` is problematic as it causes all later created loggers to use this class (which is not 100% compatible with all logging usage). As the main thing it achieves is splitting log messages that contain newlines into multiple lines this PR also switches all log messages (that I was able to find) that contain a newline into multiple log messages. Note that since `MultilineLogger` is registered during an import it is unpredictable which loggers become instances of `MultilineLogger` (and which are the default `Logger`) so it's likely this PR introduces a small change in the log output for some modified log messages.

Although unknown at this point, `MultilneLogger` may be contributing to the issues currently seen with the `metrics_logger` (see https://jira.stsci.edu/browse/SCSB-174)

Regression tests running at https://github.com/spacetelescope/RegressionTests/actions/runs/10514305515

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
