### PR TITLE
Misc small fixes and tweaks

### DIFF
--- a/romancal/lib/tests/test_basic_utils.py
+++ b/romancal/lib/tests/test_basic_utils.py
@@ -25,7 +25,7 @@ def test_structured_array_utils():
     arrays = [np.arange(0, 10), np.arange(10, 20), np.arange(30, 40)]
     names = "a, b, c"
 
-    recarr0 = np.core.records.fromarrays(
+    recarr0 = np.rec.fromarrays(
         arrays, names=names, formats=[arr.dtype for arr in arrays]
     )
     round_tripped = recarray_to_ndarray(recarr0)

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -272,7 +272,7 @@ def test_no_sat_check(setup_wfi_datamodels):
     assert np.all(output.groupdq[:, 5, 5] != group.SATURATED)
     # Test that saturation bit is NOT set
     assert np.all(
-        output.groupdq[:, 5, 5] & (1 << group.SATURATED.bit_length() - 1) == 0
+        output.groupdq[:, 5, 5] & (1 << int(group.SATURATED).bit_length() - 1) == 0
     )
     assert output.pixeldq[5, 5] == (pixel.NO_SAT_CHECK + pixel.DO_NOT_USE)
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR makes some minor fixes that I have come across and been meaning to make. This does not need regression testing as these only effect the normal romancal tests.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
