### PR TITLE
Work around NotImplemented Quantity.tofile

### DIFF
--- a/changes/1436.outlier_detection.rst
+++ b/changes/1436.outlier_detection.rst
@@ -1,0 +1,1 @@
+Fix bug where on_disk=True could fail due to Quantities not implementing tofile.

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -86,7 +86,7 @@ def _median_with_resampling(
 
             weight_threshold = compute_weight_threshold(drizzled_model.weight, maskpt)
             drizzled_model.data[drizzled_model.weight < weight_threshold] = np.nan
-            computer.append(drizzled_model.data, i)
+            computer.append(drizzled_model.data.value, i)
             del drizzled_model
 
     # Perform median combination on set of drizzled mosaics
@@ -173,7 +173,7 @@ def _median_without_resampling(
 
             weight_threshold = compute_weight_threshold(wht, maskpt)
 
-            data_copy = model.data.copy()
+            data_copy = model.data.value.copy()
             data_copy[wht < weight_threshold] = np.nan
             computer.append(data_copy, i)
 


### PR DESCRIPTION
This is a follow-up to https://github.com/spacetelescope/romancal/pull/1357 to fix a but revealed during other testing.

Calling `OutlierDetection` with `on_disk=True` fails with:
```
 NotImplementedError: cannot write Quantities to file.  Write array with q.value.tofile(...)
```

This PR works around the issue that calling `tofile` (which [stcal](https://github.com/spacetelescope/stcal/blob/787aa81a6719bb0c72be8972171c7f3f88c8adf0/src/stcal/outlier_detection/median.py#L214) now uses) is unsupported for Quantities.

This bug was hidden as the unit test that sets `in_memory=True` for outlier detection didn't provide an `on_disk` `ModelLibrary` which bypassed the call to `tofile` in stcal. This PR also updates the unit test to now check for that condition.

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/11167537599

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
