### PR TITLE
TEST: add test to show bug

### DIFF
--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -1,13 +1,18 @@
+from functools import reduce
+
 import numpy as np
 import pytest
 from asdf import AsdfFile
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling import models
+from astropy.table import QTable
+from astropy.time import Time
 from gwcs import WCS
 from gwcs import coordinate_frames as cf
 from roman_datamodels import datamodels, maker_utils
 
+from romancal.datamodels import ModelLibrary
 from romancal.resample import ResampleStep, resample_utils
 
 
@@ -370,3 +375,99 @@ def test_build_driz_weight_different_weight_type(base_image, weight_type):
     }
 
     np.testing.assert_array_almost_equal(expected_results.get(weight_type), result)
+
+
+@pytest.mark.parametrize(
+    "meta_overrides, expected_basic",
+    [
+        (  # 2 exposures, share visit, etc
+            (
+                {
+                    "meta.observation.visit": 1,
+                    "meta.observation.pass": 1,
+                    "meta.observation.segment": 1,
+                    "meta.observation.program": 1,
+                    "meta.instrument.optical_element": "F158",
+                    "meta.instrument.name": "WFI",
+                },
+                {
+                    "meta.observation.visit": 1,
+                    "meta.observation.pass": 1,
+                    "meta.observation.segment": 1,
+                    "meta.observation.program": 1,
+                    "meta.instrument.optical_element": "F158",
+                    "meta.instrument.name": "WFI",
+                },
+            ),
+            {
+                "visit": 1,
+                "pass": 1,
+                "segment": 1,
+                "optical_element": "F158",
+                "instrument": "WFI",
+            },
+        ),
+        (  # 2 exposures, different metadata
+            (
+                {
+                    "meta.observation.visit": 1,
+                    "meta.observation.pass": 1,
+                    "meta.observation.segment": 1,
+                    "meta.observation.program": 1,
+                    "meta.instrument.optical_element": "F158",
+                    "meta.instrument.name": "WFI",
+                },
+                {
+                    "meta.observation.visit": 2,
+                    "meta.observation.pass": 2,
+                    "meta.observation.segment": 2,
+                    "meta.observation.program": 2,
+                    "meta.instrument.optical_element": "F062",
+                    "meta.instrument.name": "WFI",
+                },
+            ),
+            {
+                "visit": 1,
+                "pass": 1,
+                "segment": 1,
+                "optical_element": "F158",
+                "instrument": "WFI",
+            },
+        ),
+    ],
+)
+def test_populate_mosaic_basic(base_image, meta_overrides, expected_basic):
+    """Test that the basic mosaic metadata is being populated"""
+    models = []
+    for i, meta_override in enumerate(meta_overrides):
+        model = base_image()
+
+        model.meta.observation.observation_id = i
+
+        model.meta.exposure.start_time = Time(59000 + i, format="mjd")
+        model.meta.exposure.end_time = Time(59001 + i, format="mjd")
+        model.meta.exposure.mid_time = Time(
+            (model.meta.exposure.start_time.mjd + model.meta.exposure.end_time.mjd) / 2,
+            format="mjd",
+        )
+
+        for key, value in meta_override.items():
+            *parent_keys, child_key = key.split(".")
+            setattr(reduce(getattr, parent_keys, model), child_key, value)
+        models.append(model)
+
+    input_models = ModelLibrary(models)
+    output_model = ResampleStep().run(input_models)
+
+    assert (
+        output_model.meta.basic.time_first_mjd == models[0].meta.exposure.start_time.mjd
+    )
+    assert (
+        output_model.meta.basic.time_last_mjd == models[-1].meta.exposure.end_time.mjd
+    )
+    assert output_model.meta.basic.time_mean_mjd == np.mean(
+        [m.meta.exposure.mid_time.mjd for m in models]
+    )
+
+    for key, value in expected_basic.items():
+        assert getattr(output_model.meta.basic, key) == value


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
