### PR TITLE
Manual Pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: ".*\\.asdf$"
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -28,13 +28,13 @@ repos:
     - id: text-unicode-replacement-char
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.15.1'
+  rev: 'v3.18.0'
   hooks:
     - id: pyupgrade
       args: ["--py38-plus"]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.2.2'
+  rev: 'v0.6.9'
   hooks:
     - id: ruff
       args: ["--fix"]
@@ -45,12 +45,12 @@ repos:
     - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 24.2.0
+  rev: 24.10.0
   hooks:
     - id: black
 
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.7.7
+  rev: 1.7.10
   hooks:
     - id: bandit
       args: ["-c", "pyproject.toml"]

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -31,7 +31,7 @@ def test_dark_step_interface(instrument, exptype):
 
     # Test dark results
     assert (result.data == ramp_model.data).all()
-    assert type(result) == RampModel
+    assert isinstance(result, RampModel)
     assert result.validate() is None
     assert result.data.shape == shape
     assert result.groupdq.shape == shape
@@ -99,7 +99,7 @@ def test_dark_step_output_dark_file(tmp_path, instrument, exptype):
     dark_out_file_model = rdm.open(path)
 
     # Test dark file results
-    assert type(dark_out_file_model) == DarkRefModel
+    assert isinstance(dark_out_file_model, DarkRefModel)
     assert dark_out_file_model.validate() is None
     assert dark_out_file_model.data.shape == shape
     assert dark_out_file_model.dq.shape == shape[1:]
@@ -132,7 +132,7 @@ def test_dark_step_getbestrefs(tmp_path, instrument, exptype):
     dark_out_file_model = rdm.open(path)
 
     # Test dark file results
-    assert type(dark_out_file_model) == DarkRefModel
+    assert isinstance(dark_out_file_model, DarkRefModel)
     assert dark_out_file_model.validate() is None
     assert dark_out_file_model.data.shape == shape
     assert dark_out_file_model.dq.shape == shape[1:]

--- a/romancal/linearity/tests/test_linearity.py
+++ b/romancal/linearity/tests/test_linearity.py
@@ -6,11 +6,10 @@ Unit tests for linearity correction
 
 import numpy as np
 import pytest
-from roman_datamodels import maker_utils
+from roman_datamodels import dqflags, maker_utils
 from roman_datamodels.datamodels import LinearityRefModel, ScienceRawModel
 
 from romancal.dq_init import DQInitStep
-from romancal.lib import dqflags
 from romancal.linearity import LinearityStep
 
 

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -346,10 +346,8 @@ def test_resampledata_init_default(exposure_1):
 @pytest.mark.parametrize("input_models", [list()])
 def test_resampledata_init_invalid_input(input_models):
     """Test that ResampleData will raise an exception on invalid inputs."""
-    with pytest.raises(Exception) as exec_info:
+    with pytest.raises(ValueError):
         ResampleData(input_models)
-
-    assert type(exec_info.value) == ValueError
 
 
 def test_resampledata_do_drizzle_many_to_one_default_no_rotation_single_exposure(

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -686,7 +686,7 @@ def test_tweakreg_raises_error_on_invalid_abs_refcat(tmp_path, base_image):
     img = base_image(shift_1=1000, shift_2=1000)
     add_tweakreg_catalog_attribute(tmp_path, img)
 
-    with pytest.raises(Exception) as exec_info:
+    with pytest.raises(TypeError):
         trs.TweakRegStep.call(
             [img],
             save_abs_catalog=True,
@@ -694,8 +694,6 @@ def test_tweakreg_raises_error_on_invalid_abs_refcat(tmp_path, base_image):
             catalog_path=str(tmp_path),
             output_dir=str(tmp_path),
         )
-
-    assert type(exec_info.value) == TypeError
 
 
 def test_tweakreg_combine_custom_catalogs_and_asn_file(tmp_path, base_image):
@@ -737,7 +735,7 @@ def test_tweakreg_combine_custom_catalogs_and_asn_file(tmp_path, base_image):
         catfile=catfile,
     )
 
-    assert type(res) == ModelLibrary
+    assert isinstance(res, ModelLibrary)
 
     with res:
         for i, (model, target) in enumerate(zip(res, [img1, img2, img3])):
@@ -750,7 +748,7 @@ def test_tweakreg_combine_custom_catalogs_and_asn_file(tmp_path, base_image):
 
             assert model.meta.filename == target.meta.filename
 
-            assert type(model) == type(target)
+            assert type(model) is type(target)
 
             assert (model.data == target.data).all()
 
@@ -853,7 +851,7 @@ def test_tweakreg_parses_asn_correctly(tmp_path, base_image):
 
     res = trs.TweakRegStep.call(asn_filepath)
 
-    assert type(res) == ModelLibrary
+    assert isinstance(res, ModelLibrary)
 
     with res:
         models = list(res)
@@ -872,8 +870,8 @@ def test_tweakreg_parses_asn_correctly(tmp_path, base_image):
         assert models[0].meta.filename == img_1.meta.filename
         assert models[1].meta.filename == img_2.meta.filename
 
-        assert type(models[0]) == type(img_1)
-        assert type(models[1]) == type(img_2)
+        assert type(models[0]) is type(img_1)
+        assert type(models[1]) is type(img_2)
 
         assert (models[0].data == img_1.data).all()
         assert (models[1].data == img_2.data).all()
@@ -891,7 +889,7 @@ def test_fit_results_in_meta(tmp_path, base_image):
 
     res = trs.TweakRegStep.call([img])
 
-    assert type(res) == ModelLibrary
+    assert isinstance(res, ModelLibrary)
     with res:
         for i, model in enumerate(res):
             assert hasattr(model.meta, "wcs_fit_results")
@@ -995,10 +993,8 @@ def test_parse_catfile_raises_error_on_invalid_content(tmp_path, catfile_line_co
     with open(catfile, mode="w") as f:
         print(catfile_content.getvalue(), file=f)
 
-    with pytest.raises(Exception) as exec_info:
+    with pytest.raises(ValueError):
         trs._parse_catfile(catfile)
-
-    assert type(exec_info.value) == ValueError
 
 
 def test_update_source_catalog_coordinates(tmp_path, base_image):
@@ -1234,7 +1230,7 @@ def test_tweakreg_skips_invalid_exposure_types(exposure_type, tmp_path, base_ima
     img2.meta.exposure.type = exposure_type
     res = trs.TweakRegStep.call([img1, img2])
 
-    assert type(res) == ModelLibrary
+    assert isinstance(res, ModelLibrary)
     with res:
         for i, model in enumerate(res):
             assert hasattr(model.meta.cal_step, "tweakreg")


### PR DESCRIPTION
Closes #1141

<!-- describe the changes comprising this PR here -->
This PR fixes the issues caught by pre commit in its automatic update, all of these are minor.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
