### PR TITLE
add CI check that CHANGES.rst is not modified

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
       - run: pip install towncrier
       - run: towncrier check
       - run: towncrier build --draft | grep -P '#${{ github.event.number }}'
-  no_changelog_edit:
+  changelog_uses_towncrier:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-manual-changelog-edit') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,3 +28,11 @@ jobs:
       - run: pip install towncrier
       - run: towncrier check
       - run: towncrier build --draft | grep -P '#${{ github.event.number }}'
+  no_changelog_edit:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-manual-changelog-edit') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git diff HEAD ${{ github.event.pull_request.base.sha }} --no-patch --exit-code CHANGES.rst


### PR DESCRIPTION
Add a CI check to make sure PRs don't change `CHANGES.rst`. Changelog entries now take the form of towncrier fragments and manual edits to `CHANGES.rst` are no longer needed.

Here's a run of the new check that fails (due to an edit to `CHANGES.rst` added temporarily to this PR): https://github.com/spacetelescope/romancal/actions/runs/10906504272/job/30267904518?pr=1412

**Checklist**
- [ ] for a public change, added a towncrier news fragment in `changes/` <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
    - ``changes/<PR#>.docs.rst``
    - ``changes/<PR#>.stpipe.rst``
    - ``changes/<PR#>.associations.rst``
    - ``changes/<PR#>.scripts.rst``
    - ``changes/<PR#>.mosaic_pipeline.rst``
    - ``changes/<PR#>.patch_match.rst``

    ## steps
    - ``changes/<PR#>.dq_init.rst``
    - ``changes/<PR#>.saturation.rst``
    - ``changes/<PR#>.refpix.rst``
    - ``changes/<PR#>.linearity.rst``
    - ``changes/<PR#>.dark_current.rst``
    - ``changes/<PR#>.jump_detection.rst``
    - ``changes/<PR#>.ramp_fitting.rst``
    - ``changes/<PR#>.assign_wcs.rst``
    - ``changes/<PR#>.flatfield.rst``
    - ``changes/<PR#>.photom.rst``
    - ``changes/<PR#>.flux.rst``
    - ``changes/<PR#>.source_detection.rst``
    - ``changes/<PR#>.tweakreg.rst``
    - ``changes/<PR#>.skymatch.rst``
    - ``changes/<PR#>.outlier_detection.rst``
    - ``changes/<PR#>.resample.rst``
    - ``changes/<PR#>.source_catalog.rst``
  </details>
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
