### PR TITLE
skip context arrays for many_to_many and non-science resampling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "tweakwcs >=0.8.8",
     "spherical-geometry >= 1.2.22",
     "stsci.imagestats >= 1.6.3",
-    "drizzle >= 1.15.0",
+    "drizzle >= 1.15.3",
     "webbpsf >= 1.2.1",
 ]
 dynamic = [

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -384,7 +384,7 @@ class ResampleData:
         self.update_exposure_times(output_model, exptime_tot)
 
         # TODO: fix RAD to expect a context image datatype of int32
-        output_model.context = output_model.context.astype(np.uint32)
+        output_model.context = driz.outcon.astype(np.uint32)
 
         return ModelLibrary([output_model])
 


### PR DESCRIPTION
This PR skips using a "context" array when resampling for:
- outlier detection
- variance arrays
- exposure time

and retains use of a "context" array for resampling science data.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/10564712340

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [ ] added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
