### PR TITLE
Copy input datamodel in source_catalog step

### DIFF
--- a/changes/1457.source_catalog.rst
+++ b/changes/1457.source_catalog.rst
@@ -1,0 +1,2 @@
+The input datamodel to the source_catalog step is now copied so that it
+is left completely unchanged by the step.

--- a/changes/1457.source_catalog.rst
+++ b/changes/1457.source_catalog.rst
@@ -1,2 +1,2 @@
-The input datamodel to the source_catalog step is now copied so that it
-is left completely unchanged by the step.
+The data and err array of the input datamodel to the source_catalog step
+are now copied so that they are left completely unchanged by the step.

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -175,19 +175,6 @@ class RomanSourceCatalog:
         self.model["err"] *= self.l2_conv_factor
         self.convolved_data *= self.l2_conv_factor
 
-    def convert_sb_to_l2(self):
-        """
-        Convert the data and error arrays from MJy/sr (surface
-        brightness) to DN/s (level-2 units).
-
-        This is the inverse operation of `convert_l2_to_sb`.
-        """
-        # the conversion in done in-place to avoid making copies of the data;
-        # use a dictionary to set the value to avoid on-the-fly validation
-        self.model["data"] /= self.l2_conv_factor
-        self.model["err"] /= self.l2_conv_factor
-        self.convolved_data /= self.l2_conv_factor
-
     def convert_sb_to_flux_density(self):
         """
         Convert the data and error arrays from MJy/sr (surface
@@ -205,22 +192,6 @@ class RomanSourceCatalog:
         self.model["data"] <<= self.sb_to_flux.unit
         self.model["err"] <<= self.sb_to_flux.unit
         self.convolved_data <<= self.sb_to_flux.unit
-
-    def convert_flux_density_to_sb(self):
-        """
-        Convert the data and error arrays from flux density units to
-        MJy/sr (surface brightness).
-
-        The units are also removed from the arrays.
-
-        This is the inverse operation of `convert_sb_to_flux_density`.
-        """
-        self.model["data"] /= self.sb_to_flux
-        self.model["err"] /= self.sb_to_flux
-        self.convolved_data /= self.sb_to_flux
-        self.model["data"] = self.model["data"].value
-        self.model["err"] = self.model["err"].value
-        self.convolved_data = self.convolved_data.value
 
     def convert_flux_to_abmag(self, flux, flux_err):
         """
@@ -1198,12 +1169,5 @@ class RomanSourceCatalog:
 
         # split SkyCoord columns into separate RA and Dec columns
         catalog = self._split_skycoord(catalog)
-
-        # restore units on input model back to MJy/sr
-        self.convert_flux_density_to_sb()
-
-        # restore L2 data units back to DN/s
-        if isinstance(self.model, ImageModel):
-            self.convert_sb_to_l2()
 
         return catalog

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
-from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 from photutils.segmentation import SegmentationImage
 from roman_datamodels import datamodels as rdm
 from roman_datamodels.datamodels import (
@@ -300,8 +300,8 @@ def test_l2_input_model_unchanged(image_model, tmp_path):
         save_results=False,
     )
 
-    assert_allclose(original_data, image_model.data, atol=5.0e-5)
-    assert_allclose(original_err, image_model.err, atol=5.0e-5)
+    assert_equal(original_data, image_model.data)
+    assert_equal(original_err, image_model.err)
 
 
 @pytest.mark.webbpsf
@@ -324,8 +324,8 @@ def test_l3_input_model_unchanged(mosaic_model, tmp_path):
         save_results=False,
     )
 
-    assert_allclose(original_data, mosaic_model.data, atol=5.0e-5)
-    assert_allclose(original_err, mosaic_model.err, atol=5.0e-5)
+    assert_equal(original_data, mosaic_model.data)
+    assert_equal(original_err, mosaic_model.err)
 
 
 @pytest.mark.webbpsf


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
With this PR the input datamodel to the `source_catalog` step is copied before being operated on so that it is left completely unaltered.


<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
