### PR TITLE
move run results directory on Artifactory to `regression-tests/runs/`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ filterwarnings = [
 ]
 junit_family = "xunit2"
 inputs_root = "roman-pipeline"
-results_root = "roman-pipeline-results"
+results_root = "roman-pipeline-results/regression-tests/runs/"
 doctest_plus = "enabled"
 doctest_rst = "enabled"
 text_file_format = "rst"

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -25,7 +25,7 @@ def artifactory_repos(pytestconfig):
 
     results_root = pytestconfig.getini("results_root")
     if not results_root:
-        results_root = "roman-pipeline-results"
+        results_root = "roman-pipeline-results/regression-tests/runs/"
     else:
         results_root = results_root[0]
     return inputs_root, results_root

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -44,7 +44,7 @@ class RegtestData:
         self,
         env="dev",
         inputs_root="roman-pipeline",
-        results_root="roman-pipeline-results",
+        results_root="roman-pipeline-results/regression-tests/runs/",
         docopy=True,
         input=None,
         input_remote=None,

--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -16,7 +16,7 @@ from glob import glob
 
 import asdf
 
-ARTIFACTORY_REPO = "roman-pipeline-results"
+ARTIFACTORY_REPO = "roman-pipeline-results/regression-tests/runs/"
 SPECFILE_SUFFIX = "_okify.json"
 RTDATA_SUFFIX = "_rtdata.asdf"
 TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
@@ -52,7 +52,7 @@ def artifactory_get_breadcrumbs(build_number, suffix):
 
     An example search would be:
 
-    jfrog rt search roman-pipeline-results/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
+    jfrog rt search roman-pipeline-results/regression-tests/runs/*/*_okify.json --props='build.number=540;build.name=RT :: romancal'
     """  # noqa: E501
 
     # Retreive all the okify specfiles for failed tests.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
https://github.com/spacetelescope/RegressionTests/pull/143

<!-- describe the changes comprising this PR here -->
The `roman-pipeline-results/` repositories on Artifactory has lots of auto-generated run directories in the root, which clutters the file structure and makes it unwieldy to scroll through. This PR proposes moving the run directories from the root of the repository (`roman-pipeline-results/`) to a subdirectory (`roman-pipeline-results/regression-tests/runs/`):
```diff
- roman-pipeline-results/2024-09-25_GITHUB_CI_Linux-X64-py3.12-683/
+ roman-pipeline-results/regression-tests/runs/2024-09-25_GITHUB_CI_Linux-X64-py3.12-683/
```

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
