### PR TITLE
Change source catalog flux unit from uJy to nJy

### DIFF
--- a/changes/1671.source_catalog.rst
+++ b/changes/1671.source_catalog.rst
@@ -1,0 +1,1 @@
+Changed the flux units in the source catalog from uJy to nJy.

--- a/docs/roman/source_catalog/main.rst
+++ b/docs/roman/source_catalog/main.rst
@@ -56,6 +56,13 @@ semimajor and semiminor axis lengths, orientation of the major axis,
 and sky coordinates at corners of the minimal bounding box enclosing
 the source.
 
+The units of all fluxes are in nJy. To calculate AB magnitudes, use the
+following formula:
+
+.. math::
+
+    m_{\rm AB} = -2.5 \log_{10}(f_{\rm nJy}) + 31.4
+
 Photometric errors are calculated from the resampled total-error
 array contained in the ``ERR`` (``model.err``) array. Note that this
 total-error array includes source Poisson noise.

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -88,7 +88,7 @@ class RomanSourceCatalog:
         used to perform aperture photometry (i.e., circular and Kron).
 
     flux_unit : str, optional
-        The unit of the flux density. Default is 'uJy'.
+        The unit of the flux density. Default is 'nJy'.
 
     Notes
     -----
@@ -109,7 +109,7 @@ class RomanSourceCatalog:
         fit_psf,
         mask=None,
         detection_cat=None,
-        flux_unit="uJy",
+        flux_unit="nJy",
     ):
         if not isinstance(model, ImageModel | MosaicModel):
             raise ValueError("The input model must be an ImageModel or MosaicModel.")

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -198,6 +198,8 @@ def test_l2_source_catalog(
     if nsources > 0:
         for col in columns:
             assert col in cat.colnames
+            if "flux" in col:
+                assert cat[col].unit == "nJy"
         assert np.min(cat["xcentroid"]) > 0.0
         assert np.min(cat["ycentroid"]) > 0.0
         assert np.max(cat["xcentroid"]) < 100.0
@@ -281,6 +283,8 @@ def test_l3_source_catalog(
     if nsources > 0:
         for col in columns:
             assert col in cat.colnames
+            if "flux" in col:
+                assert cat[col].unit == "nJy"
         assert np.min(cat["xcentroid"]) > 0.0
         assert np.min(cat["ycentroid"]) > 0.0
         assert np.max(cat["xcentroid"]) < 100.0
@@ -457,6 +461,11 @@ def test_do_psf_photometry_column_names(tmp_path, image_model, fit_psf):
     cat = result.source_catalog
 
     assert isinstance(cat, Table)
+
+    if fit_psf:
+        for colname in cat.colnames:
+            if "flux" in colname:
+                assert cat[colname].unit == "nJy"
 
     # check if the PSF photometry column names are present or not based on fit_psf value
     psf_colnames_present = all(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR changes the source catalog flux unit from uJy to nJy.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
