### PR TITLE
fix artifactory_repos for pytest 8

### DIFF
--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -17,12 +17,17 @@ TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
 @pytest.fixture(scope="session")
 def artifactory_repos(pytestconfig):
     """Provides Artifactory inputs_root and results_root"""
-    try:
-        inputs_root = pytestconfig.getini("inputs_root")[0]
-        results_root = pytestconfig.getini("results_root")[0]
-    except IndexError:
+    inputs_root = pytestconfig.getini("inputs_root")
+    if not inputs_root:
         inputs_root = "roman-pipeline"
+    else:
+        inputs_root = inputs_root[0]
+
+    results_root = pytestconfig.getini("results_root")
+    if not results_root:
         results_root = "roman-pipeline-results"
+    else:
+        results_root = results_root[0]
     return inputs_root, results_root
 
 


### PR DESCRIPTION
Similar to https://github.com/spacetelescope/jwst/pull/8245

This PR updates the conftest in the regtest directory to fix the stcal downstream tests.

The stcal downstream tests don't define `inputs_root` or `results_root` which causes pytest 8 to return `None` for `pytestconfig.getini('inputs_root')` (where previous pytest versions returned an empty list). Since `None[0]` triggers a `TypeError` instead of an `IndexError` the current `artifactory_repos` fixture fails to fall back to the default values. This PR changes the try except to an `if ...` (the same as the above jwst PR). This should fix the current downstream failures in the stcal CI.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
