### PR TITLE
Fix deprecation warnings

### DIFF
--- a/changes/1546.general.rst
+++ b/changes/1546.general.rst
@@ -1,0 +1,1 @@
+Fix deprication warnings that have shown up in the tests.

--- a/romancal/resample/gwcs_drizzle.py
+++ b/romancal/resample/gwcs_drizzle.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-from drizzle import cdrizzle, util
+from drizzle import cdrizzle
 
 from . import resample_utils
 
@@ -377,10 +377,7 @@ def dodrizzle(
     """
 
     # Insure that the fillval parameter gets properly interpreted for use with tdriz
-    if util.is_blank(str(fillval)):
-        fillval = "INDEF"
-    else:
-        fillval = str(fillval)
+    fillval = "INDEF" if str(fillval).strip() == "" else str(fillval)
 
     if in_units == "cps":
         expscale = 1.0

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -6,7 +6,7 @@ from typing import List
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from drizzle import cdrizzle, util
+from drizzle import cdrizzle
 from roman_datamodels import datamodels, maker_utils, stnode
 from stcal.alignment.util import compute_s_region_keyword, compute_scale
 
@@ -696,7 +696,7 @@ class ResampleData:
         """
 
         # Insure that the fillval parameter gets properly interpreted for use with tdriz
-        fillval = "INDEF" if util.is_blank(str(fillval)) else str(fillval)
+        fillval = "INDEF" if str(fillval).strip() == "" else str(fillval)
         if insci.dtype > np.float32:
             insci = insci.astype(np.float32)
 

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -8,7 +8,7 @@ from astropy import wcs as fitswcs
 from astropy.modeling import Model
 from astropy.nddata.bitmask import bitfield_to_boolean_mask
 from roman_datamodels.dqflags import pixel
-from stcal.alignment.util import wcs_from_footprints
+from stcal.alignment.util import wcs_from_sregions
 
 from romancal.assign_wcs.utils import wcs_bbox_from_shape
 
@@ -73,13 +73,14 @@ def make_output_wcs(
         if w.bounding_box is None:
             w.bounding_box = wcs_bbox_from_shape(i.data.shape)
     naxes = wcslist[0].output_frame.naxes
+    ref_wcs = wcslist[0]
 
     if naxes != 2:
         raise RuntimeError(f"Output WCS needs 2 axes.{wcslist[0]} has {naxes}.")
 
-    output_wcs = wcs_from_footprints(
-        wcslist,
-        None,
+    output_wcs = wcs_from_sregions(
+        [wcs.footprint() for wcs in wcslist],
+        ref_wcs,
         dict(input_models[0].meta.wcsinfo),
         pscale_ratio=pscale_ratio,
         pscale=pscale,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
I noticed that `romancal` tests were producing a fair number of deprecation warnings. This PR attempts to resolve those.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
