### PR TITLE
RCAL-1007: use float64 for total_exposure_time mean

### DIFF
--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -239,7 +239,9 @@ class ResampleData(Resample):
         if self.compute_exptime and hasattr(self, "_exptime_resampler"):
             exptime_total = self._exptime_resampler.finalize()
             m = exptime_total > 0
-            total_exposure_time = np.mean(exptime_total[m]) if np.any(m) else 0
+            total_exposure_time = (
+                np.mean(exptime_total[m], dtype="f8") if np.any(m) else 0
+            )
             max_exposure_time = np.max(exptime_total)
             log.info(
                 f"Mean, max exposure times: {total_exposure_time:.1f}, "


### PR DESCRIPTION
This PR updates the mean computation in the exposure time resampling during resample to use a float64 output (instead of the default float32). Once the new results are okified this should fix the nightly devdeps regtest runs which are failing due to numpy 2.3.0 changes that have small numerical differences for some operations: https://numpy.org/devdocs/release/2.3.0-notes.html#changes-to-the-main-iterator-and-potential-numerical-changes

Closes #1570
Fixes https://jira.stsci.edu/browse/RCAL-1007

Regtests running with devdeps: https://github.com/spacetelescope/RegressionTests/actions/runs/14197055170
Regtests running without devdeps: https://github.com/spacetelescope/RegressionTests/actions/runs/14200044661

Both runs show differences. Since this PR uses float64 for the mean result that's expected. Importantly the differences agree with devdeps and non-devdeps:

| test | main | PR | PR + devdeps |
| - | - | - | - |
| test_mos_pipeline | 304.9697265625 | 304.96741210212815 | 304.96741210212815 |
| test_mos_skycell_pipeline | 325.62481689453125 | 325.62258681724154 | 325.62258681724154 |
| test_resample | 305.0211181640625 | 305.0194372066956 | 305.0194372066956 |

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
