### PR TITLE
Cleanup a photom test

### DIFF
--- a/romancal/photom/tests/test_photom.py
+++ b/romancal/photom/tests/test_photom.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 from astropy import units as u
@@ -105,19 +103,16 @@ def test_no_photom_match():
     input_model.meta.photometry.pixel_area = -1.0
     input_model.meta.photometry.conversion_megajanskys = -1.0
 
-    with warnings.catch_warnings(record=True) as caught:
+    with pytest.warns(
+        UserWarning,
+        match=f"No matching photom parameters for {input_model.meta.instrument.optical_element}",
+    ):
         # Look for now non existent F146 optical element
         output_model = photom.apply_photom(input_model, photom_model)
 
-        # Assert warning key matches that of the input file
-        assert (
-            str(caught[0].message).split()[-1]
-            == input_model.meta.instrument.optical_element
-        )
-
-        # Assert that photom elements are not updated
-        assert output_model.meta.photometry.pixel_area == -1.0
-        assert output_model.meta.photometry.conversion_megajanskys == -1.0
+    # Assert that photom elements are not updated
+    assert output_model.meta.photometry.pixel_area == -1.0
+    assert output_model.meta.photometry.conversion_megajanskys == -1.0
 
 
 def test_apply_photom1():


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
When doing some testing in `roman_datamodels` I discovered a photom test that was not properly testing warnings causing issues. This PR refactors that test to use `pytest.warns` instead.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
