### PR TITLE
Update resample to use `add_model_hook`

### DIFF
--- a/changes/1663.resample.rst
+++ b/changes/1663.resample.rst
@@ -1,0 +1,1 @@
+Improve runtime by using ``add_model_hook`` from stcal resample.

--- a/romancal/resample/exptime_resampler.py
+++ b/romancal/resample/exptime_resampler.py
@@ -1,10 +1,8 @@
 import numpy as np
 from drizzle.resample import Drizzle
-from drizzle.utils import calc_pixmap
 from roman_datamodels import dqflags
 from stcal.resample.utils import (
     build_driz_weight,
-    resample_range,
 )
 
 
@@ -26,27 +24,18 @@ class ExptimeResampler:
             disable_ctx=True,
         )
 
-    def add_image(self, model):
-        data = np.full(model.data.shape, model.meta.exposure.effective_exposure_time)
+    def add_image(self, model, pixmap, xmin, xmax, ymin, ymax):
+        data = np.full(model["data"].shape, model["effective_exposure_time"])
 
         # create a unit weight map for all the input pixels with science data
         inwht = build_driz_weight(
             {
-                "data": model.data,
-                "dq": model.dq,
+                "data": model["data"],
+                "dq": model["dq"],
             },
             weight_type=None,
             good_bits=self.good_bits,
             flag_name_map=dqflags.pixel,
-        )
-
-        xmin, xmax, ymin, ymax = resample_range(data.shape, model.meta.wcs.bounding_box)
-        # FIXME reuse pixmap
-        # this would require major reworking of stcals resample
-        pixmap = calc_pixmap(
-            model.meta.wcs,
-            self.out_wcs,
-            data.shape,
         )
 
         self._driz.add_image(

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -182,7 +182,7 @@ class ResampleData(Resample):
         }
 
     def _get_intensity_scale(self, model):
-        # FIXME we lie about this to retain the old behavior
+        # always provide 1: https://github.com/spacetelescope/romancal/issues/1637
         return 1
 
     def add_model_hook(self, model, pixmap, iscale, weight_map, xmin, xmax, ymin, ymax):

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -178,26 +178,29 @@ class ResampleData(Resample):
             "duration": None,  # unused
             "level": level,
             "subtracted": subtracted,
+            "effective_exposure_time": model.meta.exposure.effective_exposure_time,
         }
 
     def _get_intensity_scale(self, model):
         # FIXME we lie about this to retain the old behavior
         return 1
 
+    def add_model_hook(self, model, pixmap, iscale, weight_map, xmin, xmax, ymin, ymax):
+        if self.compute_exptime:
+            if not hasattr(self, "_exptime_resampler"):
+                self._exptime_resampler = ExptimeResampler(
+                    self.output_wcs,
+                    self.output_array_shape,
+                    self.good_bits,
+                    self.kernel,
+                )
+            self._exptime_resampler.add_image(model, pixmap, xmin, xmax, ymin, ymax)
+
     def add_model(self, model):
         model_dict = self._input_model_to_dict(model)
         super().add_model(model_dict)
         if self.blend_meta:
             self._meta_blender.blend(model)
-        if self.compute_exptime:
-            self._resample_exptime(model)
-
-    def _resample_exptime(self, model):
-        if not hasattr(self, "_exptime_resampler"):
-            self._exptime_resampler = ExptimeResampler(
-                self.output_wcs, self.output_array_shape, self.good_bits, self.kernel
-            )
-        self._exptime_resampler.add_image(model)
 
     def finalize(self):
         super().finalize()


### PR DESCRIPTION
This PR updates the exposure time resampling to use `add_model_hook` added in https://github.com/spacetelescope/stcal/pull/342

This allows the exposure time resampling to reuse the pixmap computed for the data array resampling (improving the runtime of the resample step).

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14622303294 show only unrelated failures that are also seen on main.

The resource tracking during regtests also shows an improvement in memory usage (resample single file show 4692MB on main and 4157MB with this PR).

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
