### PR TITLE
Fix tvac dqinit test to properly okify

### DIFF
--- a/romancal/regtest/test_elp_tvac.py
+++ b/romancal/regtest/test_elp_tvac.py
@@ -28,7 +28,6 @@ def run_elp(rtdata_module):
 
     # Test Pipeline
     output = "TVAC2_NOMOPS_WFIFLA_20240419194120_WFI01_cal.asdf"
-    output_dqinit = "TVAC2_NOMOPS_WFIFLA_20240419194120_WFI01_dqinit.asdf"
     rtdata.output = output
     args = [
         "roman_elp",
@@ -42,7 +41,6 @@ def run_elp(rtdata_module):
     ExposurePipeline.from_cmdline(args)
 
     # get truth file
-    rtdata.get_truth(f"truth/WFI/image/{output_dqinit}")
     rtdata.get_truth(f"truth/WFI/image/{output}")
     return rtdata
 
@@ -68,16 +66,16 @@ def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths
     assert diff.identical, diff.report()
 
 
-def test_dqinit_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
-    dqinit_path = Path(output_filename)
-    dqinit_filename = replace_suffix(dqinit_path.stem, "dqinit")
-    dqinit_filename = dqinit_path.parent / (dqinit_filename + dqinit_path.suffix)
+def test_dqinit_matches_truth(run_elp, ignore_asdf_paths):
+    output_path = Path(run_elp.output)
+    dqinit_filename = replace_suffix(output_path.stem, "dqinit") + output_path.suffix
+    dqinit_path = output_path.parent / dqinit_filename
 
-    truth_path = Path(truth_filename)
-    truth_filename = replace_suffix(truth_path.stem, "dqinit")
-    truth_filename = truth_path.parent / (truth_filename + truth_path.suffix)
+    run_elp.get_truth(f"truth/WFI/image/{dqinit_filename}")
 
-    diff = compare_asdf(dqinit_filename, truth_filename, **ignore_asdf_paths)
+    truth_path = Path(run_elp.truth)
+
+    diff = compare_asdf(dqinit_path, truth_path, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
 

--- a/romancal/regtest/test_elp_tvac.py
+++ b/romancal/regtest/test_elp_tvac.py
@@ -71,6 +71,7 @@ def test_dqinit_matches_truth(run_elp, ignore_asdf_paths):
     dqinit_filename = replace_suffix(output_path.stem, "dqinit") + output_path.suffix
     dqinit_path = output_path.parent / dqinit_filename
 
+    run_elp.output = dqinit_filename
     run_elp.get_truth(f"truth/WFI/image/{dqinit_filename}")
 
     truth_path = Path(run_elp.truth)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses an issue raised by @braingram concerning whether okifying the test_elp_tvac tests would work properly. They currently do not. This PR resolves the issue.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
