### PR TITLE
RCAL-992: only single json encode skycell wcs in asn

### DIFF
--- a/changes/1591.associations.rst
+++ b/changes/1591.associations.rst
@@ -1,0 +1,1 @@
+Fix bug where skycell_wcs_info was double json encoded

--- a/romancal/associations/skycell_asn.py
+++ b/romancal/associations/skycell_asn.py
@@ -1,7 +1,6 @@
 """Create an association based on skycells"""
 
 import argparse
-import json
 import logging
 import sys
 
@@ -128,7 +127,7 @@ def skycell_asn(filelist, output_file_root, product_type, release_product):
             prompt_product_asn["asn_type"] = "image"
             prompt_product_asn["program"] = program_id
             prompt_product_asn["target"] = patch_name
-            prompt_product_asn["skycell_wcs_info"] = json.dumps(projcell_info)
+            prompt_product_asn["skycell_wcs_info"] = projcell_info
             _, serialized = prompt_product_asn.dump(format="json")
             outfile.write(serialized)
 

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-import json
 import logging
 import re
 from os.path import basename, isfile
@@ -95,9 +94,9 @@ class MosaicPipeline(RomanPipeline):
             if re.match(r"r\d{3}\w{2}\d{2}x\d{2}y\d{2}", skycell_name):
                 # check to see if the skycell coords are in the asn header if
                 # so read the string and convert to a dictionary to match the patch table
-                try:
-                    skycell_record = json.loads(input.asn["skycell_wcs_info"])
-                except (KeyError, json.JSONDecodeError):
+                if "skycell_wcs_info" in input.asn:
+                    skycell_record = input.asn["skycell_wcs_info"]
+                else:
                     if patch_match.PATCH_TABLE is None:
                         patch_match.load_patch_table()
                     skycell_record = patch_match.PATCH_TABLE[

--- a/romancal/regtest/test_skycell_generation.py
+++ b/romancal/regtest/test_skycell_generation.py
@@ -1,15 +1,28 @@
 """Roman tests for generating associatinos based on skycells"""
 
+import json
 import os
 
 import pytest
 
 from romancal.associations import skycell_asn
 
+# mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
 
-@pytest.mark.bigdata
-def test_skycell_asn_generation(rtdata):
-    """Test for the generation of associations based on skycells"""
+EXPECTED_FILENAMES = [
+    "r512_p_v01001001001_r274dp63x31y80_f158_asn.json",
+    "r512_p_v01001001001_r274dp63x31y81_f158_asn.json",
+    "r512_p_v01001001001_r274dp63x32y82_f158_asn.json",
+    "r512_p_v01001001001_r274dp63x32y80_f158_asn.json",
+    "r512_p_v01001001001_r274dp63x32y81_f158_asn.json",
+    "r512_p_v01001001001_r274dp63x32y82_f158_asn.json",
+]
+
+
+@pytest.fixture(scope="module")
+def run_skycell_asn(rtdata_module):
+    rtdata = rtdata_module
 
     # This test should generate seven json files
     args = [
@@ -22,17 +35,17 @@ def test_skycell_asn_generation(rtdata):
     rtdata.get_data("WFI/image/r0000101001001001001_0002_wfi10_cal.asdf")
 
     skycell_asn._cli(args)
+    return rtdata
 
-    # skycell associations that should be generated
-    output_files = [
-        "r512_p_v01001001001_r274dp63x31y80_f158_asn.json",
-        "r512_p_v01001001001_r274dp63x31y81_f158_asn.json",
-        "r512_p_v01001001001_r274dp63x32y82_f158_asn.json",
-        "r512_p_v01001001001_r274dp63x32y80_f158_asn.json",
-        "r512_p_v01001001001_r274dp63x32y81_f158_asn.json",
-        "r512_p_v01001001001_r274dp63x32y82_f158_asn.json",
-    ]
-    # Test that the json files exist
-    for file in output_files:
-        skycell_asn.logger.info(f"Check that the json file exists{file}")
-        assert os.path.isfile(file)
+
+@pytest.mark.parametrize("expected_filename", EXPECTED_FILENAMES)
+def test_file_exists(run_skycell_asn, expected_filename):
+    """Test that the expected json files were generated"""
+    assert os.path.isfile(expected_filename)
+
+
+@pytest.mark.parametrize("expected_filename", EXPECTED_FILENAMES)
+def test_files_contain_wcsinfo(run_skycell_asn, expected_filename):
+    with open(expected_filename) as f:
+        asn = json.load(f)
+    assert "skycell_wcs_info" in asn


### PR DESCRIPTION
Resolves [RCAL-992](https://jira.stsci.edu/browse/RCAL-992)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1589

This PR fixes the bug where the `skycell_wcs_info` contents added by `skycell_asn` to the association files is double json encoded.

Regtests https://github.com/spacetelescope/RegressionTests/actions/runs/12991881301

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
