### PR TITLE
update okify for new directory structure

### DIFF
--- a/romancal/scripts/okify_regtests.py
+++ b/romancal/scripts/okify_regtests.py
@@ -16,7 +16,7 @@ from glob import glob
 
 import asdf
 
-ARTIFACTORY_REPO = "roman-pipeline-results/regression-tests/runs/"
+ARTIFACTORY_REPO = "roman-pipeline-results/regression-tests/runs"
 SPECFILE_SUFFIX = "_okify.json"
 RTDATA_SUFFIX = "_rtdata.asdf"
 TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
@@ -62,7 +62,7 @@ def artifactory_get_breadcrumbs(build_number, suffix):
     )
     subprocess.run(args, check=True, capture_output=True)
 
-    return sorted(glob(f"**/**/*{suffix}"))
+    return sorted(glob(f"**/**/**/**/*{suffix}"))
 
 
 def artifactory_get_build_artifacts(build_number):


### PR DESCRIPTION
Follow up to https://github.com/spacetelescope/romancal/pull/1475

Updates the okify script to use the new artifactory directory structure.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
