### PR TITLE
Update regtest code for DMS 392, DMS394, DMS395.

### DIFF
--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -18,6 +18,13 @@ fieldlist = [
     "F158_aper_total_flux",  # DMS375 fluxes
     "F158_aper_total_flux_err",  # DMS386 flux uncertainties
     "flags",  # DMS387 dq_flags
+    "is_extended",  # DMS392 source classification
+    "semimajor_sigma",  # DMS394 galaxy morphology
+    "semiminor_sigma",  # DMS394 galaxy morphology
+    "orientation",  # DMS394 galaxy morphology
+    "F158_kron_flux_err",  # DMS395 basic statistical uncertainties
+    "F158_aper30_flux_err",  # DMS395 basic statistical uncertainties
+    "F158_x_psf_err",  # DMS395 basic statistical uncertainties
 ]
 
 
@@ -45,6 +52,10 @@ def test_multiband_catalog(rtdata_module):
     for field in fieldlist:
         assert field in afcat["roman"]["source_catalog"].dtype.names
 
+    step = MultibandCatalogStep()
+    step.log.info('DMS374, 399, 375, 386, 387, 392, 394, 395: source catalog includes fields: '
+                  + ', '.join(fieldlist))
+
     # DMS 393: multiband catalog uses both PSF-like and extend-source-like
     # kernels
     assert set(aftruth["roman"]["source_catalog"].dtype.names) == set(
@@ -56,7 +67,6 @@ def test_multiband_catalog(rtdata_module):
     # the same, but we can easily check that the columns match up
     # by name.
 
-    step = MultibandCatalogStep()
     step.log.info("DMS391: successfully used multiple kernels to detect sources.")
     step.log.info("DMS393: successfully used deblending to separate blended sources.")
     step.log.info(

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -111,7 +111,16 @@
   "DMS391": [
     "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
   ],
+  "DMS392": [
+    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+  ],
   "DMS393": [
+    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+  ],
+  "DMS394": [
+    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+  ],
+  "DMS395": [
     "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
   ],
   "DMS399": [


### PR DESCRIPTION
Resolves [RCAL-994](https://jira.stsci.edu/browse/RCAL-994)

This PR updates the regression tests to look for additional fields associated with galaxy morphology, source classification, and statistical uncertainties.  These fields already were being computed in the existing source catalogs, so no new calculations are performed.  The new work is to test for the existence of these fields.

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] update or add relevant tests
  - [X] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)