### PR TITLE
fix data workflow to use stpsf

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -5,32 +5,32 @@ on:
     - cron: "42 4 * * 3"
   workflow_dispatch:
     inputs:
-      webbpsf_minimal:
-        description: minimal WebbPSF dataset
+      stpsf_minimal:
+        description: minimal STPSF dataset
         type: boolean
         required: false
         default: true
 
 jobs:
-  download_webbpsf_data:
+  download_stpsf_data:
     uses: ./.github/workflows/download_data.yml
     with:
-      minimal: ${{ github.event_name != 'workflow_dispatch' && true || inputs.webbpsf_minimal }}
+      minimal: ${{ github.event_name != 'workflow_dispatch' && true || inputs.stpsf_minimal }}
   move_data_cache_path:
-    needs: [ download_webbpsf_data ]
+    needs: [ download_stpsf_data ]
     runs-on: ubuntu-latest
     steps:
-      - name: retrieve cached WebbPSF data
+      - name: retrieve cached STPSF data
         uses: actions/cache/restore@v4
         with:
-          path: ${{ needs.download_webbpsf_data.outputs.cache_path }}
-          key: ${{ needs.download_webbpsf_data.outputs.cache_key }}
+          path: ${{ needs.download_stpsf_data.outputs.cache_path }}
+          key: ${{ needs.download_stpsf_data.outputs.cache_key }}
       - run: mkdir -p /tmp/data/
-      - run: mv ${{ needs.download_webbpsf_data.outputs.cache_path }}/webbpsf-data/ /tmp/data/
-      - run: echo WEBBPSF_PATH=/tmp/data/webbpsf-data/ >> $GITHUB_ENV
+      - run: mv ${{ needs.download_stpsf_data.outputs.cache_path }}/stpsf-data/ /tmp/data/
+      - run: echo STPSF_PATH=/tmp/data/stpsf-data/ >> $GITHUB_ENV
       # save a new cache to the generalized data directory
       - name: save a single combined data cache
         uses: actions/cache/save@v4
         with:
           path: /tmp/data/
-          key: ${{ needs.download_webbpsf_data.outputs.cache_key }}
+          key: ${{ needs.download_stpsf_data.outputs.cache_key }}


### PR DESCRIPTION
Follow up to https://github.com/spacetelescope/romancal/pull/1636 supporting https://github.com/spacetelescope/romancal/pull/1635

This PR updates `data.yml` to move the stpsf instead of webbpsf data to the expected cache path to fix the failure:
https://github.com/spacetelescope/romancal/actions/runs/13500040063

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
