### PR TITLE
rcal-935 Check for correct skycell name in mosaic product

### DIFF
--- a/changes/1498.resample.rst
+++ b/changes/1498.resample.rst
@@ -1,0 +1,1 @@
+Update resmple to populate location_name attribute and tests to check for it

--- a/changes/1498.resample.rst
+++ b/changes/1498.resample.rst
@@ -1,1 +1,1 @@
-Update resmple to populate location_name attribute and tests to check for it
+Update resample to populate location_name attribute and tests to check for it

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -49,5 +49,11 @@ def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths
 
 def test_resample_ran(output_model):
     # DMS373 test output is resampled to a skycell
-    # FIXME this doesn't test if the output is a skyceell
+    # FIXME this doesn't test if the output is a skycell
     assert output_model.meta.cal_step.resample == "COMPLETE"
+
+def test_location_name(output_model):
+    # test that the location_name matches the skycell selected
+    assert output_model.meta.basic.location_name == 'r274dp63x31y81'
+    
+    

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -52,8 +52,7 @@ def test_resample_ran(output_model):
     # FIXME this doesn't test if the output is a skycell
     assert output_model.meta.cal_step.resample == "COMPLETE"
 
+
 def test_location_name(output_model):
     # test that the location_name matches the skycell selected
-    assert output_model.meta.basic.location_name == 'r274dp63x31y81'
-    
-    
+    assert output_model.meta.basic.location_name == "r274dp63x31y81"

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -98,6 +98,8 @@ class ResampleData:
         self.weight_type = wht_type
         self.good_bits = good_bits
         self.in_memory = kwargs.get("in_memory", True)
+        self.location_name = input_models.asn['target']
+
 
         log.info(f"Driz parameter kernel: {self.kernel}")
         log.info(f"Driz parameter pixfrac: {self.pixfrac}")
@@ -220,6 +222,8 @@ class ResampleData:
         """
         output_model = self.blank_output.copy()
         output_model.meta["resample"] = maker_utils.mk_resample()
+        output_model.meta.basic.location_name = self.location_name
+
 
         copy_asn_info_from_library(input_models, output_model)
 
@@ -235,6 +239,7 @@ class ResampleData:
             )
             output_model.meta.filename = f"{output_root}_outlier_i2d{output_type}"
             input_models.shelve(example_image, indices[0], modify=False)
+            output_model.meta.basic.location_name = self.location_name
             del example_image
 
             # Initialize the output with the wcs
@@ -326,6 +331,7 @@ class ResampleData:
         output_model.meta["resample"] = maker_utils.mk_resample()
         output_model.meta.resample.weight_type = self.weight_type
         output_model.meta.resample.pointings = len(self.input_models.group_names)
+        output_model.meta.basic.location_name = self.location_name
 
         # copy over asn information
         if (asn_pool := self.input_models.asn.get("asn_pool", None)) is not None:
@@ -934,9 +940,6 @@ def populate_mosaic_basic(
     # instrument data
     output_model.meta.basic.optical_element = input_meta[0].instrument.optical_element
     output_model.meta.basic.instrument = input_meta[0].instrument.name
-
-    # skycell location
-    output_model.meta.basic.location_name = "TBD"
 
     # association product type
     output_model.meta.basic.product_type = "TBD"

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -98,7 +98,10 @@ class ResampleData:
         self.weight_type = wht_type
         self.good_bits = good_bits
         self.in_memory = kwargs.get("in_memory", True)
-        self.location_name = input_models.asn['target']
+        if hasattr(input_models, 'target'):
+            self.location_name = input_models.asn['target']
+        else:
+            self.location_name = 'None'
 
 
         log.info(f"Driz parameter kernel: {self.kernel}")

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -98,11 +98,10 @@ class ResampleData:
         self.weight_type = wht_type
         self.good_bits = good_bits
         self.in_memory = kwargs.get("in_memory", True)
-        if hasattr(input_models, 'target'):
-            self.location_name = input_models.asn['target']
+        if hasattr(input_models, "target"):
+            self.location_name = input_models.asn["target"]
         else:
-            self.location_name = 'None'
-
+            self.location_name = "None"
 
         log.info(f"Driz parameter kernel: {self.kernel}")
         log.info(f"Driz parameter pixfrac: {self.pixfrac}")
@@ -226,7 +225,6 @@ class ResampleData:
         output_model = self.blank_output.copy()
         output_model.meta["resample"] = maker_utils.mk_resample()
         output_model.meta.basic.location_name = self.location_name
-
 
         copy_asn_info_from_library(input_models, output_model)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-935](https://jira.stsci.edu/browse/RCAL-935)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1432

<!-- describe the changes comprising this PR here -->
This PR checks for correct skycell name in mosaic product and for resampled images using an association will add the target from the association the the location_name. 

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [N/A] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
Regression test is at https://github.com/spacetelescope/RegressionTests/actions/runs/11704297274 and the new results file shows that the location_name is updated so the the file will need okification
  {'values_changed': {"root['roman']['meta']['basic']['location_name']": {'new_value': 'r274dp63x31y81',
                                                                          'old_value': 'TBD'}}}


<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
