### PR TITLE
RCAL-937: update s_region after running TweakRegStep.

### DIFF
--- a/changes/1484.tweakreg.rst
+++ b/changes/1484.tweakreg.rst
@@ -1,0 +1,1 @@
+Updates s_region after running TweakRegStep successfully.

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Tuple
 
 import numpy as np
-import pysiaf
 import pytest
 import requests
 from astropy import coordinates as coord
@@ -27,7 +26,6 @@ from stcal.tweakreg.astrometric_utils import get_catalog
 from romancal.datamodels import ModelLibrary
 from romancal.tweakreg import tweakreg_step as trs
 from romancal.tweakreg.tweakreg_step import _validate_catalog_columns
-from romancal.assign_wcs import AssignWcsStep
 
 
 class MockConnectionError:
@@ -346,17 +344,15 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
 def get_catalog_data(input_dm, **kwargs):
     ra = kwargs.get("ra", 270)
     dec = kwargs.get("dec", 66)
-    sr = kwargs.get("sr", 100/3600)
-    add_shifts= kwargs.get("add_shifts", False)
-    gaia_cat = get_catalog(
-        right_ascension=ra, declination=dec, search_radius=sr
-    )    
+    sr = kwargs.get("sr", 100 / 3600)
+    add_shifts = kwargs.get("add_shifts", False)
+    gaia_cat = get_catalog(right_ascension=ra, declination=dec, search_radius=sr)
     gaia_source_coords = [(ra, dec) for ra, dec in zip(gaia_cat["ra"], gaia_cat["dec"])]
     catalog_data = np.array(
         [input_dm.meta.wcs.world_to_pixel(ra, dec) for ra, dec in gaia_source_coords]
     )
     if add_shifts:
-        rng = np.random.default_rng(seed=int(ra+dec))
+        rng = np.random.default_rng(seed=int(ra + dec))
         shifts = rng.uniform(-1, 1, size=catalog_data.shape)
         catalog_data += shifts
     return catalog_data
@@ -1317,13 +1313,12 @@ def test_tweakreg_handles_mixed_exposure_types(tmp_path, base_image):
 
 
 def test_tweakreg_updates_s_region(tmp_path, base_image):
-    """Test that the TweakRegStep updates the s_region attribute.
-    """
+    """Test that the TweakRegStep updates the s_region attribute."""
     img = base_image(shift_1=1000, shift_2=1000)
-    old_fake_s_region = 'POLYGON ICRS 1.0000000000000 2.0000000000000 3.0000000000000 4.0000000000000 5.0000000000000 6.0000000000000 7.0000000000000 8.0000000000000 '
+    old_fake_s_region = "POLYGON ICRS 1.0000000000000 2.0000000000000 3.0000000000000 4.0000000000000 5.0000000000000 6.0000000000000 7.0000000000000 8.0000000000000 "
     img.meta.wcsinfo["s_region"] = old_fake_s_region
     add_tweakreg_catalog_attribute(tmp_path, img, catalog_filename="img")
-    
+
     # call TweakRegStep to update WCS & S_REGION
     res = trs.TweakRegStep.call([img])
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 from roman_datamodels import datamodels as rdm
+from romancal.assign_wcs.utils import add_s_region
 from stcal.tweakreg import tweakreg
 from stcal.tweakreg.tweakreg import _SINGLE_GROUP_REFCAT_STR, SINGLE_GROUP_REFCAT
 
@@ -270,7 +271,11 @@ class TweakRegStep(RomanStep):
                         ]:
                             del image_model.meta["wcs_fit_results"][k]
 
+                        # update WCS
                         image_model.meta.wcs = imcat.wcs
+                        # update S_REGION
+                        add_s_region(image_model)
+
                     images.shelve(image_model, imcat.meta["model_index"])
 
         return images

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -8,9 +8,10 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 from roman_datamodels import datamodels as rdm
-from romancal.assign_wcs.utils import add_s_region
 from stcal.tweakreg import tweakreg
 from stcal.tweakreg.tweakreg import _SINGLE_GROUP_REFCAT_STR, SINGLE_GROUP_REFCAT
+
+from romancal.assign_wcs.utils import add_s_region
 
 # LOCAL
 from ..datamodels import ModelLibrary


### PR DESCRIPTION
Resolves [RCAL-937](https://jira.stsci.edu/browse/RCAL-937)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1455 

<!-- describe the changes comprising this PR here -->
This PR updates the `meta.wcsinfo.s_region` attribute after running `TweakRegStep`, which so far was only updating the WCS but not the footprint.

### Regression tests
- https://github.com/spacetelescope/RegressionTests/actions/runs/11687286223

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [X] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
