### PR TITLE
Put okify results in unique subdirectories to avoid file overwrites

### DIFF
--- a/changes/1456.general.rst
+++ b/changes/1456.general.rst
@@ -1,0 +1,1 @@
+Give regtest okify results unique subdirectories.

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -61,6 +61,12 @@ def postmortem(request, fixturename):
         return None
 
 
+def pytest_collection_modifyitems(config, items):
+    # add the index of each item in the list of items
+    for i, item in enumerate(items):
+        item.index = i
+
+
 @pytest.fixture(scope="function", autouse=True)
 def generate_artifactory_json(request, artifactory_repos):
     """Pytest fixture that leaves behind JSON upload and okify specfiles
@@ -78,8 +84,9 @@ def generate_artifactory_json(request, artifactory_repos):
         build_matrix_suffix = os.environ.get("BUILD_MATRIX_SUFFIX", "0")
         subdir = f"{TODAYS_DATE}_{build_tag}_{build_matrix_suffix}"
         testname = request.node.originalname or request.node.name
+        basename = f"{request.node.index}_{testname}"
 
-        return os.path.join(results_root, subdir, testname) + os.sep
+        return os.path.join(results_root, subdir, basename) + os.sep
 
     yield
     # Execute the following at test teardown

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -63,6 +63,10 @@ def postmortem(request, fixturename):
 
 def pytest_collection_modifyitems(config, items):
     # add the index of each item in the list of items
+    # this is used below for artifactory_result_path
+    # to produce a unique result subdirectory for
+    # each test (even if that test shares a name with
+    # another test which is the case for parametrized tests).
     for i, item in enumerate(items):
         item.index = i
 


### PR DESCRIPTION
Fixes #1454

This PR modifies the organization of okify results uploaded to artifactory to avoid overwriting results if multiple tests fail which share the same name (such as parameterized tests). To provide an example, if [test_rampfit_step](https://github.com/spacetelescope/romancal/blob/1945dad5eb600fe82acb865baf3f1d66da12dd7f/romancal/regtest/test_ramp_fitting.py#L165) is made to fail (by adding an `assert False`). 4 errors will be produced (from the 4 parametrizations of the test):
https://github.com/spacetelescope/RegressionTests/actions/runs/11325106885/job/31501401451#step:30:1020
as these 4 tests share the same name the results will be put into the same directory on artifactory "test_rampfit_step":
https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/2024-10-14_GITHUB_CI_Linux-X64-py3.11-1145/test_rampfit_step
This can result in files being overwritten (if they share the same name).

This PR prefixes the artifactory subdirectory with a unique number (the index of the test for the test run) to avoid file overwrites. Here's an example run forcing the same test to fail:
https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/2024-10-14_GITHUB_CI_Linux-X64-py3.11-1147
showing the 4 test results split into 4 subdirectories.

I was able to run a 'dry-run' okify on the above example and it picked up the 4 test failures in the newly named subdirectories.

Regression tests running here: https://github.com/spacetelescope/RegressionTests/actions/runs/11331347662

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
