### PR TITLE
Clean up bounding box assignment

### DIFF
--- a/changes/1527.general.rst
+++ b/changes/1527.general.rst
@@ -1,0 +1,1 @@
+Perform bounding box assignment inline with the ordering that GWCS prefers.

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -198,7 +198,6 @@ def _create_wcs(input_dm, shift_1=0, shift_2=0):
 
     # create necessary transformations
     distortion = Shift(-shift_1) & Shift(-shift_2)
-    distortion.bounding_box = ((-0.5, shape[-1] + 0.5), (-0.5, shape[-2] + 0.5))
     tel2sky = pointing.v23tosky(input_dm)
 
     # create required frames
@@ -219,6 +218,7 @@ def _create_wcs(input_dm, shift_1=0, shift_2=0):
     ]
 
     wcs_obj = wcs.WCS(pipeline)
+    wcs_obj.bounding_box = ((-0.5, shape[-2] + 0.5), (-0.5, shape[-1] + 0.5))
 
     input_dm.meta["wcs"] = wcs_obj
 

--- a/romancal/tweakreg/tests/test_astrometric_utils.py
+++ b/romancal/tweakreg/tests/test_astrometric_utils.py
@@ -254,7 +254,6 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
 
     # create necessary transformations
     distortion = Shift(-shift_1) & Shift(-shift_2)
-    distortion.bounding_box = ((-0.5, shape[-1] + 0.5), (-0.5, shape[-2] + 0.5))
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
@@ -276,6 +275,7 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     ]
 
     wcs_obj = wcs.WCS(pipeline)
+    wcs_obj.bounding_box = ((-0.5, shape[-2] + 0.5), (-0.5, shape[-1] + 0.5))
 
     input_dm.meta["wcs"] = wcs_obj
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -316,7 +316,6 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
 
     # create necessary transformations
     distortion = Shift(-shift_1) & Shift(-shift_2)
-    distortion.bounding_box = ((-0.5, shape[-1] + 0.5), (-0.5, shape[-2] + 0.5))
     tel2sky = _create_tel2sky_model(input_dm)
 
     # create required frames
@@ -337,6 +336,7 @@ def create_wcs_for_tweakreg_pipeline(input_dm, shift_1=0, shift_2=0):
     ]
 
     wcs_obj = wcs.WCS(pipeline)
+    wcs_obj.bounding_box = ((-0.5, shape[-2] + 0.5), (-0.5, shape[-1] + 0.5))
 
     input_dm.meta["wcs"] = wcs_obj
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
spacetelescope/gwcs#522 adds a warning to flag instances where bounding boxes that GWCS uses are ordered using the `C` (y, x) ordering rather than the `F` ordering the GWCS defaults to. GWCS handles the alternate ordering by default however tuple assignment to the forward transform before creating the GWCS causes astropy to assume a `C` ordering while if one assigns the same tuple directly to the wcs, GWCS will assume a `F` order. Due to this source of issues GWCS now throws a warning when it discovers an assigned bounding box with the `C` ordering as GWCS will always attach and handle bounding boxes specifically in the `F` ordering.

This PR updates `romancal` so that bounding boxes are always attached with the tuple correctly ordered and flagged as `F` order.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
