### PR TITLE
Group models by obs_id for steps that use grouping

### DIFF
--- a/changes/1448.outlier_detection.1.rst
+++ b/changes/1448.outlier_detection.1.rst
@@ -1,0 +1,1 @@
+Group by obs_id

--- a/changes/1448.resample.2.rst
+++ b/changes/1448.resample.2.rst
@@ -1,0 +1,1 @@
+Group by obs_id

--- a/changes/1448.tweakreg.0.rst
+++ b/changes/1448.tweakreg.0.rst
@@ -1,0 +1,1 @@
+Group by obs_id

--- a/romancal/datamodels/library.py
+++ b/romancal/datamodels/library.py
@@ -75,8 +75,4 @@ def _mapping_to_group_id(mapping):
     """
     Combine a number of file metadata values into a ``group_id`` string
     """
-    return (
-        "roman{program}{observation}{visit}"
-        "_{visit_file_group}{visit_file_sequence}{visit_file_activity}"
-        "_{exposure}"
-    ).format_map(mapping)
+    return "{obs_id}".format_map(mapping)

--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -142,7 +142,7 @@ def test_find_outliers(tmp_path, base_image, on_disk):
         img.data[42, 72] = source_value
         img.err[:] = err_value
         img.meta.filename = str(tmp_path / f"img{i}_suffix.asdf")
-        img.meta.observation.exposure = i
+        img.meta.observation.obs_id = str(i)
         img.meta.background.level = 0
         imgs.append(img)
 

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -253,6 +253,7 @@ def exposure_1(wfi_sca1, wfi_sca2, wfi_sca3):
             "2020-02-01T00:02:30", format="isot", scale="utc"
         )
         sca.meta.observation["exposure"] = 1
+        sca.meta.observation["obs_id"] = "1"
     return [wfi_sca1, wfi_sca2, wfi_sca3]
 
 
@@ -268,6 +269,7 @@ def exposure_2(wfi_sca4, wfi_sca5, wfi_sca6):
             "2020-05-01T00:02:30", format="isot", scale="utc"
         )
         sca.meta.observation["exposure"] = 2
+        sca.meta.observation["obs_id"] = "2"
     return [wfi_sca4, wfi_sca5, wfi_sca6]
 
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -908,7 +908,9 @@ def test_tweakreg_handles_multiple_groups(tmp_path, base_image):
     add_tweakreg_catalog_attribute(tmp_path, img2, catalog_filename="img2")
 
     img1.meta.observation["program"] = "-program_id1"
+    img1.meta.observation["obs_id"] = "1"
     img2.meta.observation["program"] = "-program_id2"
+    img2.meta.observation["obs_id"] = "2"
 
     img1.meta["filename"] = "file1.asdf"
     img2.meta["filename"] = "file2.asdf"

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -920,10 +920,7 @@ def test_tweakreg_handles_multiple_groups(tmp_path, base_image):
     assert len(res.group_names) == 2
     with res:
         for r, i in zip(res, [img1, img2]):
-            assert (
-                r.meta.group_id.split("-")[1]
-                == i.meta.observation.program.split("-")[1]
-            )
+            assert r.meta.group_id == i.meta.observation.obs_id
             res.shelve(r, modify=False)
 
 


### PR DESCRIPTION
Group by `meta.observation.obs_id`.

Fixes: https://github.com/spacetelescope/romancal/issues/1259

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/11281421723
show 5 expected failures like the following:
```
   {'values_changed': {"root['roman']['meta']['group_id']": {'new_value': '0000201001001001001011010001',
                                                            'old_value': 'roman0000211_1101_1'}}}
```

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
