### PR TITLE
Make var_flat optional.

### DIFF
--- a/docs/roman/flatfield/main.rst
+++ b/docs/roman/flatfield/main.rst
@@ -59,3 +59,10 @@ and finally the error that is associated with the science data is given by,
 
 The total ERR array in the science exposure is updated as the square root
 of the quadratic sum of VAR_POISSON, VAR_RNOISE, and VAR_FLAT.
+
+Note that by default we do not compute VAR_FLAT nor include its
+contribution to ERR, unless the "include_var_flat" is specified.  This
+means that the uncertainties on very bright pixels are
+underestimated.  However, other effects like charge migration,
+saturation, and non-linearity can be important at these flux levels,
+and their contributions to the uncertainty are never included.

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -14,7 +14,7 @@ log.setLevel(logging.DEBUG)
 MICRONS_100 = 1.0e-4  # 100 microns, in meters
 
 
-def do_correction(input_model, flat=None):
+def do_correction(input_model, flat=None, include_var_flat=False):
     """Flat-field a Roman data model using a flat-field model
 
     Parameters
@@ -25,6 +25,9 @@ def do_correction(input_model, flat=None):
     flat : Roman data model, or None
         Data model containing flat-field for all instruments
 
+    include_var_flat : bool
+        compute & store the flat field variance?
+
     Returns
     -------
     output_model : data model
@@ -32,12 +35,12 @@ def do_correction(input_model, flat=None):
         The data is modified in place.
     """
 
-    do_flat_field(input_model, flat)
+    do_flat_field(input_model, flat, include_var_flat=include_var_flat)
 
     return input_model
 
 
-def do_flat_field(output_model, flat_model):
+def do_flat_field(output_model, flat_model, include_var_flat=False):
     """Apply flat-fielding, and update the output model.
 
     Parameters
@@ -47,6 +50,9 @@ def do_flat_field(output_model, flat_model):
 
     flat_model : Roman data model
         data model containing flat-field
+
+    include_var_flat : bool
+        compute & store the flat field variance?
     """
     if flat_model is not None and output_model.data.shape != flat_model.data.shape:
         # Check to see if flat data array is smaller than science data
@@ -62,11 +68,12 @@ def do_flat_field(output_model, flat_model):
         log.info("Skipping flat field - no flat reference file.")
         output_model.meta.cal_step.flat_field = "SKIPPED"
     else:
-        apply_flat_field(output_model, flat_model)
+        apply_flat_field(output_model, flat_model,
+                         include_var_flat=include_var_flat)
         output_model.meta.cal_step.flat_field = "COMPLETE"
 
 
-def apply_flat_field(science, flat):
+def apply_flat_field(science, flat, include_var_flat=False):
     """Flat field the data and error arrays.
 
     Extended summary
@@ -83,6 +90,9 @@ def apply_flat_field(science, flat):
 
     flat : Roman data model
         flat field data model
+
+    include_var_flat : bool
+        compute & store the flat vield variance?
     """
     flat_data = flat.data.copy()
     flat_dq = flat.dq.copy()
@@ -114,13 +124,19 @@ def apply_flat_field(science, flat):
     flat_data_squared = flat_data**2
     science.var_poisson /= flat_data_squared
     science.var_rnoise /= flat_data_squared
-    try:
-        science.var_flat = science.data**2 / flat_data_squared * flat_err**2
-    except AttributeError:
-        science["var_flat"] = np.zeros(shape=science.data.shape, dtype=np.float32)
-        science.var_flat = science.data**2 / flat_data_squared * flat_err**2
 
-    science.err = np.sqrt(science.var_poisson + science.var_rnoise + science.var_flat)
+    total_var = science.var_poisson + science.var_rnoise
+    if include_var_flat:
+        try:
+            science.var_flat = science.data**2 / flat_data_squared * flat_err**2
+        except AttributeError:
+            science["var_flat"] = np.zeros(
+                shape=science.data.shape, dtype=np.float32)
+            science.var_flat = (science.data**2
+                                    / flat_data_squared * flat_err**2)
+        total_var += science.var_flat
+
+    science.err = np.sqrt(total_var)
     science.err = science.err.to(science.data.unit)
     # Workaround for https://github.com/astropy/astropy/issues/16055
 

--- a/romancal/flatfield/flat_field_step.py
+++ b/romancal/flatfield/flat_field_step.py
@@ -13,6 +13,10 @@ __all__ = ["FlatFieldStep"]
 class FlatFieldStep(RomanStep):
     """Flat-field a science image using a flatfield reference image."""
 
+    spec = """
+        include_var_flat = boolean(default=False) # include flat field variance
+    """  # noqa: E501
+
     reference_file_types = ["flat"]
 
     def process(self, input_model):
@@ -38,6 +42,7 @@ class FlatFieldStep(RomanStep):
         output_model = flat_field.do_correction(
             input_model,
             reference_file_model,
+            include_var_flat=self.include_var_flat
         )
 
         # Close reference file

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -97,6 +97,21 @@ def test_crds_temporal_match(instrument, exptype):
     )
 
 
+def test_skip_var_flat():
+    """Test that we don't populate var_flat if requested."""
+
+    wfi_image1 = maker_utils.mk_level2_image()
+    wfi_image2 = maker_utils.mk_level2_image()
+    del wfi_image1['var_flat']
+    del wfi_image2['var_flat']
+    wfi_image_model1 = ImageModel(wfi_image1)
+    wfi_image_model2 = ImageModel(wfi_image2)
+    result1 = FlatFieldStep.call(wfi_image_model1, include_var_flat=False)
+    result2 = FlatFieldStep.call(wfi_image_model2, include_var_flat=True)
+    assert not hasattr(result1, 'var_flat')
+    assert hasattr(result2, 'var_flat')
+
+
 @pytest.mark.parametrize(
     "instrument",
     [

--- a/romancal/flux/flux_step.py
+++ b/romancal/flux/flux_step.py
@@ -102,7 +102,9 @@ def apply_flux_correction(model):
     """
     # Define the various arrays to be converted.
     DATA = ("data", "err")
-    VARIANCES = ("var_rnoise", "var_poisson", "var_flat")
+    VARIANCES = ("var_rnoise", "var_poisson")
+    if hasattr(model, "var_flat"):
+        VARIANCES = VARIANCES + ("var_flat",)
 
     if model.data.unit == model.meta.photometry.conversion_megajanskys.unit:
         log.info(

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -59,14 +59,13 @@ def test_resample_single_file(rtdata, ignore_asdf_paths):
                         "err",
                         "var_poisson",
                         "var_rnoise",
-                        "var_flat",
                     ]
                 )
             }"""
     )
     assert all(
         hasattr(resample_out, x)
-        for x in ["data", "err", "var_poisson", "var_rnoise", "var_flat"]
+        for x in ["data", "err", "var_poisson", "var_rnoise"]
     )
 
     step.log.info(
@@ -94,14 +93,14 @@ def test_resample_single_file(rtdata, ignore_asdf_paths):
                             np.isnan(getattr(resample_out, x)),
                             np.equal(getattr(resample_out, x), 0)
                         )
-                    ) > 0 for x in ["var_poisson", "var_rnoise", "var_flat"]
+                    ) > 0 for x in ["var_poisson", "var_rnoise"]
                 )
 
             }"""
     )
     assert all(
         np.sum(np.isnan(getattr(resample_out, x)))
-        for x in ["var_poisson", "var_rnoise", "var_flat"]
+        for x in ["var_poisson", "var_rnoise"]
     )
 
     step.log.info(

--- a/romancal/regtest/test_wfi_pipeline.py
+++ b/romancal/regtest/test_wfi_pipeline.py
@@ -198,11 +198,6 @@ def test_level2_image_processing_pipeline(rtdata, ignore_asdf_paths):
         " level 2 image output......." + passfail("var_rnoise" in model.keys())
     )
     assert "var_rnoise" in model.keys()
-    pipeline.log.info(
-        "DMS87 MSG: Testing existence of flatfield uncertainty variance array"
-        " (var_flat) in Level 2 image output...." + passfail("var_flat" in model.keys())
-    )
-    assert "var_flat" in model.keys()
 
     # DMS88 total exposure time test
     pipeline.log.info(

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -165,6 +165,8 @@ class ResampleData:
 
         with self.input_models:
             models = list(self.input_models)
+            self.all_have_var_flat = np.all([
+                hasattr(model, 'var_flat') for model in models])
 
             # update meta.basic
             populate_mosaic_basic(self.blank_output, models)
@@ -187,6 +189,9 @@ class ResampleData:
             ]
             for i, m in enumerate(models):
                 self.input_models.shelve(m, i, modify=False)
+
+        if not self.all_have_var_flat:
+            del self.blank_output._instance['var_flat']
 
     def do_drizzle(self):
         """Pick the correct drizzling mode based on ``self.single``."""
@@ -339,6 +344,9 @@ class ResampleData:
         )
 
         log.info("Resampling science data")
+
+        all_have_var_flat = True
+
         with self.input_models:
             for i, img in enumerate(self.input_models):
                 inwht = resample_utils.build_driz_weight(
@@ -380,23 +388,18 @@ class ResampleData:
         # Resample variances array in self.input_models to output_model
         self.resample_variance_array("var_rnoise", output_model)
         self.resample_variance_array("var_poisson", output_model)
-        self.resample_variance_array("var_flat", output_model)
+        if self.all_have_var_flat:
+            self.resample_variance_array("var_flat", output_model)
 
         # Make exposure time image
         exptime_tot = self.resample_exposure_time(output_model)
 
-        # TODO: fix unit here
+        all_vars = [output_model.var_rnoise, output_model.var_poisson]
+        if self.all_have_var_flat:
+            all_vars = all_vars + [output_model.var_flat]
+
         output_model.err = u.Quantity(
-            np.sqrt(
-                np.nansum(
-                    [
-                        output_model.var_rnoise,
-                        output_model.var_poisson,
-                        output_model.var_flat,
-                    ],
-                    axis=0,
-                )
-            ),
+            np.sqrt(np.nansum(all_vars, axis=0)),
             unit=output_model.err.unit,
         )
 

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -602,6 +602,28 @@ def test_update_exposure_times_same_sca_different_exposures(exposure_1, exposure
         output_models.shelve(output_model, 0, modify=False)
 
 
+@pytest.mark.parametrize("include_var_flat", [False, True])
+def test_var_flat_presence(exposure_1, include_var_flat):
+    """Test that var_flat is included or excluded depending on its presence in the underlying exposures."""
+    if not include_var_flat:
+        exposure_1 = [e.copy() for e in exposure_1]
+        for e in exposure_1:
+            del e._instance['var_flat']
+    input_models = ModelLibrary(exposure_1)
+    resample_data = ResampleData(input_models)
+
+    output_models = resample_data.resample_many_to_one()
+    with output_models:
+        output_model = output_models.borrow(0)
+
+        if not include_var_flat:
+            assert not hasattr(output_model, 'var_flat')
+        else:
+            assert hasattr(output_model, 'var_flat')
+
+        output_models.shelve(output_model, 0, modify=False)
+
+
 @pytest.mark.parametrize(
     "name",
     ["var_rnoise", "var_poisson", "var_flat"],


### PR DESCRIPTION
This PR makes the ELP not compute var_flat by default for individual exposures.  It adds a new keyword "include_var_flat" to the flat field step spec to enable including the flat field variances, with a default value of False---we will not by default compute var_flat.  It adds tests to make sure that this keyword is being followed.

Together with https://github.com/spacetelescope/rad/pull/462, it makes the mosaic pipeline either create a var_flat extension or not, depending on whether the input exposures contain var_flat.  If not all of the input exposures include var_flat, it will not compute var_flat in the output.

This will lead to changes in the regression tests, since we will not be computing var_flat by default.  The derived errors will also be different.  If we update the exposures used as input for the mosaic pipeline to not include flat variances, the derived mosaics will also be different.

"err" will no longer include a contribution from var_flat by default, in either the exposures or eventually the mosaics.  In principle we could include var_flat in "err" but still delete var_flat by default.  This seems a little perverse to me, but I mention it as a possibility.

It makes a handful of forward-looking changes to the regression tests, essentially not requiring that var_flat exist.

@tddesjardins , @hcferguson, you've expressed opinions about removing this in the past; care to weigh in?

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
