### PR TITLE
Populate segmentation model metadata for exposures and mosaics.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ source_catalog
 
 - Populate segmentation image metadata. [#1391]
 
+resample
+--------
+
+- Use association product name for output meta.filename by default [#1391]
+
 0.16.2 (2024-08-23)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ mosaic_pipeline
 
 - Only load patch table when needed. [#1367]
 
+source_catalog
+--------------
+
+- Populate segmentation image metadata. [#1391]
+
 0.16.2 (2024-08-23)
 ===================
 

--- a/romancal/outlier_detection/outlier_detection_step.py
+++ b/romancal/outlier_detection/outlier_detection_step.py
@@ -152,7 +152,7 @@ class OutlierDetectionStep(RomanStep):
                     intermediate_files_suffixes = (
                         "*blot.asdf",
                         "*median.asdf",
-                        f'*{pars.get("resample_suffix")}*.asdf',
+                        f'*outlier_{pars.get("resample_suffix")}.asdf',
                     )
                     for current_path in intermediate_files_paths:
                         for suffix in intermediate_files_suffixes:

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -132,9 +132,7 @@ class MosaicPipeline(RomanPipeline):
                         wcs_file = asdf.open(self.resample.output_wcs)
                         self.suffix = "i2d"
                         result = self.resample(result)
-                        self.output_file = input.asn["products"][0]["name"]
-                        # force the SourceCatalogStep to save the results
-                        self.sourcecatalog.save_results = True
+                        self.sourcecatalog.output_file = input.asn["products"][0]["name"]
                         result_catalog = self.sourcecatalog(result)
                     else:
                         log.info("resampling a mosaic file is not yet supported")
@@ -144,7 +142,7 @@ class MosaicPipeline(RomanPipeline):
                 self.resample.suffix = "i2d"
                 self.output_file = input.asn["products"][0]["name"]
                 result = self.resample(result)
-                self.sourcecatalog.save_results = True
+                self.sourcecatalog.output_file = self.output_file
                 result_catalog = self.sourcecatalog(result)  # noqa: F841
                 self.suffix = "i2d"
                 if input_filename:

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -131,8 +131,9 @@ class MosaicPipeline(RomanPipeline):
                         )
                         wcs_file = asdf.open(self.resample.output_wcs)
                         self.suffix = "i2d"
+                        self.output_file = input.asn["products"][0]["name"]
                         result = self.resample(result)
-                        self.sourcecatalog.output_file = input.asn["products"][0]["name"]
+                        self.sourcecatalog.output_file = self.output_file
                         result_catalog = self.sourcecatalog(result)
                     else:
                         log.info("resampling a mosaic file is not yet supported")

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -83,11 +83,14 @@ class ResampleStep(RomanStep):
             output = input_models.asn["products"][0]["name"]
         elif isinstance(input, ModelLibrary):
             input_models = input
-            # set output filename using the common prefix of all datamodels
-            output = f"{os.path.commonprefix([x['expname'] for x in input_models.asn['products'][0]['members']])}.asdf"
-            if len(output) == 0:
-                # set default filename if no common prefix can be determined
-                output = "resample_output.asdf"
+            if "name" in input_models.asn["products"][0]:
+                output = input_models.asn["products"][0]["name"]
+            else:
+                # set output filename using the common prefix of all datamodels
+                output = f"{os.path.commonprefix([x['expname'] for x in input_models.asn['products'][0]['members']])}.asdf"
+                if len(output) == 0:
+                    # set default filename if no common prefix can be determined
+                    output = "resample_output.asdf"
         else:
             raise TypeError(
                 "Input must be an ASN filename, a ModelLibrary, "

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -146,9 +146,16 @@ class SourceCatalogStep(RomanStep):
     def save_base_results(self, segment_img, source_catalog_model):
         # save the segmentation map and
         output_filename = source_catalog_model.meta.filename
-        segmentation_model = maker_utils.mk_datamodel(
-            datamodels.MosaicSegmentationMapModel
-        )
+
+        if isinstance(source_catalog_model, datamodels.SourceCatalogModel):
+            seg_model = datamodels.SegmentationMapModel
+        else:
+            seg_model = datamodels.MosaicSegmentationMapModel
+
+        segmentation_model = maker_utils.mk_datamodel(seg_model)
+        for key in segmentation_model.meta.keys():
+            segmentation_model.meta[key] = source_catalog_model.meta[key]
+
         if segment_img is not None:
             segmentation_model.data = segment_img.data.astype(np.uint32)
             self.save_model(

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -145,7 +145,9 @@ class SourceCatalogStep(RomanStep):
 
     def save_base_results(self, segment_img, source_catalog_model):
         # save the segmentation map and
-        output_filename = source_catalog_model.meta.filename
+        output_filename = (self.output_file
+                           if self.output_file is not None
+                           else source_catalog_model.meta.filename)
 
         if isinstance(source_catalog_model, datamodels.SourceCatalogModel):
             seg_model = datamodels.SegmentationMapModel

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -14,6 +14,7 @@ from roman_datamodels.datamodels import (
     MosaicModel,
     MosaicSegmentationMapModel,
     MosaicSourceCatalogModel,
+    SegmentationMapModel,
     SourceCatalogModel,
 )
 from roman_datamodels.maker_utils import mk_level2_image, mk_level3_mosaic
@@ -461,7 +462,7 @@ def test_do_psf_photometry_column_names(tmp_path, image_model, fit_psf):
             ImageModel,
             {
                 "cat": SourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
+                "segm": SegmentationMapModel,
                 "sourcecatalog": ImageModel,
             },
         ),
@@ -474,7 +475,7 @@ def test_do_psf_photometry_column_names(tmp_path, image_model, fit_psf):
             SourceCatalogModel,
             {
                 "cat": SourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
+                "segm": SegmentationMapModel,
             },
         ),
         (
@@ -486,7 +487,7 @@ def test_do_psf_photometry_column_names(tmp_path, image_model, fit_psf):
             ImageModel,
             {
                 "cat": SourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
+                "segm": SegmentationMapModel,
             },
         ),
         (
@@ -498,7 +499,7 @@ def test_do_psf_photometry_column_names(tmp_path, image_model, fit_psf):
             SourceCatalogModel,
             {
                 "cat": SourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
+                "segm": SegmentationMapModel,
             },
         ),
     ),


### PR DESCRIPTION
Closes #1389 

We were previously populating segmentation image metadata with filler values that were not related to the input L2 or L3 image.  This PR adds code that copies the metadata from the catalogs into the segmentation images.

This now also fixes some file naming issues; the mosaic pipeline was saving the catalogs, as well as the step saving the catalogs, leading to two copies of the catalogs with different file names.  Now only the step saves the catalogs.  I have also changed some of the logic around the construction of the file names.

Regtests running here: https://github.com/spacetelescope/RegressionTests/actions/runs/10600468693/job/29383387213

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [X] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
