### PR TITLE
[CI] rename changelog check job to be more explicit on its purpose

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,5 +35,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: prevent direct changes to `CHANGES.rst` (you can override this with the `allow-manual-changelog-edit` label)
+      - name: prevent direct changes to `CHANGES.rst` (write a towncrier fragment in `changes/` instead; you can override this with the `allow-manual-changelog-edit` label)
         run: git diff HEAD ${{ github.event.pull_request.base.sha }} --no-patch --exit-code CHANGES.rst

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,11 +28,12 @@ jobs:
       - run: pip install towncrier
       - run: towncrier check
       - run: towncrier build --draft | grep -P '#${{ github.event.number }}'
-  changelog_uses_towncrier:
+  prevent_manually_editing_changlog:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-manual-changelog-edit') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git diff HEAD ${{ github.event.pull_request.base.sha }} --no-patch --exit-code CHANGES.rst
+      - name: prevent direct changes to `CHANGES.rst` (you can override this with the `allow-manual-changelog-edit` label)
+        run: git diff HEAD ${{ github.event.pull_request.base.sha }} --no-patch --exit-code CHANGES.rst


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
follow-on to #1412 to make the check less confusing

**Checklist**
- [ ] for a public change, added a towncrier news fragment in `changes/` <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
    - ``changes/<PR#>.docs.rst``
    - ``changes/<PR#>.stpipe.rst``
    - ``changes/<PR#>.associations.rst``
    - ``changes/<PR#>.scripts.rst``
    - ``changes/<PR#>.mosaic_pipeline.rst``
    - ``changes/<PR#>.patch_match.rst``

    ## steps
    - ``changes/<PR#>.dq_init.rst``
    - ``changes/<PR#>.saturation.rst``
    - ``changes/<PR#>.refpix.rst``
    - ``changes/<PR#>.linearity.rst``
    - ``changes/<PR#>.dark_current.rst``
    - ``changes/<PR#>.jump_detection.rst``
    - ``changes/<PR#>.ramp_fitting.rst``
    - ``changes/<PR#>.assign_wcs.rst``
    - ``changes/<PR#>.flatfield.rst``
    - ``changes/<PR#>.photom.rst``
    - ``changes/<PR#>.flux.rst``
    - ``changes/<PR#>.source_detection.rst``
    - ``changes/<PR#>.tweakreg.rst``
    - ``changes/<PR#>.skymatch.rst``
    - ``changes/<PR#>.outlier_detection.rst``
    - ``changes/<PR#>.resample.rst``
    - ``changes/<PR#>.source_catalog.rst``
  </details>
- [ ] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below. [How to run regression tests on a PR](https://github.com/spacetelescope/romancal/wiki/Running-Regression-Tests-Against-PR-Branches)
