### PR TITLE
remove logging manipulation during create_gridded_psf_model

### DIFF
--- a/changes/1503.source_detection.rst
+++ b/changes/1503.source_detection.rst
@@ -1,0 +1,1 @@
+Don't restart loggers during create_gridded_psf_model.

--- a/romancal/lib/psf.py
+++ b/romancal/lib/psf.py
@@ -14,7 +14,7 @@ from photutils.detection import DAOStarFinder
 from photutils.psf import IterativePSFPhotometry, PSFPhotometry, SourceGrouper
 from roman_datamodels.datamodels import ImageModel
 from roman_datamodels.dqflags import pixel
-from webbpsf import conf, gridded_library, restart_logging
+from webbpsf import gridded_library
 
 __all__ = [
     "create_gridded_psf_model",
@@ -60,7 +60,6 @@ def create_gridded_psf_model(
     sqrt_n_psfs=2,
     buffer_pixels=100,
     instrument_options=None,
-    logging_level=None,
 ):
     """
     Compute a gridded PSF model for one SCA via
@@ -90,9 +89,6 @@ def create_gridded_psf_model(
         For example, WebbPSF assumes Roman pointing jitter consistent with
         mission specs by default, but this can be turned off with:
         ``{'jitter': None, 'jitter_sigma': 0}``.
-    logging_level : str, optional
-        Set logging level by name if not `None`, otherwise inherit from
-        the romancal logger.
 
     Returns
     -------
@@ -125,14 +121,6 @@ def create_gridded_psf_model(
 
     # generate PSFs over a grid of detector positions [pix]
     model_psf_centroids = [(int(x), int(y)) for y in pixel_range for x in pixel_range]
-
-    if logging_level is None:
-        # pass along logging level from __name__'s logger to WebbPSF:
-        logging_level = logging.getLevelName(log.level)
-
-    # set the WebbPSF logging level (similar to webbpsf.utils.setup_logging):
-    conf.logging_level = logging_level
-    restart_logging(verbose=False)
 
     wfi = webbpsf.roman.WFI()
     wfi.filter = filt

--- a/romancal/lib/tests/test_psf.py
+++ b/romancal/lib/tests/test_psf.py
@@ -62,7 +62,6 @@ def setup_inputs(
         webbpsf_config["detector"],
         oversample=webbpsf_config["oversample"],
         fov_pixels=webbpsf_config["fov_pixels"],
-        logging_level="ERROR",
     )
 
     return mod, webbpsf_config, psf_model

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -1145,7 +1145,6 @@ class RomanSourceCatalog:
         gridded_psf_model, _ = psf.create_gridded_psf_model(
             filt=filt,
             detector=detector,
-            logging_level="ERROR",
         )
 
         log.info("Fitting a PSF model to sources for improved astrometric precision.")

--- a/romancal/source_detection/source_detection_step.py
+++ b/romancal/source_detection/source_detection_step.py
@@ -172,7 +172,6 @@ class SourceDetectionStep(RomanStep):
             gridded_psf_model, _ = psf.create_gridded_psf_model(
                 filt=filt,
                 detector=detector,
-                logging_level="ERROR",
             )
 
             log.info(


### PR DESCRIPTION
https://github.com/spacetelescope/romancal/pull/1494 uncovered a bug where building a psf messes up logging.

The call to `restart_logging`:
https://github.com/spacetelescope/romancal/blob/78d5e0f546b52e533e43b5739695d620717ce5df/romancal/lib/psf.py#L135
in `create_gridded_psf_model`

results in (if the [comment](https://github.com/spacetelescope/webbpsf/blob/3043186b5e420a87b6891bdac1380aec866068b6/webbpsf/utils.py#L62) is to be believed) webbpsf clearing all log handlers for the root logger:
https://github.com/spacetelescope/webbpsf/blob/3043186b5e420a87b6891bdac1380aec866068b6/webbpsf/utils.py#L54

This PR removes the call to `restart_logging` and the `logging_level` argument to `create_gridded_psf_model` (since I believe the logging infrastructure for webbpsf is by default [unconfigured](https://github.com/spacetelescope/webbpsf/blob/3043186b5e420a87b6891bdac1380aec866068b6/webbpsf/__init__.py#L74)).

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/11730160143

show only the 1 unrelated failure on main.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
