### PR TITLE
allow `MosaicModel`

### DIFF
--- a/changes/1613.scripts.rst
+++ b/changes/1613.scripts.rst
@@ -1,0 +1,1 @@
+allow `MosaicModel` in `roman_static_preview`

--- a/romancal/scripts/static_preview.py
+++ b/romancal/scripts/static_preview.py
@@ -50,7 +50,7 @@ def command():
 
         with asdf.open(input) as file:
             model = file["roman"]["meta"]["model_type"]
-            if "image" not in model.lower():
+            if "image" not in model.lower() and "mosaic" not in model.lower():
                 raise NotImplementedError(f'"{model}" model not supported')
             wcs = file["roman"]["meta"]["wcs"]
 
@@ -89,7 +89,7 @@ def command():
 
         with asdf.open(input) as file:
             model = file["roman"]["meta"]["model_type"]
-            if "image" not in model.lower():
+            if "image" not in model.lower() and "mosaic" not in model.lower():
                 raise NotImplementedError(f'"{model}" model not supported')
 
         data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-958](https://jira.stsci.edu/browse/RCAL-958)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
also allows `MosaicModel` when creating previews

```shell
roman_static_preview preview /grp/roman/ddavis/roman/level3_products/r00001_p_v01001001001_r274dp63x31y80_f158_coadd_i2d.asdf test.png 400 400
```
![test](https://github.com/user-attachments/assets/7f11393d-768b-4020-b5bd-c05756e7b330)

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
