### PR TITLE
fix return code for asn_from_list and skycell_asn, remove unused scripts, cleanup skycell_asn

### DIFF
--- a/changes/1538.associations.rst
+++ b/changes/1538.associations.rst
@@ -1,0 +1,1 @@
+Switch association scripts from using ``Main`` class to ``_cli`` function to fix return code.

--- a/changes/1538.scripts.rst
+++ b/changes/1538.scripts.rst
@@ -1,0 +1,1 @@
+Remove install of missing scripts "schema_editor" and "schemadoc".

--- a/docs/roman/associations/asn_from_list.rst
+++ b/docs/roman/associations/asn_from_list.rst
@@ -4,8 +4,7 @@ asn_from_list
 =============
 
 Create an association using either the command line tool
-``asn_from_list`` or through the Python API using either
-:class:`romancal.associations.asn_from_list.Main` or
+``asn_from_list`` or through the Python API using
 :func:`romancal.associations.asn_from_list.asn_from_list`
 
 

--- a/docs/roman/associations/skycell_asn.rst
+++ b/docs/roman/associations/skycell_asn.rst
@@ -4,8 +4,7 @@ skycell_asn
 ===========
 
 Create an association using either the command line tool
-``skycell_asn`` or through the Python API using either
-:class:`romancal.associations.skycell_asn.Main` or
+``skycell_asn`` or through the Python API using
 :func:`romancal.associations.skycellasn.skycell_asn`
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,11 +88,9 @@ webbpsf = "pytest_plugin.webbpsf_plugin"
 
 [project.scripts]
 roman_static_preview = "romancal.scripts.static_preview:command"
-schema_editor = "romancal.scripts.schema_editor:main"
-schemadoc = "romancal.scripts.schemadoc:main"
 verify_install_requires = "romancal.scripts.verify_install_requires:main"
-asn_from_list = "romancal.associations.asn_from_list:Main"
-skycell_asn = "romancal.associations.skycell_asn:Main"
+asn_from_list = "romancal.associations.asn_from_list:main"
+skycell_asn = "romancal.associations.skycell_asn:main"
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ webbpsf = "pytest_plugin.webbpsf_plugin"
 [project.scripts]
 roman_static_preview = "romancal.scripts.static_preview:command"
 verify_install_requires = "romancal.scripts.verify_install_requires:main"
-asn_from_list = "romancal.associations.asn_from_list:main"
-skycell_asn = "romancal.associations.skycell_asn:main"
+asn_from_list = "romancal.associations.asn_from_list:_cli"
+skycell_asn = "romancal.associations.skycell_asn:_cli"
 
 [build-system]
 requires = [

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -147,5 +147,5 @@ class Main:
             outfile.write(serialized)
 
 
-def main():
+def _cli():
     Main()

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -145,3 +145,7 @@ class Main:
             )
             _, serialized = asn.dump(format=parsed.format)
             outfile.write(serialized)
+
+
+def main():
+    Main()

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -43,7 +43,7 @@ def asn_from_list(items, rule=DMS_ELPP_Base, **kwargs):
     return asn
 
 
-class Main:
+def _cli(args=None):
     """Command-line interface for list_to_asn
 
     Parameters
@@ -55,97 +55,90 @@ class Main:
               with the similar structure as `sys.argv`
     """
 
-    def __init__(self, args=None):
-        if args is None:
-            args = sys.argv[1:]
-        if isinstance(args, str):
-            args = args.split(" ")
+    if args is None:
+        args = sys.argv[1:]
+    if isinstance(args, str):
+        args = args.split(" ")
 
-        parser = argparse.ArgumentParser(
-            description="Create an association from a list of files",
-            usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.fits",
+    parser = argparse.ArgumentParser(
+        description="Create an association from a list of files",
+        usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.fits",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        type=str,
+        required=True,
+        help="File to write association to",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        default="json",
+        help='Format of the association files. Default: "%(default)s"',
+    )
+
+    parser.add_argument(
+        "--product-name",
+        type=str,
+        help="The product name when creating a Level 3 association",
+    )
+
+    parser.add_argument(
+        "-r",
+        "--rule",
+        type=str,
+        default="DMS_ELPP_Base",
+        help=('The rule to base the association structure on. Default: "%(default)s"'),
+    )
+    parser.add_argument(
+        "--ruledefs",
+        action="append",
+        help=(
+            "Association rules definition file(s) If not specified, the default"
+            " rules will be searched."
+        ),
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        type=str,
+        default="o999",
+        help='The association candidate id to use. Default: "%(default)s"',
+        dest="acid",
+    )
+    parser.add_argument(
+        "-t",
+        "--target",
+        type=str,
+        default="None",
+        help='The target name for the association. Default: "%(default)s"',
+        dest="target",
+    )
+
+    parser.add_argument(
+        "filelist",
+        type=str,
+        nargs="+",
+        help="File list to include in the association",
+    )
+
+    parsed = parser.parse_args(args=args)
+    print("Parsed args:", parsed)
+
+    # Get the rule
+    rule = AssociationRegistry(parsed.ruledefs, include_bases=True)[parsed.rule]
+
+    with open(parsed.output_file, "w") as outfile:
+        asn = asn_from_list(
+            parsed.filelist,
+            rule=rule,
+            product_name=parsed.product_name,
+            acid=parsed.acid,
+            target=parsed.target,
         )
-
-        parser.add_argument(
-            "-o",
-            "--output-file",
-            type=str,
-            required=True,
-            help="File to write association to",
-        )
-
-        parser.add_argument(
-            "-f",
-            "--format",
-            type=str,
-            default="json",
-            help='Format of the association files. Default: "%(default)s"',
-        )
-
-        parser.add_argument(
-            "--product-name",
-            type=str,
-            help="The product name when creating a Level 3 association",
-        )
-
-        parser.add_argument(
-            "-r",
-            "--rule",
-            type=str,
-            default="DMS_ELPP_Base",
-            help=(
-                'The rule to base the association structure on. Default: "%(default)s"'
-            ),
-        )
-        parser.add_argument(
-            "--ruledefs",
-            action="append",
-            help=(
-                "Association rules definition file(s) If not specified, the default"
-                " rules will be searched."
-            ),
-        )
-        parser.add_argument(
-            "-i",
-            "--id",
-            type=str,
-            default="o999",
-            help='The association candidate id to use. Default: "%(default)s"',
-            dest="acid",
-        )
-        parser.add_argument(
-            "-t",
-            "--target",
-            type=str,
-            default="None",
-            help='The target name for the association. Default: "%(default)s"',
-            dest="target",
-        )
-
-        parser.add_argument(
-            "filelist",
-            type=str,
-            nargs="+",
-            help="File list to include in the association",
-        )
-
-        parsed = parser.parse_args(args=args)
-        print("Parsed args:", parsed)
-
-        # Get the rule
-        rule = AssociationRegistry(parsed.ruledefs, include_bases=True)[parsed.rule]
-
-        with open(parsed.output_file, "w") as outfile:
-            asn = asn_from_list(
-                parsed.filelist,
-                rule=rule,
-                product_name=parsed.product_name,
-                acid=parsed.acid,
-                target=parsed.target,
-            )
-            _, serialized = asn.dump(format=parsed.format)
-            outfile.write(serialized)
-
-
-def _cli():
-    Main()
+        _, serialized = asn.dump(format=parsed.format)
+        outfile.write(serialized)

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -62,7 +62,7 @@ def _cli(args=None):
 
     parser = argparse.ArgumentParser(
         description="Create an association from a list of files",
-        usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.fits",
+        usage="asn_from_list -o mosaic_asn.json\n--product-name my_mosaic *.asdf",
     )
 
     parser.add_argument(

--- a/romancal/associations/skycell_asn.py
+++ b/romancal/associations/skycell_asn.py
@@ -21,7 +21,27 @@ logger.setLevel("INFO")
 
 
 def skycell_asn(filelist, output_file_root, product_type, release_product):
-    """Create the skycell associaton from the list"""
+    """
+    Create the skycell association from the list of files.
+
+    This function processes a list of files, identifies matching patches, generates
+    TAN WCS parameters, and creates an association file for the identified sky patches.
+
+    Parameters
+    ----------
+    filelist : list of str
+        List of file names to be processed.
+    output_file_root : str
+        Root string for the output association file.
+    product_type : str
+        Type of product when creating the association (e.g., 'visit', 'daily').
+    release_product : str
+        Release product identifier for the association.
+
+    Returns
+    -------
+    None
+    """
     all_patches = []
     file_list = []
     for file_name in filelist:

--- a/romancal/associations/skycell_asn.py
+++ b/romancal/associations/skycell_asn.py
@@ -190,9 +190,9 @@ class Main:
         skycell_asn(self)
 
 
-def main():
+def _cli():
     Main()
 
 
 if __name__ == "__main__":
-    main()
+    _cli()

--- a/romancal/associations/skycell_asn.py
+++ b/romancal/associations/skycell_asn.py
@@ -190,6 +190,9 @@ class Main:
         skycell_asn(self)
 
 
-if __name__ == "__main__":
-
+def main():
     Main()
+
+
+if __name__ == "__main__":
+    main()

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -3,7 +3,7 @@
 import pytest
 
 from romancal.associations import Association, AssociationRegistry, load_asn
-from romancal.associations.asn_from_list import Main, asn_from_list
+from romancal.associations.asn_from_list import _cli, asn_from_list
 from romancal.associations.exceptions import AssociationNotValidError
 
 
@@ -111,11 +111,11 @@ def test_cmdline_fails():
 
     # No arguments
     with pytest.raises(SystemExit):
-        Main([])
+        _cli([])
 
     # Only the association file argument
     with pytest.raises(SystemExit):
-        Main(["-o", "test_asn.json"])
+        _cli(["-o", "test_asn.json"])
 
 
 @pytest.mark.parametrize("format", ["json", "yaml"])
@@ -126,7 +126,7 @@ def test_cmdline_success(format, tmp_path):
     inlist = ["a", "b", "c"]
     args = ["-o", str(path), "--product-name", product_name, "--format", format]
     args = args + inlist
-    Main(args)
+    return_code = _cli(args)
     with path.open() as fp:
         asn = load_asn(fp, format=format)
     assert len(asn["products"]) == 1
@@ -134,6 +134,7 @@ def test_cmdline_success(format, tmp_path):
     members = asn["products"][0]["members"]
     expnames = [member["expname"] for member in members]
     assert inlist == expnames
+    assert not return_code
 
 
 def test_cmdline_change_rules(tmp_path):
@@ -150,7 +151,7 @@ def test_cmdline_change_rules(tmp_path):
         "test",
     ]
     args = args + inlist
-    Main(args)
+    _cli(args)
     with path.open() as fp:
         asn = load_asn(fp, registry=AssociationRegistry(include_bases=True))
     # assert inlist == asn['members']

--- a/romancal/associations/tests/test_skycell_asn.py
+++ b/romancal/associations/tests/test_skycell_asn.py
@@ -4,7 +4,7 @@ import pytest
 
 # from romancal.associations import Association, AssociationRegistry, load_asn
 import romancal.associations.skycell_asn as skycell_asn
-from romancal.associations.skycell_asn import Main
+from romancal.associations.skycell_asn import _cli
 
 
 def test_cmdline_fails():
@@ -12,11 +12,11 @@ def test_cmdline_fails():
 
     # No arguments
     with pytest.raises(SystemExit):
-        Main([])
+        _cli([])
 
     # Only the association file argument
     with pytest.raises(SystemExit):
-        Main(["-o", "test_asn.json"])
+        _cli(["-o", "test_asn.json"])
 
 
 def test_parse_visitID():

--- a/romancal/regtest/test_skycell_generation.py
+++ b/romancal/regtest/test_skycell_generation.py
@@ -21,7 +21,7 @@ def test_skycell_asn_generation(rtdata):
     rtdata.get_data("WFI/image/r0000101001001001001_0002_wfi01_cal.asdf")
     rtdata.get_data("WFI/image/r0000101001001001001_0002_wfi10_cal.asdf")
 
-    skycell_asn.Main(args)
+    skycell_asn._cli(args)
 
     # skycell associations that should be generated
     output_files = [


### PR DESCRIPTION
This PR fixes the return code for `asn_from_list` and `skycell_asn` when they succeed (see #1535).

Which sorting out that fix I saw that:
- "schema_editor" and "schemadoc" are registered scripts that do not exist. This PR removes their registration from pyproject.toml
- The python function (not method) "skycell_asn" takes 1 argument "self". This PR updates the function signature to follow conventions of a non-method function. Further improvements are likely called for if this is expected to be part of the public API (it is mentioned in the documentation).

I left a number of in-line comments with some important ones about unused command line arguments for "skycell_asn" (which are not modified in this PR).

Closes https://github.com/spacetelescope/romancal/issues/1535

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/12018368084

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
