### PR TITLE
Force regtests that use rtdata to have a unique name

### DIFF
--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -288,3 +288,27 @@ def diff_astropy_tables():
         return True
 
     return _diff_astropy_tables
+
+
+def pytest_collection_modifyitems(config, items):
+    # For any fixture using rtdata or rtdata_module it needs to have
+    # a unique name to not overwrite the okify results uploaded to artifactory.
+    used_names = set()
+    duplicate_names = set()
+    for item in items:
+        if (
+            "rtdata" not in item.fixturenames
+            and "rtdata_module" not in item.fixturenames
+        ):
+            # this item doesn't use rtdata so skip it
+            continue
+        # FIXME rtdata uses originalname. For a parametrized test
+        # each parametrization will have a unique name but they will
+        # all share the same originalname. Since name is used here
+        # that means it's possible that parametrized tests might
+        # overwrite themselves.
+        name = item.name
+        if name in used_names:
+            duplicate_names.add(name)
+        used_names.add(name)
+    assert not duplicate_names, f"Tests share names: {duplicate_names}"

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -98,7 +98,7 @@ def test_output_is_mosaic(output_model):
         "resample",
     ),
 )
-def test_steps_ran(output_model, step_name):
+def test_mos_steps_ran(output_model, step_name):
     # DMS356
     # DMS400 for skymatch
     # DMS86 for outlier_detection and resample

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -62,7 +62,7 @@ def preview_filename(output_filename):
     return preview_filename
 
 
-def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
+def test_mos_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     # DMS356
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
     assert diff.identical, diff.report()

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -42,7 +42,9 @@ def truth_filename(run_mos):
     return run_mos.truth
 
 
-def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
+def test_mos_skycell_output_matches_truth(
+    output_filename, truth_filename, ignore_asdf_paths
+):
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/regtest/test_wfi_grism_16resultants.py
+++ b/romancal/regtest/test_wfi_grism_16resultants.py
@@ -53,17 +53,17 @@ def input_model(input_filename):
         yield model
 
 
-def test_output_is_image_model(output_model):
+def test_output_grism_16_is_image_model(output_model):
     # DMS414
     assert isinstance(output_model, rdm.datamodels.ImageModel)
 
 
-def test_input_has_16_resultants(input_model):
+def test_grism_input_has_16_resultants(input_model):
     # DMS414
     assert len(input_model.meta.exposure.read_pattern) == 16
 
 
-def test_output_has_16_resultants(output_model):
+def test_grism_output_has_16_resultants(output_model):
     # DMS414
     assert len(output_model.meta.exposure.read_pattern) == 16
 
@@ -83,5 +83,5 @@ def test_output_has_16_resultants(output_model):
         ("photom", "SKIPPED"),
     ),
 )
-def test_step_status(output_model, step_name, status):
+def test_grism_16_step_status(output_model, step_name, status):
     assert getattr(output_model.meta.cal_step, step_name) == status

--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -103,31 +103,31 @@ def test_grism_output_matches_truth(output_filename, truth_filename, ignore_asdf
         ("tweakreg", "SKIPPED"),
     ),
 )
-def test_step_status(output_model, step_name, status):
+def test_grism_step_status(output_model, step_name, status):
     # DMS90
     # DMS278
     # also DMS129 for assign_wcs
     assert getattr(output_model.meta.cal_step, step_name) == status
 
 
-def test_jump_in_uneven_ramp(output_model):
+def test_grism_jump_in_uneven_ramp(output_model):
     # DMS365 jump detection detected jumps in uneven ramp
     uneven = len({len(x) for x in output_model.meta.exposure.read_pattern}) > 1
     assert uneven & np.any(output_model.dq & pixel.JUMP_DET)
 
 
 @pytest.mark.parametrize("arr_name", ("dq", "err", "var_poisson", "var_rnoise"))
-def test_array_exists(output_model, arr_name):
+def test_grism_array_exists(output_model, arr_name):
     # DMS91
     assert hasattr(output_model, arr_name)
 
 
-def test_has_exposure_time(output_model):
+def test_grism_has_exposure_time(output_model):
     # DMS88 total exposure time exists
     assert "exposure_time" in output_model.meta.exposure
 
 
-def test_wcs_has_bounding_box(output_model):
+def test_grism_wcs_has_bounding_box(output_model):
     # DMS93 WCS tests
     assert len(output_model.meta.wcs.bounding_box) == 2
 
@@ -146,7 +146,7 @@ def test_grism_repointed_matches_truth(
     assert diff.identical, diff.report()
 
 
-def test_repointed_wcs_differs(repointed_filename_and_delta, output_model):
+def test_grism_repointed_wcs_differs(repointed_filename_and_delta, output_model):
     # DMS93 WCS tests
     repointed_filename, delta = repointed_filename_and_delta
     orig_wcs = output_model.meta.wcs

--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -80,7 +80,7 @@ def repointed_filename_and_delta(output_filename):
     return repointed_filename, delta
 
 
-def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
+def test_grism_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
@@ -132,13 +132,15 @@ def test_wcs_has_bounding_box(output_model):
     assert len(output_model.meta.wcs.bounding_box) == 2
 
 
-def test_repointed_matches_truth(
+def test_grism_repointed_matches_truth(
     repointed_filename_and_delta, rtdata, ignore_asdf_paths
 ):
     # DMS90
     repointed_filename, _ = repointed_filename_and_delta
 
     rtdata.get_truth(f"truth/WFI/grism/{Path(repointed_filename).name}")
+    # set output to provide okify the new truth file
+    # when the output of this test is okified
     rtdata.output = repointed_filename
     diff = compare_asdf(repointed_filename, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()

--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -139,6 +139,7 @@ def test_repointed_matches_truth(
     repointed_filename, _ = repointed_filename_and_delta
 
     rtdata.get_truth(f"truth/WFI/grism/{Path(repointed_filename).name}")
+    rtdata.output = repointed_filename
     diff = compare_asdf(repointed_filename, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/regtest/test_wfi_image_16resultants.py
+++ b/romancal/regtest/test_wfi_image_16resultants.py
@@ -53,17 +53,17 @@ def input_model(input_filename):
         yield model
 
 
-def test_output_is_image_model(output_model):
+def test_image_16_output_is_image_model(output_model):
     # DMS413
     assert isinstance(output_model, rdm.datamodels.ImageModel)
 
 
-def test_input_has_16_resultants(input_model):
+def test_image_input_has_16_resultants(input_model):
     # DMS413
     assert len(input_model.meta.exposure.read_pattern) == 16
 
 
-def test_output_has_16_resultants(output_model):
+def test_image_output_has_16_resultants(output_model):
     # DMS413
     assert len(output_model.meta.exposure.read_pattern) == 16
 
@@ -82,5 +82,5 @@ def test_output_has_16_resultants(output_model):
         "photom",
     ),
 )
-def test_steps_ran(output_model, step_name):
+def test_image_16_steps_ran(output_model, step_name):
     assert getattr(output_model.meta.cal_step, step_name) == "COMPLETE"

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -90,7 +90,7 @@ def test_image_output_matches_truth(output_filename, truth_filename, ignore_asdf
 
 
 @pytest.mark.soctests
-def test_output_is_image_model(output_model):
+def test_image_output_is_image_model(output_model):
     # DMS280 result is an ImageModel
     assert isinstance(output_model, rdm.datamodels.ImageModel)
 
@@ -109,14 +109,14 @@ def test_output_is_image_model(output_model):
         "saturation",
     ),
 )
-def test_steps_ran(output_model, step_name):
+def test_image_steps_ran(output_model, step_name):
     # DMS86
     # also DMS129 for assign_wcs
     assert getattr(output_model.meta.cal_step, step_name) == "COMPLETE"
 
 
 @pytest.mark.soctests
-def test_jump_in_uneven_ramp(output_model):
+def test_image_jump_in_uneven_ramp(output_model):
     # DMS361 jump detection detected jumps in uneven ramp
     uneven = len({len(x) for x in output_model.meta.exposure.read_pattern}) > 1
     assert uneven & np.any(output_model.dq & pixel.JUMP_DET)
@@ -154,13 +154,13 @@ def test_wcs_applies_distortion_correction(output_model):
 @pytest.mark.parametrize(
     "arr_name", ("dq", "err", "var_poisson", "var_rnoise", "var_flat")
 )
-def test_array_exists(output_model, arr_name):
+def test_image_array_exists(output_model, arr_name):
     # DMS87
     assert hasattr(output_model, arr_name)
 
 
 @pytest.mark.soctests
-def test_has_exposure_time(output_model):
+def test_image_has_exposure_time(output_model):
     # DMS88 total exposure time exists
     assert "exposure_time" in output_model.meta.exposure
 
@@ -173,7 +173,7 @@ def test_instrument_meta(output_model, meta_attribute):
 
 
 @pytest.mark.soctests
-def test_wcs_has_bounding_box(output_model):
+def test_image_wcs_has_bounding_box(output_model):
     # DMS89 WCS tests
     assert len(output_model.meta.wcs.bounding_box) == 2
 
@@ -194,7 +194,7 @@ def test_image_repointed_matches_truth(
 
 
 @pytest.mark.soctests
-def test_repointed_wcs_differs(repointed_filename_and_delta, output_model):
+def test_image_repointed_wcs_differs(repointed_filename_and_delta, output_model):
     # DMS89 WCS tests
     repointed_filename, delta = repointed_filename_and_delta
     orig_wcs = output_model.meta.wcs

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -186,6 +186,7 @@ def test_repointed_matches_truth(
     repointed_filename, _ = repointed_filename_and_delta
 
     rtdata.get_truth(f"truth/WFI/image/{Path(repointed_filename).name}")
+    rtdata.output = repointed_filename
     diff = compare_asdf(repointed_filename, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -84,7 +84,7 @@ def repointed_filename_and_delta(output_filename):
 
 
 @pytest.mark.soctests
-def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
+def test_image_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
@@ -179,13 +179,15 @@ def test_wcs_has_bounding_box(output_model):
 
 
 @pytest.mark.soctests
-def test_repointed_matches_truth(
+def test_image_repointed_matches_truth(
     repointed_filename_and_delta, rtdata, ignore_asdf_paths
 ):
     # DMS89 WCS tests
     repointed_filename, _ = repointed_filename_and_delta
 
     rtdata.get_truth(f"truth/WFI/image/{Path(repointed_filename).name}")
+    # set output to provide okify the new truth file
+    # when the output of this test is okified
     rtdata.output = repointed_filename
     diff = compare_asdf(repointed_filename, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -19,7 +19,7 @@
   ],
   "DMS89": [
     "romancal.regtest.test_wfi_image_pipeline.test_wcs_has_bounding_box",
-    "romancal.regtest.test_wfi_image_pipeline.test_repointed_matches_truth",
+    "romancal.regtest.test_wfi_image_pipeline.test_image_repointed_matches_truth",
     "romancal.regtest.test_wfi_image_pipeline.test_repointed_wcs_differs"
   ],
   "DMS90": [
@@ -65,7 +65,7 @@
     "romancal.regtest.test_resample.test_resample_single_file"
   ],
   "DMS356": [
-    "romancal.regtest.test_mos_pipeline.test_output_matches_truth",
+    "romancal.regtest.test_mos_pipeline.test_mos_output_matches_truth",
     "romancal.regtest.test_mos_pipeline.test_thumbnail_exists",
     "romancal.regtest.test_mos_pipeline.test_preview_exists",
     "romancal.regtest.test_mos_pipeline.test_output_is_mosaic",

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -7,34 +7,34 @@
     "romancal.regtest.test_wfi_flat_field.test_flat_field_crds_match_image_step"
   ],
   "DMS86": [
-    "romancal.regtest.test_wfi_image_pipeline.test_steps_ran",
-    "romancal.regtest.test_mos_pipeline.test_steps_ran"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_steps_ran",
+    "romancal.regtest.test_mos_pipeline.test_mos_steps_ran"
   ],
   "DMS87": [
-    "romancal.regtest.test_wfi_image_pipeline.test_array_exists"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_array_exists"
   ],
   "DMS88": [
-    "romancal.regtest.test_wfi_image_pipeline.test_has_exposure_time",
-    "romancal.regtest.test_wfi_grism_pipeline.test_has_exposure_time"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_has_exposure_time",
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_has_exposure_time"
   ],
   "DMS89": [
-    "romancal.regtest.test_wfi_image_pipeline.test_wcs_has_bounding_box",
+    "romancal.regtest.test_wfi_image_pipeline.test_image_wcs_has_bounding_box",
     "romancal.regtest.test_wfi_image_pipeline.test_image_repointed_matches_truth",
-    "romancal.regtest.test_wfi_image_pipeline.test_repointed_wcs_differs"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_repointed_wcs_differs"
   ],
   "DMS90": [
-    "romancal.regtest.test_wfi_grism_pipeline.test_step_status"
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_step_status"
   ],
   "DMS91": [
-    "romancal.regtest.test_wfi_grism_pipeline.test_array_exists"
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_array_exists"
   ],
   "DMS93": [
-    "romancal.regtest.test_wfi_grism_pipeline.test_wcs_has_bounding_box",
-    "romancal.regtest.test_wfi_grism_pipeline.test_repointed_wcs_differs"
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_wcs_has_bounding_box",
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_repointed_wcs_differs"
   ],
   "DMS129": [
-    "romancal.regtest.test_wfi_image_pipeline.test_steps_ran",
-    "romancal.regtest.test_wfi_grism_pipeline.test_step_status",
+    "romancal.regtest.test_wfi_image_pipeline.test_image_steps_ran",
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_step_status",
     "romancal.regtest.test_wfi_image_pipeline.test_has_a_wcs",
     "romancal.regtest.test_wfi_image_pipeline.test_wcs_has_distortion_information",
     "romancal.regtest.test_wfi_image_pipeline.test_wcs_applies_distortion_correction"
@@ -46,11 +46,11 @@
     "romancal.regtest.test_wfi_photom.test_absolute_photometric_calibration"
   ],
   "DMS278": [
-    "romancal.regtest.test_wfi_grism_pipeline.test_step_status"
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_step_status"
   ],
   "DMS280": [
     "romancal.regtest.test_tweakreg.test_tweakreg",
-    "romancal.regtest.test_wfi_image_pipeline.test_output_is_image_model"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_output_is_image_model"
   ],
   "DMS342": [
     "romancal.regtest.test_resample.test_resample_single_file"
@@ -69,10 +69,10 @@
     "romancal.regtest.test_mos_pipeline.test_thumbnail_exists",
     "romancal.regtest.test_mos_pipeline.test_preview_exists",
     "romancal.regtest.test_mos_pipeline.test_output_is_mosaic",
-    "romancal.regtest.test_mos_pipeline.test_steps_ran"
+    "romancal.regtest.test_mos_pipeline.test_mos_steps_ran"
   ],
   "DMS361": [
-    "romancal.regtest.test_wfi_image_pipeline.test_jump_in_uneven_ramp"
+    "romancal.regtest.test_wfi_image_pipeline.test_image_jump_in_uneven_ramp"
   ],
   "DMS362": [
     "romancal.regtest.test_ramp_fitting.test_rampfit_step"
@@ -81,7 +81,7 @@
     "romancal.regtest.test_ramp_fitting.test_rampfit_step"
   ],
   "DMS365": [
-    "romancal.regtest.test_wfi_grism_pipeline.test_jump_in_uneven_ramp"
+    "romancal.regtest.test_wfi_grism_pipeline.test_grism_jump_in_uneven_ramp"
   ],
   "DMS366": [
     "romancal.regtest.test_ramp_fitting.test_rampfit_step"
@@ -109,7 +109,7 @@
     "romancal.regtest.test_catalog.test_has_field"
   ],
   "DMS400": [
-    "romancal.regtest.test_mos_pipeline.test_steps_ran",
+    "romancal.regtest.test_mos_pipeline.test_mos_steps_ran",
     "romancal.regtest.test_mos_pipeline.test_added_background",
     "romancal.regtest.test_mos_pipeline.test_added_background_level"
   ],
@@ -117,14 +117,14 @@
     "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
   "DMS413": [
-    "romancal.regtest.test_wfi_image_16resultants.test_output_is_image_model",
-    "romancal.regtest.test_wfi_image_16resultants.test_input_has_16_resultants",
-    "romancal.regtest.test_wfi_image_16resultants.test_output_has_16_resultants"
+    "romancal.regtest.test_wfi_image_16resultants.test_image_16_output_is_image_model",
+    "romancal.regtest.test_wfi_image_16resultants.test_image_input_has_16_resultants",
+    "romancal.regtest.test_wfi_image_16resultants.test_image_output_has_16_resultants"
   ],
   "DMS414": [
-    "romancal.regtest.test_wfi_grism_16resultants.test_output_is_image_model",
-    "romancal.regtest.test_wfi_grism_16resultants.test_input_has_16_resultants",
-    "romancal.regtest.test_wfi_grism_16resultants.test_output_has_16_resultants"
+    "romancal.regtest.test_wfi_grism_16resultants.test_grism_16_output_is_image_model",
+    "romancal.regtest.test_wfi_grism_16resultants.test_grism_input_has_16_resultants",
+    "romancal.regtest.test_wfi_grism_16resultants.test_grism_output_has_16_resultants"
   ],
   "DMS488": [
     "romancal.regtest.test_tweakreg.test_tweakreg"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
