### PR TITLE
add regtest resource tracking

### DIFF
--- a/changes/1664.general.rst
+++ b/changes/1664.general.rst
@@ -1,0 +1,1 @@
+Add resource tracking fixtures for regression tests.

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -241,8 +241,8 @@ def resource_tracker():
 
 @pytest.fixture()
 def log_tracked_resources(resource_tracker, request):
-    def callback(fixture_name):
-        resource_tracker.log(fixture_name, request.node.user_properties)
+    def callback(fixture_name=None):
+        resource_tracker.log(request.node.user_properties, fixture_name)
 
     yield callback
 

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -9,8 +9,8 @@ from astropy.table import Table
 from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from numpy.testing import assert_allclose, assert_equal
 
-from romancal.regtest.benchmarks import BenchmarkManager
 from romancal.regtest.regtestdata import RegtestData
+from romancal.regtest.resource_tracker import ResourceTrackerManager
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
 
@@ -235,14 +235,14 @@ def ignore_asdf_paths():
 
 
 @pytest.fixture(scope="module")
-def benchmark():
-    return BenchmarkManager()
+def resource_tracker():
+    return ResourceTrackerManager()
 
 
 @pytest.fixture()
-def log_benchmark(benchmark, request):
+def log_tracked_resources(resource_tracker, request):
     def callback(fixture_name):
-        benchmark.log(fixture_name, request.node.user_properties)
+        resource_tracker.log(fixture_name, request.node.user_properties)
 
     yield callback
 

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -242,7 +242,7 @@ def resource_tracker():
 @pytest.fixture()
 def log_tracked_resources(resource_tracker, request):
     def callback(fixture_name=None):
-        resource_tracker.log(request.node.user_properties, fixture_name)
+        resource_tracker.log(request, fixture_name)
 
     yield callback
 

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -9,6 +9,7 @@ from astropy.table import Table
 from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from numpy.testing import assert_allclose, assert_equal
 
+from romancal.regtest.benchmarks import BenchmarkManager
 from romancal.regtest.regtestdata import RegtestData
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
@@ -231,6 +232,19 @@ def ignore_asdf_paths():
     ]
 
     return {"ignore": ignore_attr}
+
+
+@pytest.fixture(scope="module")
+def benchmark():
+    return BenchmarkManager()
+
+
+@pytest.fixture()
+def log_benchmark(benchmark, request):
+    def callback(fixture_name):
+        benchmark.log(fixture_name, request.node.user_properties)
+
+    yield callback
 
 
 @pytest.fixture

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -10,7 +10,7 @@ from ci_watson.artifactory_helpers import UPLOAD_SCHEMA
 from numpy.testing import assert_allclose, assert_equal
 
 from romancal.regtest.regtestdata import RegtestData
-from romancal.regtest.resource_tracker import ResourceTrackerManager
+from romancal.regtest.resource_tracker import ResourceTracker
 
 TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
 
@@ -236,13 +236,13 @@ def ignore_asdf_paths():
 
 @pytest.fixture(scope="module")
 def resource_tracker():
-    return ResourceTrackerManager()
+    return ResourceTracker()
 
 
 @pytest.fixture()
 def log_tracked_resources(resource_tracker, request):
-    def callback(fixture_name=None):
-        resource_tracker.log(request, fixture_name)
+    def callback():
+        resource_tracker.log(request)
 
     yield callback
 

--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -236,11 +236,44 @@ def ignore_asdf_paths():
 
 @pytest.fixture(scope="module")
 def resource_tracker():
+    """Fixture to return the current module-scoped ResourceTracker.
+
+    Use by calling ``track`` to generate a context in which resource
+    usage will be tracked.
+
+    >>>
+    >> with resource_tracker.track():
+    >>     # do stuff
+
+    For resources used during tests providing a function-scoped
+    request fixture result as the log argument will also log the
+    used resources to the junit results.xml.
+
+    >>>
+    >> def test_something(resource_tracker, request):
+    >>     with resource_tracker.track(log=request):
+    >>         # do stuff
+
+    For resources used during fixtures the tracked resources
+    can be logged in a separate test using ``log_tracked_resources``.
+    """
     return ResourceTracker()
 
 
 @pytest.fixture()
 def log_tracked_resources(resource_tracker, request):
+    """Fixture to log resources tracked by ``resource_tracker``.
+
+    >>>
+    >> @pytest.fixture
+    >> def my_fixture(resource_tracker):
+    >>     with resource_tracker.track():
+    >>         # do stuff
+    >>
+    >> def test_write_log(log_tracked_resources, my_fixture):
+    >>     log_tracked_resources()
+    """
+
     def callback():
         resource_tracker.log(request)
 

--- a/romancal/regtest/resource_tracker.py
+++ b/romancal/regtest/resource_tracker.py
@@ -48,5 +48,8 @@ class ResourceTrackerManager:
         self.named_trackers[name] = named_tracker
         return named_tracker
 
-    def log(self, name, user_properties):
-        self.named_trackers[name].log(user_properties)
+    def log(self, user_properties, name=None):
+        if name is None:
+            self.named_trackers.popitem()[1].log(user_properties)
+        else:
+            self.named_trackers[name].log(user_properties)

--- a/romancal/regtest/resource_tracker.py
+++ b/romancal/regtest/resource_tracker.py
@@ -10,7 +10,7 @@ class TrackRuntime:
         self.value = time.monotonic() - self._t0
 
     def log(self):
-        return ("bench-time", self.value)
+        return ("tracked-time", self.value)
 
 
 class TrackMemory:
@@ -22,10 +22,10 @@ class TrackMemory:
         tracemalloc.stop()
 
     def log(self):
-        return ("bench-peakmem", self.value)
+        return ("tracked-peakmem", self.value)
 
 
-class Benchmark:
+class ResourceTracker:
     def __init__(self):
         self.trackers = [TrackMemory(), TrackRuntime()]
 
@@ -39,14 +39,14 @@ class Benchmark:
         user_properties.extend(t.log() for t in self.trackers)
 
 
-class BenchmarkManager:
+class ResourceTrackerManager:
     def __init__(self):
-        self.benchmarks = {}
+        self.named_trackers = {}
 
-    def __call__(self, name):
-        benchmark = Benchmark()
-        self.benchmarks[name] = benchmark
-        return benchmark
+    def track(self, name):
+        named_tracker = ResourceTracker()
+        self.named_trackers[name] = named_tracker
+        return named_tracker
 
     def log(self, name, user_properties):
-        self.benchmarks[name].log(user_properties)
+        self.named_trackers[name].log(user_properties)

--- a/romancal/regtest/resource_tracker.py
+++ b/romancal/regtest/resource_tracker.py
@@ -1,5 +1,6 @@
 import time
 import tracemalloc
+import uuid
 
 
 class TrackRuntime:
@@ -43,7 +44,9 @@ class ResourceTrackerManager:
     def __init__(self):
         self.named_trackers = {}
 
-    def track(self, name):
+    def track(self, name=None):
+        if name is None:
+            name = str(uuid.uuid4())
         named_tracker = ResourceTracker()
         self.named_trackers[name] = named_tracker
         return named_tracker

--- a/romancal/regtest/resource_tracker.py
+++ b/romancal/regtest/resource_tracker.py
@@ -51,8 +51,9 @@ class ResourceTrackerManager:
         self.named_trackers[name] = named_tracker
         return named_tracker
 
-    def log(self, user_properties, name=None):
+    def log(self, request, name=None):
         if name is None:
-            self.named_trackers.popitem()[1].log(user_properties)
+            tracker = self.named_trackers.popitem()[1]
         else:
-            self.named_trackers[name].log(user_properties)
+            self.named_trackers[name]
+        tracker.log(request.node.user_properties)

--- a/romancal/regtest/resource_tracker.py
+++ b/romancal/regtest/resource_tracker.py
@@ -1,9 +1,57 @@
+"""Resource tracking regtest utilities
+
+Can be used within module-scoped fixtures (often used to
+run Steps or Pipelines) or within tests.
+
+For uses where the resource usage occurs within a test:
+
+>>>
+>> def test_long_step(resource_tracker, request):
+>>     with resource_tracker.track(log=request):
+>>         # something that takes memory and time
+>>         pass
+
+For a module-scoped fixture the resource tracking can
+be performed in the fixture but the logging/reporting of
+the resource usage must occur during a test:
+
+>>>
+>> @pytest.fixture(scope="module")
+>> def resource_tracker():
+>>     return ResourceTracker()
+>>
+>> @pytest.fixture()
+>> def log_tracked_resources(resource_tracker, request):
+>>     def callback():
+>>         resource_tracker.log(request)
+>>
+>>     yield callback
+>>
+>> @pytest.fixture
+>> def my_long_fixture(resource_tracker):
+>>     with resource_tracker.track():
+>>         # something that takes memory and time
+>>         pass
+>>
+>> def test_log_tracked_resources(log_tracked_resources, my_long_fixture):
+>>     log_tracked_resources()
+
+Use of the module-scoped fixture has fixture-reuse
+considerations similar to the ``rtdata_module`` fixture. Having
+more than one module scoped fixture that uses ``resource_tracker``
+per module is discouraged (as both will use the same ``ResourceTracker``
+instance). Parameterization of a fixture using ``resource_tracker``
+is supported (same as ``rtdata_module``).
+"""
+
 import time
 import tracemalloc
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 
 class TrackRuntime:
+    """Runtime tracker context."""
+
     def __enter__(self):
         self._t0 = time.monotonic()
 
@@ -14,7 +62,9 @@ class TrackRuntime:
         return ("tracked-time", self.value)
 
 
-class TrackMemory:
+class TrackPeakMemory:
+    """Peak memory tracker context."""
+
     def __enter__(self):
         tracemalloc.start()
 
@@ -27,22 +77,33 @@ class TrackMemory:
 
 
 class ResourceTracker:
+    """Track resources used during track context."""
+
     def __init__(self):
-        self.trackers = [TrackMemory(), TrackRuntime()]
-
-    def __enter__(self):
-        [t.__enter__() for t in self.trackers]
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        [t.__exit__(exc_type, exc_value, traceback) for t in self.trackers]
+        self._trackers = [TrackPeakMemory(), TrackRuntime()]
 
     def log(self, request):
-        request.node.user_properties.extend(t.log() for t in self.trackers)
+        """Log tracked resource usage to the pytest request user properties.
+
+        Parameters
+        ----------
+        request : pytest.FixtureRequest
+            Must be a function-scoped pytest request fixture result.
+        """
+        request.node.user_properties.extend(t.log() for t in self._trackers)
 
     @contextmanager
     def track(self, log=None):
+        """Context during which resources are tracked.
+
+        Parameters
+        ----------
+        log : pytest.FixtureRequest, optional
+            If provided, log the usage to the provided request fixture result.
+        """
         try:
-            with self:
+            with ExitStack() as stack:
+                [stack.enter_context(t) for t in self._trackers]
                 yield self
         finally:
             if log:

--- a/romancal/regtest/test_catalog.py
+++ b/romancal/regtest/test_catalog.py
@@ -6,8 +6,6 @@ import pytest
 from romancal.source_catalog.source_catalog_step import SourceCatalogStep
 from romancal.stpipe import RomanStep
 
-RESOURCE_TRACKER_NAME = "source_catalog"
-
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -37,7 +35,7 @@ def run_source_catalog(rtdata_module, request, resource_tracker):
         "romancal.step.SourceCatalogStep",
         rtdata.input,
     ]
-    with resource_tracker.track(f"{RESOURCE_TRACKER_NAME}_{inputfn}"):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
     return rtdata_module
 

--- a/romancal/regtest/test_catalog.py
+++ b/romancal/regtest/test_catalog.py
@@ -6,6 +6,8 @@ import pytest
 from romancal.source_catalog.source_catalog_step import SourceCatalogStep
 from romancal.stpipe import RomanStep
 
+RESOURCE_TRACKER_NAME = "source_catalog"
+
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -19,7 +21,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
     ],
     ids=["L3", "L2", "L3skycell"],
 )
-def run_source_catalog(rtdata_module, request):
+def run_source_catalog(rtdata_module, request, resource_tracker):
     rtdata = rtdata_module
 
     inputfn = request.param
@@ -35,7 +37,8 @@ def run_source_catalog(rtdata_module, request):
         "romancal.step.SourceCatalogStep",
         rtdata.input,
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track(f"{RESOURCE_TRACKER_NAME}_{inputfn}"):
+        RomanStep.from_cmdline(args)
     return rtdata_module
 
 
@@ -66,6 +69,10 @@ def fields(catalog):
 )
 def test_has_field(fields, field):
     assert field in fields
+
+
+def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
+    log_tracked_resources()
 
 
 def test_forced_catalog(rtdata_module):

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -8,7 +8,9 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
+def test_dark_current_subtraction_step(
+    rtdata, ignore_asdf_paths, resource_tracker, request
+):
     """Function to run and compare Dark Current subtraction files. Note: This
     should include tests for overrides etc."""
 
@@ -17,7 +19,9 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track("dark"):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.properties)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -26,7 +30,9 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
+def test_dark_current_outfile_step(
+    rtdata, ignore_asdf_paths, resource_tracker, request
+):
     """Function to run and compare Dark Current subtraction files. Here the
     test is for renaming the output file."""
     input_datafile = "r0000101001001001001_0001_wfi01_linearity.asdf"
@@ -38,7 +44,9 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
         rtdata.input,
         "--output_file=Test_darkcurrent",
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track("dark"):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.properties)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -47,7 +55,9 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
+def test_dark_current_outfile_suffix(
+    rtdata, ignore_asdf_paths, resource_tracker, request
+):
     """Function to run and compare Dark Current subtraction files. Here the
     test is for renaming the output file."""
     input_datafile = "r0000101001001001001_0001_wfi01_linearity.asdf"
@@ -60,7 +70,9 @@ def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
         "--output_file=Test_dark",
         '--suffix="suffix_test"',
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track("dark"):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.properties)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -69,7 +81,7 @@ def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_dark_current_output(rtdata, ignore_asdf_paths):
+def test_dark_current_output(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Function to run and compare Dark Current subtraction files. Here the
     test for overriding the CRDS dark reference file."""
 
@@ -83,7 +95,9 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
         rtdata.input,
         f"--dark_output={dark_output_name}",
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track("dark"):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.properties)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -19,9 +19,8 @@ def test_dark_current_subtraction_step(
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -44,9 +43,8 @@ def test_dark_current_outfile_step(
         rtdata.input,
         "--output_file=Test_darkcurrent",
     ]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -70,9 +68,8 @@ def test_dark_current_outfile_suffix(
         "--output_file=Test_dark",
         '--suffix="suffix_test"',
     ]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -95,9 +92,8 @@ def test_dark_current_output(rtdata, ignore_asdf_paths, resource_tracker, reques
         rtdata.input,
         f"--dark_output={dark_output_name}",
     ]
-    with resource_tracker.track("dark"):
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -19,7 +19,7 @@ def test_dark_current_subtraction_step(
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
-    with resource_tracker.track("dark"):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
     resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
@@ -44,7 +44,7 @@ def test_dark_current_outfile_step(
         rtdata.input,
         "--output_file=Test_darkcurrent",
     ]
-    with resource_tracker.track("dark"):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
     resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"
@@ -70,7 +70,7 @@ def test_dark_current_outfile_suffix(
         "--output_file=Test_dark",
         '--suffix="suffix_test"',
     ]
-    with resource_tracker.track("dark"):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
     resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -21,7 +21,7 @@ def test_dark_current_subtraction_step(
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -46,7 +46,7 @@ def test_dark_current_outfile_step(
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -72,7 +72,7 @@ def test_dark_current_outfile_suffix(
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -97,7 +97,7 @@ def test_dark_current_output(rtdata, ignore_asdf_paths, resource_tracker, reques
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -21,7 +21,7 @@ def test_dark_current_subtraction_step(
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.properties)
+    resource_tracker.log(request.node.user_properties)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -46,7 +46,7 @@ def test_dark_current_outfile_step(
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.properties)
+    resource_tracker.log(request.node.user_properties)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -72,7 +72,7 @@ def test_dark_current_outfile_suffix(
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.properties)
+    resource_tracker.log(request.node.user_properties)
     output = "Test_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -97,7 +97,7 @@ def test_dark_current_output(rtdata, ignore_asdf_paths, resource_tracker, reques
     ]
     with resource_tracker.track("dark"):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.properties)
+    resource_tracker.log(request.node.user_properties)
     output = "r0000101001001001001_0001_wfi01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -15,9 +15,8 @@ def test_linearity_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -34,9 +33,8 @@ def test_linearity_outfile_step(rtdata, ignore_asdf_paths, resource_tracker, req
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input, "--output_file=Test_linearity"]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     output = "Test_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -8,14 +8,16 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_linearity_step(rtdata, ignore_asdf_paths):
+def test_linearity_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Function to run and compare linearity correction files."""
     input_file = "r0000101001001001001_0001_wfi01_refpix.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
     output = "r0000101001001001001_0001_wfi01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -24,7 +26,7 @@ def test_linearity_step(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
+def test_linearity_outfile_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Function to run and linearity correction files. Here the
     test is for renaming the output file."""
     input_file = "r0000101001001001001_0001_wfi01_refpix.asdf"
@@ -32,7 +34,9 @@ def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input, "--output_file=Test_linearity"]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
     output = "Test_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -17,7 +17,7 @@ def test_linearity_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     args = ["romancal.step.LinearityStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "r0000101001001001001_0001_wfi01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -36,7 +36,7 @@ def test_linearity_outfile_step(rtdata, ignore_asdf_paths, resource_tracker, req
     args = ["romancal.step.LinearityStep", rtdata.input, "--output_file=Test_linearity"]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     output = "Test_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -11,8 +11,6 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
-RESOURCE_TRACKER_NAME = "mosaic_pipeline"
-
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -31,7 +29,7 @@ def run_mos(rtdata_module, resource_tracker):
         "roman_mos",
         rtdata.input,
     ]
-    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+    with resource_tracker.track():
         MosaicPipeline.from_cmdline(args)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -71,7 +69,7 @@ def preview_filename(output_filename):
 
 
 def test_log_tracked_resources(log_tracked_resources, run_mos):
-    log_tracked_resources(RESOURCE_TRACKER_NAME)
+    log_tracked_resources()
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -11,14 +11,14 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
-BENCHMARK_NAME = "mosiac_pipeline"
+RESOURCE_TRACKER_NAME = "mosaic_pipeline"
 
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_mos(rtdata_module, benchmark):
+def run_mos(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     rtdata.get_asn("WFI/image/L3_regtest_asn.json")
@@ -31,7 +31,7 @@ def run_mos(rtdata_module, benchmark):
         "roman_mos",
         rtdata.input,
     ]
-    with benchmark(BENCHMARK_NAME):
+    with resource_tracker.track(RESOURCE_TRACKER_NAME):
         MosaicPipeline.from_cmdline(args)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -70,8 +70,8 @@ def preview_filename(output_filename):
     return preview_filename
 
 
-def test_benchmark(log_benchmark, run_mos):
-    log_benchmark(BENCHMARK_NAME)
+def test_log_tracked_resources(log_tracked_resources, run_mos):
+    log_tracked_resources(RESOURCE_TRACKER_NAME)
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -11,12 +11,14 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
+BENCHMARK_NAME = "mosiac_pipeline"
+
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_mos(rtdata_module):
+def run_mos(rtdata_module, benchmark):
     rtdata = rtdata_module
 
     rtdata.get_asn("WFI/image/L3_regtest_asn.json")
@@ -29,7 +31,8 @@ def run_mos(rtdata_module):
         "roman_mos",
         rtdata.input,
     ]
-    MosaicPipeline.from_cmdline(args)
+    with benchmark(BENCHMARK_NAME):
+        MosaicPipeline.from_cmdline(args)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     return rtdata
@@ -65,6 +68,10 @@ def preview_filename(output_filename):
     preview_cmd = f"stpreview to {output_filename} {preview_filename} 1080 1080 roman"
     os.system(preview_cmd)  # noqa: S605
     return preview_filename
+
+
+def test_benchmark(log_benchmark, run_mos):
+    log_benchmark(BENCHMARK_NAME)
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -7,14 +7,14 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
-BENCHMARK_NAME = "mosiac_pipeline_skycell"
+RESOURCE_TRACKER_NAME = "mosaic_pipeline_skycell"
 
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_mos(rtdata_module, benchmark):
+def run_mos(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     # Test Pipeline
@@ -25,7 +25,7 @@ def run_mos(rtdata_module, benchmark):
         "roman_mos",
         rtdata.input,
     ]
-    with benchmark(BENCHMARK_NAME):
+    with resource_tracker.track(RESOURCE_TRACKER_NAME):
         MosaicPipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
     return rtdata
@@ -47,8 +47,8 @@ def truth_filename(run_mos):
     return run_mos.truth
 
 
-def test_benchmark(log_benchmark, run_mos):
-    log_benchmark(BENCHMARK_NAME)
+def test_log_tracked_resources(log_tracked_resources, run_mos):
+    log_tracked_resources(RESOURCE_TRACKER_NAME)
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -7,12 +7,14 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
+BENCHMARK_NAME = "mosiac_pipeline_skycell"
+
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_mos(rtdata_module):
+def run_mos(rtdata_module, benchmark):
     rtdata = rtdata_module
 
     # Test Pipeline
@@ -23,7 +25,8 @@ def run_mos(rtdata_module):
         "roman_mos",
         rtdata.input,
     ]
-    MosaicPipeline.from_cmdline(args)
+    with benchmark(BENCHMARK_NAME):
+        MosaicPipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
     return rtdata
 
@@ -42,6 +45,10 @@ def output_model(output_filename):
 @pytest.fixture(scope="module")
 def truth_filename(run_mos):
     return run_mos.truth
+
+
+def test_benchmark(log_benchmark, run_mos):
+    log_benchmark(BENCHMARK_NAME)
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -7,8 +7,6 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from . import util
 from .regtestdata import compare_asdf
 
-RESOURCE_TRACKER_NAME = "mosaic_pipeline_skycell"
-
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -25,7 +23,7 @@ def run_mos(rtdata_module, resource_tracker):
         "roman_mos",
         rtdata.input,
     ]
-    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+    with resource_tracker.track():
         MosaicPipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/image/{output}")
     return rtdata
@@ -48,7 +46,7 @@ def truth_filename(run_mos):
 
 
 def test_log_tracked_resources(log_tracked_resources, run_mos):
-    log_tracked_resources(RESOURCE_TRACKER_NAME)
+    log_tracked_resources()
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -48,9 +48,8 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request):
         "--deblend",
         "True",  # use deblending, DMS 393
     ]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
     afcat = asdf.open(outputfn)
     for field in fieldlist:
         assert field in afcat["roman"]["source_catalog"].dtype.names

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -29,7 +29,7 @@ fieldlist = [
 ]
 
 
-def test_multiband_catalog(rtdata_module):
+def test_multiband_catalog(rtdata_module, resource_tracker, request):
     rtdata = rtdata_module
     inputasnfn = "L3_skycell_mbcat_asn.json"
     # note that this input association currently only has a single
@@ -48,7 +48,9 @@ def test_multiband_catalog(rtdata_module):
         "--deblend",
         "True",  # use deblending, DMS 393
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
     afcat = asdf.open(outputfn)
     for field in fieldlist:
         assert field in afcat["roman"]["source_catalog"].dtype.names

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -50,7 +50,7 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request):
     ]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
     afcat = asdf.open(outputfn)
     for field in fieldlist:
         assert field in afcat["roman"]["source_catalog"].dtype.names

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -141,7 +141,7 @@ CONDITIONS_TRUNC = [*CONDITIONS_FULL, cond_is_truncated]
     ],
     ids=["image_full", "spec_full", "image_trunc", "spec_trunc"],
 )
-def rampfit_result(request, rtdata_module):
+def rampfit_result(request, rtdata_module, resource_tracker):
     """Run RampFitStep
 
     Parameters
@@ -160,7 +160,8 @@ def rampfit_result(request, rtdata_module):
     rtdata_module.input = input_data
 
     # Execute the step
-    result_model = RampFitStep.call(input_data, save_results=True)
+    with resource_tracker.track():
+        result_model = RampFitStep.call(input_data, save_results=True)
 
     # Setup outputs
     input_data_path = Path(input_data)
@@ -181,6 +182,11 @@ def rampfit_result(request, rtdata_module):
 # #####
 # Tests
 # #####
+@pytest.mark.bigdata
+def test_log_tracked_resources(log_tracked_resources, rampfit_result):
+    log_tracked_resources()
+
+
 @pytest.mark.bigdata
 def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths):
     """Test rampfit result against various conditions"""

--- a/romancal/regtest/test_refpix.py
+++ b/romancal/regtest/test_refpix.py
@@ -17,7 +17,7 @@ def test_refpix_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     args = ["romancal.step.RefPixStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     # Again I have no idea here
     output = "r0000101001001001001_0001_wfi01_refpix.asdf"

--- a/romancal/regtest/test_refpix.py
+++ b/romancal/regtest/test_refpix.py
@@ -15,9 +15,8 @@ def test_refpix_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     rtdata.input = input_datafile
 
     args = ["romancal.step.RefPixStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     # Again I have no idea here
     output = "r0000101001001001001_0001_wfi01_refpix.asdf"

--- a/romancal/regtest/test_refpix.py
+++ b/romancal/regtest/test_refpix.py
@@ -8,14 +8,16 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_refpix_step(rtdata, ignore_asdf_paths):
+def test_refpix_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     # I have no idea what this is supposed to be
     input_datafile = "r0000101001001001001_0001_wfi01_saturation.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
     args = ["romancal.step.RefPixStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
 
     # Again I have no idea here
     output = "r0000101001001001001_0001_wfi01_refpix.asdf"

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -29,7 +29,7 @@ def test_resample_single_file(rtdata, ignore_asdf_paths, resource_tracker, reque
     ]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     resample_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -27,9 +27,8 @@ def test_resample_single_file(rtdata, ignore_asdf_paths, resource_tracker, reque
         "--resample_on_skycell=False",
         f"--output_file='{rtdata.output}'",
     ]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     resample_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -7,9 +7,11 @@ from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
 
+RESOURCE_TRACKER_NAME = "resample"
+
 
 @pytest.mark.bigdata
-def test_resample_single_file(rtdata, ignore_asdf_paths):
+def test_resample_single_file(rtdata, ignore_asdf_paths, resource_tracker, request):
     output_data = "mosaic_resamplestep.asdf"
 
     rtdata.get_asn("WFI/image/L3_mosaic_asn.json")
@@ -27,7 +29,10 @@ def test_resample_single_file(rtdata, ignore_asdf_paths):
         "--resample_on_skycell=False",
         f"--output_file='{rtdata.output}'",
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties, RESOURCE_TRACKER_NAME)
+
     resample_out = rdm.open(rtdata.output)
 
     step.log.info(

--- a/romancal/regtest/test_resample.py
+++ b/romancal/regtest/test_resample.py
@@ -7,8 +7,6 @@ from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
 
-RESOURCE_TRACKER_NAME = "resample"
-
 
 @pytest.mark.bigdata
 def test_resample_single_file(rtdata, ignore_asdf_paths, resource_tracker, request):
@@ -29,9 +27,9 @@ def test_resample_single_file(rtdata, ignore_asdf_paths, resource_tracker, reque
         "--resample_on_skycell=False",
         f"--output_file='{rtdata.output}'",
     ]
-    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties, RESOURCE_TRACKER_NAME)
+    resource_tracker.log(request.node.user_properties)
 
     resample_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_resource_tracker.py
+++ b/romancal/regtest/test_resource_tracker.py
@@ -1,0 +1,47 @@
+import time
+
+from romancal.regtest.resource_tracker import ResourceTracker, TrackMemory, TrackRuntime
+
+
+class FakeNode:
+    def __init__(self):
+        self.user_properties = []
+
+
+class FakeRequest:
+    def __init__(self):
+        self.node = FakeNode()
+
+
+def test_runtime():
+    tracker = TrackRuntime()
+    with tracker:
+        time.sleep(1.0)
+    assert abs(tracker.log()[1] - 1.0) < 0.01
+
+
+def test_memory():
+    tracker = TrackMemory()
+    N = 1024 * 1024
+    with tracker:
+        b = b"0" * N  # noqa: F841
+    assert abs(tracker.log()[1] - N) / N < 0.01
+
+
+def test_resource_tracker():
+    tracker = ResourceTracker()
+    with tracker.track():
+        pass
+    fake_request = FakeRequest()
+    tracker.log(fake_request)
+    keys = {log[0] for log in fake_request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}
+
+
+def test_log():
+    tracker = ResourceTracker()
+    fake_request = FakeRequest()
+    with tracker.track(log=fake_request):
+        pass
+    keys = {log[0] for log in fake_request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}

--- a/romancal/regtest/test_resource_tracker.py
+++ b/romancal/regtest/test_resource_tracker.py
@@ -1,6 +1,10 @@
 import time
 
-from romancal.regtest.resource_tracker import ResourceTracker, TrackMemory, TrackRuntime
+from romancal.regtest.resource_tracker import (
+    ResourceTracker,
+    TrackPeakMemory,
+    TrackRuntime,
+)
 
 
 class FakeNode:
@@ -21,7 +25,7 @@ def test_runtime():
 
 
 def test_memory():
-    tracker = TrackMemory()
+    tracker = TrackPeakMemory()
     N = 1024 * 1024
     with tracker:
         b = b"0" * N  # noqa: F841

--- a/romancal/regtest/test_resource_tracker.py
+++ b/romancal/regtest/test_resource_tracker.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from romancal.regtest.resource_tracker import (
@@ -21,7 +22,11 @@ def test_runtime():
     tracker = TrackRuntime()
     with tracker:
         time.sleep(1.0)
-    assert abs(tracker.log()[1] - 1.0) < 0.01
+    # a 1 second sleep is sometimes too much to ask
+    # of CI runners. Use a wide margin to make this test
+    # less brittle in those cases.
+    threshold = 0.5 if "CI" in os.environ else 0.1
+    assert abs(tracker.log()[1] - 1.0) < threshold
 
 
 def test_memory():

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -9,9 +9,11 @@ from romancal.tweakreg.tweakreg_step import TweakRegStep
 
 from .regtestdata import compare_asdf
 
+RESOURCE_TRACKER_NAME = "tweakreg"
+
 
 @pytest.mark.bigdata
-def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
+def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request):
     # N.B.: uncal file is from simulator
     # ``shifted'' version is created in make_regtestdata.sh; cal file is taken,
     # the wcsinfo is perturbed, and AssignWCS is run to update the WCS with the
@@ -39,7 +41,10 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
         f"--output_file='{rtdata.output}'",
         "--suffix='tweakregstep'",
     ]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties, RESOURCE_TRACKER_NAME)
+
     tweakreg_out = rdm.open(rtdata.output)
 
     step.log.info(

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -39,9 +39,8 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
         f"--output_file='{rtdata.output}'",
         "--suffix='tweakregstep'",
     ]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     tweakreg_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -9,8 +9,6 @@ from romancal.tweakreg.tweakreg_step import TweakRegStep
 
 from .regtestdata import compare_asdf
 
-RESOURCE_TRACKER_NAME = "tweakreg"
-
 
 @pytest.mark.bigdata
 def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request):
@@ -41,9 +39,9 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
         f"--output_file='{rtdata.output}'",
         "--suffix='tweakregstep'",
     ]
-    with resource_tracker.track(RESOURCE_TRACKER_NAME):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties, RESOURCE_TRACKER_NAME)
+    resource_tracker.log(request)
 
     tweakreg_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -50,7 +50,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
     )
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     step.log.info(
@@ -108,7 +108,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
     )
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     step.log.info(

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -12,7 +12,7 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_dq_init_image_step(rtdata, ignore_asdf_paths):
+def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """DMS25 Test: Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
@@ -48,7 +48,10 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
         " The first ERROR is expected, due to extra CRDS parameters"
         " not having been implemented yet."
     )
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     ramp_out = rdm.open(rtdata.output)
     step.log.info(
         "DMS25 MSG: Does ramp data contain pixeldq from mask file? :"
@@ -67,7 +70,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
+def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """DMS25 Test: Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
@@ -103,7 +106,10 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
         "The first ERROR is expected, due to extra CRDS parameters "
         "not having been implemented yet."
     )
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     ramp_out = rdm.open(rtdata.output)
     step.log.info(
         "DMS25 MSG: Does ramp data contain pixeldq from mask file? :"

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -48,9 +48,8 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
         " The first ERROR is expected, due to extra CRDS parameters"
         " not having been implemented yet."
     )
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     step.log.info(
@@ -106,9 +105,8 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
         "The first ERROR is expected, due to extra CRDS parameters "
         "not having been implemented yet."
     )
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     step.log.info(

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -11,7 +11,7 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_flat_field_image_step(rtdata, ignore_asdf_paths):
+def test_flat_field_image_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Test for the flat field step using imaging data."""
 
     input_data = "r0000101001001001001_0001_wfi01_assignwcs.asdf"
@@ -28,15 +28,17 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     output = "r0000101001001001001_0001_wfi01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()
 
 
-# @pytest.mark.xfail(reason="Wrong input for the purpose of this test")
 @pytest.mark.bigdata
-def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
+def test_flat_field_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Test for the flat field step using grism data. The reference file for
     the grism and prism data should be None, only testing the grism
     case here."""
@@ -63,7 +65,10 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     output = "r0000201001001001001_0001_wfi01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     output_model = rdm.open(rtdata.output)
     assert output_model.meta.cal_step.flat_field == "SKIPPED"
     rtdata.get_truth(f"truth/WFI/grism/{output}")
@@ -73,7 +78,9 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
 
 @pytest.mark.bigdata
 @pytest.mark.soctests
-def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
+def test_flat_field_crds_match_image_step(
+    rtdata, ignore_asdf_paths, resource_tracker, request
+):
     """DMS79 Test: Testing that different datetimes pull different
     flat files and successfully make level 2 output"""
 
@@ -113,7 +120,10 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
         "expected, due to extra CRDS parameters not having been "
         "implemented yet."
     )
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     rtdata.get_truth(f"truth/WFI/image/{output}")
 
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -30,7 +30,7 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
@@ -67,7 +67,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     output_model = rdm.open(rtdata.output)
     assert output_model.meta.cal_step.flat_field == "SKIPPED"
@@ -122,7 +122,7 @@ def test_flat_field_crds_match_image_step(
     )
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
 

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -28,9 +28,8 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     output = "r0000101001001001001_0001_wfi01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
@@ -65,9 +64,8 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     output = "r0000201001001001001_0001_wfi01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     output_model = rdm.open(rtdata.output)
     assert output_model.meta.cal_step.flat_field == "SKIPPED"
@@ -120,9 +118,8 @@ def test_flat_field_crds_match_image_step(
         "expected, due to extra CRDS parameters not having been "
         "implemented yet."
     )
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
 

--- a/romancal/regtest/test_wfi_grism_16resultants.py
+++ b/romancal/regtest/test_wfi_grism_16resultants.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_elp(rtdata_module):
+def run_elp(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     # The input data is from INS for stress testing at some point this should be generated
@@ -27,7 +27,8 @@ def run_elp(rtdata_module):
         "roman_elp",
         rtdata.input,
     ]
-    ExposurePipeline.from_cmdline(args)
+    with resource_tracker.track():
+        ExposurePipeline.from_cmdline(args)
     return rtdata
 
 
@@ -51,6 +52,10 @@ def input_filename(run_elp):
 def input_model(input_filename):
     with rdm.open(input_filename) as model:
         yield model
+
+
+def test_log_tracked_resources(log_tracked_resources, run_elp):
+    log_tracked_resources()
 
 
 def test_output_is_image_model(output_model):

--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_elp(rtdata_module):
+def run_elp(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     input_data = "r0000201001001001001_0001_wfi01_uncal.asdf"
@@ -30,7 +30,8 @@ def run_elp(rtdata_module):
         "roman_elp",
         rtdata.input,
     ]
-    ExposurePipeline.from_cmdline(args)
+    with resource_tracker.track():
+        ExposurePipeline.from_cmdline(args)
     rtdata.get_truth(f"truth/WFI/grism/{output}")
     return rtdata
 
@@ -78,6 +79,10 @@ def repointed_filename_and_delta(output_filename):
         model.to_asdf(repointed_filename)
 
     return repointed_filename, delta
+
+
+def test_log_tracked_resources(log_tracked_resources, run_elp):
+    log_tracked_resources()
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):

--- a/romancal/regtest/test_wfi_image_16resultants.py
+++ b/romancal/regtest/test_wfi_image_16resultants.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 
 @pytest.fixture(scope="module")
-def run_elp(rtdata_module):
+def run_elp(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     # The input data is from INS for stress testing at some point this should be generated
@@ -27,7 +27,8 @@ def run_elp(rtdata_module):
         "roman_elp",
         rtdata.input,
     ]
-    ExposurePipeline.from_cmdline(args)
+    with resource_tracker.track():
+        ExposurePipeline.from_cmdline(args)
     return rtdata
 
 
@@ -51,6 +52,10 @@ def input_filename(run_elp):
 def input_model(input_filename):
     with rdm.open(input_filename) as model:
         yield model
+
+
+def test_log_tracked_resources(log_tracked_resources, run_elp):
+    log_tracked_resources()
 
 
 def test_output_is_image_model(output_model):

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.bigdata
 
 
 @pytest.fixture(scope="module")
-def run_elp(rtdata_module):
+def run_elp(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     input_data = "r0000101001001001001_0001_wfi01_uncal.asdf"
@@ -32,7 +32,8 @@ def run_elp(rtdata_module):
         "roman_elp",
         rtdata.input,
     ]
-    ExposurePipeline.from_cmdline(args)
+    with resource_tracker.track():
+        ExposurePipeline.from_cmdline(args)
 
     # get truth file
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -82,6 +83,10 @@ def repointed_filename_and_delta(output_filename):
         model.to_asdf(repointed_filename)
 
     return repointed_filename, delta
+
+
+def test_log_tracked_resources(log_tracked_resources, run_elp):
+    log_tracked_resources()
 
 
 @pytest.mark.soctests

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -51,7 +51,7 @@ def test_absolute_photometric_calibration(
     )
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     photom_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -49,9 +49,8 @@ def test_absolute_photometric_calibration(
         " The first ERROR is expected, due to extra CRDS parameters"
         " not having been implemented yet."
     )
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     photom_out = rdm.open(rtdata.output)
 

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -12,7 +12,9 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
+def test_absolute_photometric_calibration(
+    rtdata, ignore_asdf_paths, resource_tracker, request
+):
     """DMS140 Test: Testing application of photometric correction using
     CRDS selected photom file."""
 
@@ -47,7 +49,10 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
         " The first ERROR is expected, due to extra CRDS parameters"
         " not having been implemented yet."
     )
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
+
     photom_out = rdm.open(rtdata.output)
 
     step.log.info(

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -36,7 +36,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     args = ["romancal.step.SaturationStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
@@ -71,7 +71,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     args = ["romancal.step.SaturationStep", rtdata.input]
     with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request.node.user_properties)
+    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     assert "roman.pixeldq" in ramp_out.to_flat_dict()

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -12,7 +12,7 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_saturation_image_step(rtdata, ignore_asdf_paths):
+def test_saturation_image_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected saturation file applied."""
 
@@ -34,7 +34,9 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
 
     ramp_out = rdm.open(rtdata.output)
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
@@ -45,7 +47,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
 
 
 @pytest.mark.bigdata
-def test_saturation_grism_step(rtdata, ignore_asdf_paths):
+def test_saturation_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request):
     """Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected saturation file applied."""
 
@@ -67,7 +69,9 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
-    RomanStep.from_cmdline(args)
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    resource_tracker.log(request.node.user_properties)
 
     ramp_out = rdm.open(rtdata.output)
     assert "roman.pixeldq" in ramp_out.to_flat_dict()

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -34,9 +34,8 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
-    resource_tracker.log(request)
 
     ramp_out = rdm.open(rtdata.output)
     assert "roman.pixeldq" in ramp_out.to_flat_dict()
@@ -69,7 +68,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths, resource_tracker, requ
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
-    with resource_tracker.track():
+    with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
     resource_tracker.log(request)
 


### PR DESCRIPTION
This PR adds test fixtures to make it easier for regtests to log peak memory usage and runtime (specifically of fixtures) to allow using regtests runs as pseudo benchmarks. The general API is:
```python
@pytest.fixture
def my_long_fixture(resource_tracker):
    with resource_tracker.track():
        # something that takes memory and time
        pass

def test_log_tracked_resources(log_tracked_resources, my_long_fixture):
    log_tracked_resources()
```
or for a test where the long-running or resource-intensive operation is in the test (not a fixture):
```python
def test_long_step(resource_tracker, request):
    with resource_tracker.track(log=request):
        # something that takes memory and time
        pass
```

At the moment the `resource_tracker` fixture logs peak memory usage and runtime and reports these values in the `report*.xml` generated during regtests run (which is uploaded to github and artifactory).

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14042952366
all pass and generate a report:
https://github.com/spacetelescope/RegressionTests/actions/runs/14042952366/artifacts/2818137935
that contains the recorded resource usage:
```xml
<testcase classname="romancal.regtest.test_mos_skycell_pipeline" name="test_log_tracked_resources" time="500.187"><properties><property name="tracked-peakmem" value="4632279697" /><property name="tracked-time" value="479.6778707471" /></properties>
```

With these included in the results xml combined with the recorded commit hash and dependencies in the snapshot yaml uploaded to artifactory for each regtest run we hopefully have enough information compare performance as changes are made (both from dependencies and from PRs). We would likely benefit from expanding some tooling (like [pytestresultsdiff](https://github.com/zacharyburnett/pytestresultsdiff)) around this to say A-B compare the current PR run with the most recent nightly run.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
