### PR TITLE
turn exit calls into exceptions

### DIFF
--- a/changes/1545.mosaic_pipeline.rst
+++ b/changes/1545.mosaic_pipeline.rst
@@ -1,0 +1,1 @@
+Convert calls to ``exit(0)`` within the pipeline into exceptions.

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -65,9 +65,7 @@ class MosaicPipeline(RomanPipeline):
         # open the input file
         file_type = filetype.check(input)
         if file_type == "asdf":
-            log.info("The level three pipeline input needs to be an association")
-            exit(0)
-            return
+            raise TypeError("The level three pipeline input needs to be an association")
 
         if file_type == "asn":
             input = ModelLibrary(input, on_disk=self.on_disk)
@@ -135,8 +133,9 @@ class MosaicPipeline(RomanPipeline):
                         self.sourcecatalog.output_file = self.output_file
                         result_catalog = self.sourcecatalog.run(result)
                     else:
-                        log.info("resampling a mosaic file is not yet supported")
-                        exit(0)
+                        raise NotImplementedError(
+                            "resampling a mosaic file is not yet supported"
+                        )
 
             else:
                 self.resample.suffix = "coadd"


### PR DESCRIPTION
Closes #1544

This PR converts the `exit(0)` calls in the mosaic pipeline to exceptions.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/12036561824

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
