### PR TITLE
Add a default suffix to ELP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 0.16.2 (unreleased)
 ===================
 
--
+pipeline
+--------
+
+- Added ``suffix`` to the spec of ExposurePipeline with a 
+  default value of ``cal``. Removed explicit setting of ``suffix`` 
+  so that it can be passed as an argument to ``strun``. [#1378]
 
 0.16.1 (2024-08-13)
 ===================

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -47,6 +47,7 @@ class ExposurePipeline(RomanPipeline):
     spec = """
         save_calibrated_ramp = boolean(default=False)
         save_results = boolean(default=False)
+        suffix = string(default="cal")
     """
 
     # Define aliases to steps
@@ -179,8 +180,6 @@ class ExposurePipeline(RomanPipeline):
                 result.meta.cal_step.tweakreg = "SKIPPED"
                 self.suffix = "cal"
 
-            self.setup_output(result)
-
             self.output_use_model = True
             results.append(result)
 
@@ -192,10 +191,6 @@ class ExposurePipeline(RomanPipeline):
         log.info("Roman exposure calibration pipeline ending...")
 
         return results
-
-    def setup_output(self, input):
-        """Determine the proper file name suffix to use later"""
-        self.suffix = "cal"
 
     def create_fully_saturated_zeroed_image(self, input_model):
         """

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -150,8 +150,6 @@ class ExposurePipeline(RomanPipeline):
                 ]:
                     result.meta.cal_step[step_str] = "SKIPPED"
 
-                # Set suffix for proper output naming
-                self.suffix = "cal"
                 results.append(result)
                 return results
 
@@ -178,11 +176,10 @@ class ExposurePipeline(RomanPipeline):
                 result.meta.cal_step.photom = "SKIPPED"
                 result.meta.cal_step.source_detection = "SKIPPED"
                 result.meta.cal_step.tweakreg = "SKIPPED"
-                self.suffix = "cal"
 
             self.output_use_model = True
             results.append(result)
-
+            
         # Now that all the exposures are collated, run tweakreg
         # Note: this does not cover the case where the asn mixes imaging and spectral
         #          observations. This should not occur on-prem
@@ -220,9 +217,6 @@ class ExposurePipeline(RomanPipeline):
             "tweakreg",
         ]:
             fully_saturated_model.meta.cal_step[step_str] = "SKIPPED"
-
-        # Set suffix for proper output naming
-        self.suffix = "cal"
 
         # Return zeroed-out image file
         return fully_saturated_model

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -551,7 +551,7 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 def test_pipeline_suffix(rtdata, ignore_asdf_paths):
-    """Tests for fully saturated data skipping steps in the pipeline"""
+    """Tests passing suffix to the pipeline"""
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
 

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -519,8 +519,8 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
 def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
     """Tests for fully saturated data skipping steps in the pipeline
 
-       Note that this test mimics how the pipeline is run in OPS.
-       Any changes to this test should be coordinated with OPS.
+    Note that this test mimics how the pipeline is run in OPS.
+    Any changes to this test should be coordinated with OPS.
     """
     input_data = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -517,7 +517,11 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
-    """Tests for fully saturated data skipping steps in the pipeline"""
+    """Tests for fully saturated data skipping steps in the pipeline
+
+       Note that this test mimics how the pipeline is run in OPS.
+       Any changes to this test should be coordinated with OPS.
+    """
     input_data = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
@@ -589,5 +593,5 @@ def test_pipeline_suffix(rtdata, ignore_asdf_paths):
     assert model.meta.cal_step.flat_field == "COMPLETE"
     assert model.meta.cal_step.photom == "COMPLETE"
     assert model.meta.cal_step.source_detection == "COMPLETE"
-    assert model.meta.cal_step.tweakreg == "SKIPPED"
+    assert model.meta.cal_step.tweakreg == "INCOMPLETE"
     assert model.meta.filename == output

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -551,7 +551,13 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 def test_pipeline_suffix(rtdata, ignore_asdf_paths):
-    """Tests passing suffix to the pipeline"""
+    """
+    Tests passing suffix to the pipeline
+    
+    Note that this test mimics how the pipeline is run in OPS.
+    
+    Any changes to this test should be coordinated with OPS.
+    """
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
 

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -553,9 +553,9 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
 def test_pipeline_suffix(rtdata, ignore_asdf_paths):
     """
     Tests passing suffix to the pipeline
-    
+
     Note that this test mimics how the pipeline is run in OPS.
-    
+
     Any changes to this test should be coordinated with OPS.
     """
     input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-898](https://jira.stsci.edu/browse/RCAL-898)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1379 

<!-- describe the changes comprising this PR here -->
This PR addresses an issue in OPS where files generated from the ELP do not have the expected suffix.
With this change passing `--sufix=` to the `strun` command generates output with the specified suffix. If no suffix is passed, the default suffix is `cal`. 


**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
