### PR TITLE
change default fillval to nan

### DIFF
--- a/changes/1644.outlier_detection.rst
+++ b/changes/1644.outlier_detection.rst
@@ -1,0 +1,1 @@
+Change default fillval to nan.

--- a/changes/1644.resample.rst
+++ b/changes/1644.resample.rst
@@ -1,0 +1,1 @@
+Change default fillval to nan.

--- a/docs/roman/outlier_detection/arguments.rst
+++ b/docs/roman/outlier_detection/arguments.rst
@@ -50,13 +50,7 @@ behavior of the processing:
     The value for this parameter is to be assigned to the output pixels that
     have zero weight or which do not receive flux from any input pixels during
     drizzling. This parameter corresponds to the ``fillval`` parameter of the
-    `drizzle` task. If the default of `None` is used, and if the weight in
-    both the input and output images for a given pixel are zero, then
-    the output pixel will be set to the value it would have had if the input
-    had a non-zero weight. Otherwise, if a numerical value is provided
-    (e.g. 0), then these pixels will be set to that numerical value.
-    Any floating-point value, given as a string, is valid.
-    A value of 'INDEF' will use the last zero weight flux.
+    `drizzle` task and will be converted to a float.
 
 ``--maskpt``
   Percentage of weight image values below which they are flagged as bad and rejected

--- a/docs/roman/outlier_detection/outlier_detection.rst
+++ b/docs/roman/outlier_detection/outlier_detection.rst
@@ -27,9 +27,7 @@ Specifically, this routine performs the following operations:
      a single exposure ever contributes to each pixel in these mosaics.
    * The ``fillval`` parameter specifies what value to use in the output
      resampled image for any pixel which has no valid contribution from any
-     input exposure.  The default value of ``INDEF`` indicates that the value
-     from the last exposure will be used, while a value of 0 would result in
-     holes.
+     input exposure.
    * The resampling can be controlled with the ``pixfrac``, ``kernel`` and
      ``weight_type`` parameters.
    * The ``pixfrac`` indicates the fraction by

--- a/docs/roman/resample/arguments.rst
+++ b/docs/roman/resample/arguments.rst
@@ -1,51 +1,54 @@
 .. _resample_step_args:
 
+For more details about step arguments (including datatypes, possible values
+and defaults) see :py:obj:`romancal.resample.ResampleStep.spec`.
+
 Step Arguments
 ==============
 The ``resample`` step has the following optional arguments that control
 the behavior of the processing and the characteristics of the resampled
 image.
 
-``--pixfrac`` (float, default=1.0)
+``--pixfrac``
     The fraction by which input pixels are "shrunk" before being drizzled
     onto the output image grid, given as a real number between 0 and 1.
 
-``--kernel`` (str, default='square')
+``--kernel``
     The form of the kernel function used to distribute flux onto the output
     image.  Available kernels are `square`, `gaussian`, `point`, `tophat`,
     `turbo`, `lanczos2`, and `lanczos3`.
 
-``--pixel_scale_ratio`` (float, default=1.0)
+``--pixel_scale_ratio``
     Ratio of input to output pixel scale.  A value of 0.5 means the output
     image would have 4 pixels sampling each input pixel.
     Ignored when ``pixel_scale`` or ``output_wcs`` are provided.
 
-``--pixel_scale`` (float, default=None)
+``--pixel_scale``
     Absolute pixel scale in ``arcsec``. When provided, overrides
     ``pixel_scale_ratio``. Ignored when ``output_wcs`` is provided.
 
-``--rotation`` (float, default=None)
+``--rotation``
     Position angle of output image’s Y-axis relative to North.
     A value of 0.0 would orient the final output image to be North up.
-    The default of `None` specifies that the images will not be rotated,
+    The value of `None` specifies that the images will not be rotated,
     but will instead be resampled in the default orientation for the camera
     with the x and y axes of the resampled image corresponding
     approximately to the detector axes. Ignored when ``pixel_scale``
     or ``output_wcs`` are provided.
 
-``--crpix`` (tuple of float, default=None)
+``--crpix``
     Position of the reference pixel in the image array in the ``x, y`` order.
     If ``crpix`` is not specified, it will be set to the center of the bounding
     box of the returned WCS object. When supplied from command line, it should
     be a comma-separated list of floats. Ignored when ``output_wcs``
     is provided.
 
-``--crval`` (tuple of float, default=None)
+``--crval``
     Right ascension and declination of the reference pixel. Automatically
     computed if not provided. When supplied from command line, it should be a
     comma-separated list of floats. Ignored when ``output_wcs`` is provided.
 
-``--output_shape`` (tuple of int, default=None)
+``--output_shape``
     Shape of the image (data array) using "standard" ``nx`` first and ``ny``
     second (as opposite to the ``numpy.ndarray`` convention - ``ny`` first and
     ``nx`` second). This value will be assigned to
@@ -57,7 +60,7 @@ image.
         Specifying ``output_shape`` *is required* when the WCS in
         ``output_wcs`` does not have ``bounding_box`` property set.
 
-``--output_wcs`` (str, default='')
+``--output_wcs``
     File name of a ``ASDF`` file with a GWCS stored under the ``"wcs"`` key
     under the root of the file. The output image size is determined from the
     bounding box of the WCS (if any). Argument ``output_shape`` overrides
@@ -69,29 +72,29 @@ image.
         ``pixel_scale_ratio``, ``pixel_scale``, ``rotation``, ``crpix``,
         and ``crval`` will be ignored.
 
-``--fillval`` (str, default='INDEF')
+``--fillval``
     The value to assign to output pixels that have zero weight or do not
     receive any flux from any input pixels during drizzling.
 
-``--weight_type`` (str, default='ivm')
+``--weight_type``
     The weighting type for each input image.
-    If `weight_type=ivm` (the default), the scaling value
+    If `weight_type=ivm`, the scaling value
     will be determined per-pixel using the inverse of the read noise
     (VAR_RNOISE) array stored in each input image. If the VAR_RNOISE array does
     not exist, the variance is set to 1 for all pixels (equal weighting).
     If `weight_type=exptime`, the scaling value will be set equal to the
     exposure time found in the image header.
 
-``--in_memory`` (bool, default=True)
+``--in_memory``
     If set to `False`, write output datamodel to disk.
 
-``--good_bits`` (str, default='~DO_NOT_USE+NON_SCIENCE')
+``--good_bits``
     Specifies the bits to use when creating the resampling mask.
     Either a single bit value or a combination of them can be provided.
     If the string starts with a tilde (`~`), then the provided bit(s)
     will be excluded when creating the resampling mask.
-    The default value is to exclude pixels flagged with ``DO_NOT_USE``
-    and ``NON_SCIENCE``.
+    A value of ``~DO_NOT_USE+NON_SCIENCE`` will exclude pixels
+    flagged with ``DO_NOT_USE`` and ``NON_SCIENCE``.
 
     The bit value can be provided in a few different ways, but always as
     a string type. For example, if the user deems OK to use pixels with

--- a/romancal/outlier_detection/outlier_detection_step.py
+++ b/romancal/outlier_detection/outlier_detection_step.py
@@ -32,7 +32,7 @@ class OutlierDetectionStep(RomanStep):
         weight_type = option('ivm','exptime',default='ivm') # Weighting type to use to create the median image
         pixfrac = float(default=1.0) # Fraction by which input pixels are shrunk before being drizzled onto the output image grid
         kernel = string(default='square') # Shape of the kernel used for flux distribution onto output images
-        fillval = string(default='INDEF') # Value assigned to output pixels that have zero weight or no flux during drizzling
+        fillval = string(default='NaN') # Value assigned to output pixels that have zero weight or no flux during drizzling
         maskpt = float(default=0.7) # Percentage of weight image values below which they are flagged as bad pixels
         snr = string(default='5.0 4.0') # The signal-to-noise values to use for bad pixel identification
         scale = string(default='1.2 0.7') # The scaling factor applied to derivative used to identify bad pixels

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -192,10 +192,17 @@ def _flag_resampled_model_crs(
     scale1,
     scale2,
     backg,
+    fillval,
     save_intermediate_results,
     make_output_path,
 ):
-    blot = gwcs_blot(median_data, median_wcs, image.data.shape, image.meta.wcs, 1.0)
+    if fillval is None or fillval.strip().upper() == "INDEF":
+        fillval = 0
+    else:
+        fillval = float(fillval)
+    blot = gwcs_blot(
+        median_data, median_wcs, image.data.shape, image.meta.wcs, 1.0, fillval
+    )
 
     # Get background level of science data if it has not been subtracted, so it
     # can be added into the level of the blotted data, which has been
@@ -298,6 +305,7 @@ def detect_outliers(
                     scale1,
                     scale2,
                     backg,
+                    fillval,
                     save_intermediate_results,
                     make_output_path,
                 )

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -54,7 +54,7 @@ class ResampleStep(RomanStep):
     spec = """
         pixfrac = float(default=1.0)
         kernel = string(default='square')
-        fillval = string(default='INDEF' )
+        fillval = string(default='NAN' )
         weight_type = option('ivm', 'exptime', None, default='ivm')
         output_shape = int_list(min=2, max=2, default=None)  # [x, y] order
         crpix = float_list(min=2, max=2, default=None)


### PR DESCRIPTION
Closes #1630

This PR changes the default fillval in outlier detection and resample to `nan` (from `indef`).

The resample documentation was also updated removing the default values and instead (similar to the existing outlier detection documentation) the step spec is referred to at the top of the arguments page. This allows the defaults in the documentation to always be up to date with the step.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/13638995662
show 3 expected differences all with absolute differences of 0 (since 0 values in truth files for resampled pixels with no contributed flux are now nan).

For example roman-pipeline-results/regression-tests/runs/2025-02-27_GITHUB_CI_Linux-X64-py3.11-1774/393_test_resample_single_file/mosaic_resamplestep.asdf
all 0 value pixels in the truth file contain nans

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
