### PR TITLE
unpin pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
 ]
 test = [
     "ci-watson >=0.5.0",
-    "pytest >=4.6.0, <8.0.0",
+    "pytest >8.0.0",
     "pytest-astropy",
     "deepdiff",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 test = [
     "ci-watson >=0.5.0",
     "pytest >8.0.0",
-    "pytest-astropy",
+    "pytest-astropy >= 0.11.0",
     "deepdiff",
 ]
 dev = [


### PR DESCRIPTION
This PR removes the upper pin for pytest and updates the lower pin.

It's unclear why https://github.com/spacetelescope/romancal/pull/1085 added the upper pin.

This caused issues during testing with stasis as some packages use pytest > 8.0.

Regression tests all passed: https://github.com/spacetelescope/RegressionTests/actions/runs/10814310251

**Checklist**
- [ ] for a public change, added a towncrier news fragment in `changes/` <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
    - ``changes/<PR#>.docs.rst``
    - ``changes/<PR#>.stpipe.rst``
    - ``changes/<PR#>.associations.rst``
    - ``changes/<PR#>.scripts.rst``
    - ``changes/<PR#>.mosaic_pipeline.rst``
    - ``changes/<PR#>.patch_match.rst``

    ## steps
    - ``changes/<PR#>.dq_init.rst``
    - ``changes/<PR#>.saturation.rst``
    - ``changes/<PR#>.refpix.rst``
    - ``changes/<PR#>.linearity.rst``
    - ``changes/<PR#>.dark_current.rst``
    - ``changes/<PR#>.jump_detection.rst``
    - ``changes/<PR#>.ramp_fitting.rst``
    - ``changes/<PR#>.assign_wcs.rst``
    - ``changes/<PR#>.flatfield.rst``
    - ``changes/<PR#>.photom.rst``
    - ``changes/<PR#>.flux.rst``
    - ``changes/<PR#>.source_detection.rst``
    - ``changes/<PR#>.tweakreg.rst``
    - ``changes/<PR#>.skymatch.rst``
    - ``changes/<PR#>.outlier_detection.rst``
    - ``changes/<PR#>.resample.rst``
    - ``changes/<PR#>.source_catalog.rst``
  </details>
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
