### PR TITLE
test with latest supported Python version

### DIFF
--- a/.github/workflows/roman_ci.yml
+++ b/.github/workflows/roman_ci.yml
@@ -73,14 +73,13 @@ jobs:
       cache-restore-keys: ${{ needs.stpsf_data_cache.outputs.cache_key }}
       envs: |
         - linux: py311-oldestdeps-stpsf-cov
-          pytest-results-summary: true
         - linux: py311-stpsf-nolegacypath
-          pytest-results-summary: true
         - linux: py312-ddtrace-stpsf
-          pytest-results-summary: true
         - macos: py312-ddtrace-stpsf
-          pytest-results-summary: true
-        - linux: py312-stpsf-cov
+        # `tox` does not currently respect `requires-python` versions when creating testing environments;
+        # if this breaks, add an upper pin to `requires-python` and revert this py3 to the latest working version
+        - linux: py3-stpsf-cov
           coverage: codecov
           pytest-results-summary: true
-        - linux: py313-stpsf
+        - macos: py3-stpsf
+          pytest-results-summary: true

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -66,17 +66,11 @@ jobs:
       cache-key: data-${{ needs.stpsf_data_cache.outputs.cache_key }}-${{ needs.crds_context.outputs.context }}
       cache-restore-keys: ${{ needs.stpsf_data_cache.outputs.cache_key }}
       envs: |
-        - linux: py311-stdevdeps-stpsf
-        - linux: py311-devdeps-stpsf
-        - macos: py311-stdevdeps-stpsf
-        - macos: py311-devdeps-stpsf
         - linux: py3-stdevdeps-stpsf
-          pytest-results-summary: true
-        - linux: py3-devdeps-stpsf
           pytest-results-summary: true
         - macos: py3-stdevdeps-stpsf
           pytest-results-summary: true
+        - linux: py3-devdeps-stpsf
+          pytest-results-summary: true
         - macos: py3-devdeps-stpsf
           pytest-results-summary: true
-        - linux: py312-devdeps
-          python_version: "3.12-dev"

--- a/changes/1640.general.rst
+++ b/changes/1640.general.rst
@@ -1,0 +1,1 @@
+test with latest supported Python version


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-195](https://jira.stsci.edu/browse/SCSB-195)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
