### PR TITLE
rcal-952 Update grism flat field tests with correct input

### DIFF
--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -34,14 +34,14 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     assert diff.identical, diff.report()
 
 
-@pytest.mark.xfail(reason="Wrong input for the purpose of this test")
+#@pytest.mark.xfail(reason="Wrong input for the purpose of this test")
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using grism data. The reference file for
     the grism and prism data should be None, only testing the grism
     case here."""
 
-    input_file = "r0000201001001001001_0001_wfi01_uncal.asdf"
+    input_file = "r0000201001001001001_0001_wfi01_assignwcs.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -64,6 +64,8 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
+    output_model = rdm.open(rtdata.output)
+    assert output_model.meta.cal_step.flat_field == 'SKIPPED'
     rtdata.get_truth(f"truth/WFI/grism/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -34,7 +34,7 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     assert diff.identical, diff.report()
 
 
-#@pytest.mark.xfail(reason="Wrong input for the purpose of this test")
+# @pytest.mark.xfail(reason="Wrong input for the purpose of this test")
 @pytest.mark.bigdata
 def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using grism data. The reference file for
@@ -65,7 +65,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
     output_model = rdm.open(rtdata.output)
-    assert output_model.meta.cal_step.flat_field == 'SKIPPED'
+    assert output_model.meta.cal_step.flat_field == "SKIPPED"
     rtdata.get_truth(f"truth/WFI/grism/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-952](https://jira.stsci.edu/browse/RCAL-952)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1516

<!-- describe the changes comprising this PR here -->
This PR updates the input files for the grism flatfield test and checks that the output file matches the truth file
with flat_field set to "SKIPPED"

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>


passing regression tests are at
https://github.com/spacetelescope/RegressionTests/actions/runs/11918027530