### PR TITLE
Reduce the number of tests for supported catalog formats.

### DIFF
--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -475,22 +475,7 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
     table.Table.write.list_formats(out=fh)
     fh.seek(0)
     list_of_supported_formats = [
-        x.strip().split()[0]
-        for x in fh.readlines()[2:]
-        if x.strip().split()[1].lower() == "yes"
-    ]
-    # exclude data formats
-    [
-        list_of_supported_formats.remove(x)
-        for x in [
-            "asdf",
-            "fits",
-            "hdf5",
-            "parquet",
-            "pandas.html",
-            "pandas.json",
-            "pandas.csv",
-        ]
+        "ascii.ecsv", "fits"
     ]
 
     for table_format in list_of_supported_formats:

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -474,9 +474,7 @@ def test_create_astrometric_catalog_write_results_to_disk(tmp_path, base_image):
     fh = StringIO()
     table.Table.write.list_formats(out=fh)
     fh.seek(0)
-    list_of_supported_formats = [
-        "ascii.ecsv", "fits"
-    ]
+    list_of_supported_formats = ["ascii.ecsv", "fits"]
 
     for table_format in list_of_supported_formats:
         res = create_astrometric_catalog(


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1481

<!-- describe the changes comprising this PR here -->
This PR reduces the number of supported formats to be tested in the unit test runs. It doesn't mean we're reducing the number of actual supported formats, which should be the same as those supported by `astropy`'s `table.Table` class (full list can be created by running `Table.write.list_formats()`).

### Regression tests
All regtests are passing:
- https://github.com/spacetelescope/RegressionTests/actions/runs/11693029998

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
