### PR TITLE
rcal-906 Allow asn product name to be the output product name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 mosaic_pipeline
 ---------------
 
-- Allow asn product name to be the output product []
+- Allow asn product name to be the output product [#1394]
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+0.16.4dev
+=========
+
+mosaic_pipeline
+---------------
+
+- Allow asn product name to be the output product []
+
+
+
+
 0.16.3 (2024-08-29)
 ===================
 

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -100,8 +100,7 @@ class MosaicPipeline(RomanPipeline):
                 if skycell_name in skycell_record["name"]:
                     # skycell name are in the form of r270dm90x99y99
                     # example of product name "r0099101001001001001_F158_visit_r270dm90x99y99"
-                    skycell_root = re.findall("^[^%\n\r]*_", product_name)[0]
-                    skycell_file_name = skycell_root + skycell_name + "_i2d.asdf"
+                    skycell_file_name = product_name + "_i2d.asdf"
 
                     # check to see if there exists a skycell on disk if not create it
                     if not isfile(skycell_file_name):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-906](https://jira.stsci.edu/browse/RCAL-906)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1390

<!-- describe the changes comprising this PR here -->
This PR allows the asn product name to be the output product name

**Checklist**
- [x] added entry in `CHANGES.rst` under the corresponding subsection
- [N/A] updated relevant tests
- [N/A] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
The passing regression tests are at: 
https://github.com/spacetelescope/RegressionTests/actions/runs/10635674348
