### PR TITLE
Fix unit tests due to incoming changes in stcal

### DIFF
--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -457,8 +457,12 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0(exposure_1):
     expected_max_value = np.max(np.stack(input_wcs_list))
 
     # Assert
-    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
-    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    assert (
+        (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    )
+    assert (
+        (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    )
 
 
 def test_resampledata_do_drizzle_many_to_one_default_rotation_0_multiple_exposures(
@@ -492,8 +496,12 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0_multiple_exposur
     expected_max_value = np.max(np.stack(input_wcs_list))
 
     # Assert
-    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
-    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    assert (
+        (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    )
+    assert (
+        (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    )
 
 
 def test_resampledata_do_drizzle_many_to_one_single_input_model(wfi_sca1):
@@ -686,8 +694,13 @@ def test_custom_wcs_input_entire_field_no_rotation(multiple_exposures):
     expected_min_value = np.min(np.stack(input_wcs_list))
     expected_max_value = np.max(np.stack(input_wcs_list))
 
-    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
-    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    assert (
+        (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    )
+    assert (
+        (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
+    )
+
 
 @pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
 def test_resampledata_do_drizzle_default_single_exposure_weight_array(

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -279,6 +279,13 @@ def multiple_exposures(exposure_1, exposure_2):
     return exposure_1
 
 
+def get_resampled_wcs_pixel_scale(wcs):
+    t = wcs.forward_transform
+    for p in t.param_names:
+        if p.startswith("factor"):
+            return getattr(t, p).value
+
+
 def test_resampledata_init(exposure_1):
     """Test that ResampleData can set initial values."""
     input_models = ModelLibrary(exposure_1)
@@ -436,6 +443,7 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0(exposure_1):
 
     with output_models:
         model = output_models.borrow(0)
+        pscale = get_resampled_wcs_pixel_scale(model.meta.wcs)
         output_min_value = np.min(model.meta.wcs.footprint())
         output_max_value = np.max(model.meta.wcs.footprint())
         output_models.shelve(model, 0, modify=False)
@@ -449,8 +457,8 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0(exposure_1):
     expected_max_value = np.max(np.stack(input_wcs_list))
 
     # Assert
-    np.testing.assert_allclose(output_min_value, expected_min_value)
-    np.testing.assert_allclose(output_max_value, expected_max_value)
+    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
 
 
 def test_resampledata_do_drizzle_many_to_one_default_rotation_0_multiple_exposures(
@@ -472,6 +480,7 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0_multiple_exposur
         model = output_models.borrow(0)
         output_min_value = np.min(model.meta.wcs.footprint())
         output_max_value = np.max(model.meta.wcs.footprint())
+        pscale = get_resampled_wcs_pixel_scale(model.meta.wcs)
         output_models.shelve(model, 0, modify=False)
 
     def get_footprint(model, index):
@@ -483,8 +492,8 @@ def test_resampledata_do_drizzle_many_to_one_default_rotation_0_multiple_exposur
     expected_max_value = np.max(np.stack(input_wcs_list))
 
     # Assert
-    np.testing.assert_allclose(output_min_value, expected_min_value)
-    np.testing.assert_allclose(output_max_value, expected_max_value)
+    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
 
 
 def test_resampledata_do_drizzle_many_to_one_single_input_model(wfi_sca1):
@@ -505,9 +514,10 @@ def test_resampledata_do_drizzle_many_to_one_single_input_model(wfi_sca1):
         model = output_models.borrow(0)
         flat_2 = np.sort(model.meta.wcs.footprint().flatten())
         assert model.meta.filename == resample_data.output_filename
+        pscale = get_resampled_wcs_pixel_scale(model.meta.wcs)
         output_models.shelve(model, 0, modify=False)
 
-    np.testing.assert_allclose(flat_1, flat_2)
+    np.testing.assert_allclose(flat_1, flat_2, atol=0.5 * pscale)
 
 
 def test_update_exposure_times_different_sca_same_exposure(exposure_1):
@@ -665,6 +675,7 @@ def test_custom_wcs_input_entire_field_no_rotation(multiple_exposures):
         model = output_models.borrow(0)
         output_min_value = np.min(model.meta.wcs.footprint())
         output_max_value = np.max(model.meta.wcs.footprint())
+        pscale = get_resampled_wcs_pixel_scale(model.meta.wcs)
         output_models.shelve(model, 0, modify=False)
 
     def get_footprint(model, index):
@@ -675,9 +686,8 @@ def test_custom_wcs_input_entire_field_no_rotation(multiple_exposures):
     expected_min_value = np.min(np.stack(input_wcs_list))
     expected_max_value = np.max(np.stack(input_wcs_list))
 
-    np.testing.assert_allclose(output_min_value, expected_min_value)
-    np.testing.assert_allclose(output_max_value, expected_max_value)
-
+    assert (expected_min_value - 0.5001 * pscale) <= output_min_value <= expected_min_value
+    assert (expected_max_value + 0.5001 * pscale) >= output_max_value >= expected_max_value
 
 @pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
 def test_resampledata_do_drizzle_default_single_exposure_weight_array(
@@ -708,6 +718,8 @@ def test_populate_mosaic_basic_single_exposure(exposure_1):
     input_models = ModelLibrary(exposure_1)
     with input_models:
         models = list(input_models)
+        crpix = tuple(s // 2 for s in models[0].data.shape[::-1])
+        crval = models[0].meta.wcs(*crpix)
         output_wcs = resample_utils.make_output_wcs(
             models,
             pscale_ratio=1,
@@ -715,7 +727,7 @@ def test_populate_mosaic_basic_single_exposure(exposure_1):
             rotation=0,
             shape=None,
             crpix=(0, 0),
-            crval=(0, 0),
+            crval=crval,
         )
 
         output_model = maker_utils.mk_datamodel(
@@ -1014,7 +1026,7 @@ def test_populate_mosaic_basic_different_observations(
         rotation=0,
         shape=None,
         crpix=(0, 0),
-        crval=(0, 0),
+        crval=(30, 45),
     )
     output_model = maker_utils.mk_datamodel(
         datamodels.MosaicModel, shape=tuple(output_wcs.array_shape)


### PR DESCRIPTION
This PR fixes unit test failures that will occur if https://github.com/spacetelescope/stcal/pull/326 is accepted.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
