### PR TITLE
Remove use of maker_utils in steps

### DIFF
--- a/changes/1678.multiband_catalog.rst
+++ b/changes/1678.multiband_catalog.rst
@@ -1,0 +1,1 @@
+Remove maker_utils usage.

--- a/changes/1678.ramp_fitting.rst
+++ b/changes/1678.ramp_fitting.rst
@@ -1,0 +1,1 @@
+Remove maker_utils usage.

--- a/changes/1678.skymatch.rst
+++ b/changes/1678.skymatch.rst
@@ -1,0 +1,1 @@
+Remove maker_util usage.

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -196,9 +196,9 @@ def create_image_model(input_model, image_info):
     meta["cal_logs"] = rds.CalLogs()
     meta["photometry"] = rds.Photometry(
         {
-            "conversion_megajanskys": None,
-            "conversion_megajanskys_uncertainty": None,
-            "pixel_area": None,
+            "conversion_megajanskys": -999999,
+            "conversion_megajanskys_uncertainty": -999999,
+            "pixel_area": -999999,
         }
     )
     inst = {

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from roman_datamodels import datamodels as rdd
-from roman_datamodels import maker_utils
 from roman_datamodels import stnode as rds
 from roman_datamodels.dqflags import group, pixel
 from stcal.ramp_fitting import ols_cas22_fit
@@ -194,8 +193,14 @@ def create_image_model(input_model, image_info):
     meta = dict(wcs=None)  # default empty WCS
     meta.update(input_model.meta)
     meta["cal_step"]["ramp_fit"] = "INCOMPLETE"
-    meta["cal_logs"] = maker_utils.mk_cal_logs()
-    meta["photometry"] = maker_utils.mk_photometry()
+    meta["cal_logs"] = rds.CalLogs()
+    meta["photometry"] = rds.Photometry(
+        {
+            "conversion_megajanskys": None,
+            "conversion_megajanskys_uncertainty": None,
+            "pixel_area": None,
+        }
+    )
     inst = {
         "meta": meta,
         "data": data,

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from astropy.nddata.bitmask import bitfield_to_boolean_mask, interpret_bit_flags
+from roman_datamodels import stnode
 from roman_datamodels.dqflags import pixel
 from stcal.skymatch import SkyImage, SkyStats, skymatch
 
@@ -106,7 +107,13 @@ class SkyMatchStep(RomanStep):
         input_image_model = image_model
 
         if "background" not in image_model.meta:
-            image_model.meta["background"] = {}
+            image_model.meta["background"] = stnode.SkyBackground(
+                {
+                    "level": None,
+                    "subtracted": None,
+                    "method": None,
+                }
+            )
 
         if self._dqbits is None:
             dqmask = np.isfinite(image_model.data).astype(dtype=np.uint8)

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from astropy.nddata.bitmask import bitfield_to_boolean_mask, interpret_bit_flags
-from roman_datamodels import maker_utils
 from roman_datamodels.dqflags import pixel
 from stcal.skymatch import SkyImage, SkyStats, skymatch
 
@@ -107,9 +106,7 @@ class SkyMatchStep(RomanStep):
         input_image_model = image_model
 
         if "background" not in image_model.meta:
-            image_model.meta["background"] = maker_utils.mk_sky_background(
-                level=None, subtracted=None, method="None"
-            )
+            image_model.meta["background"] = {}
 
         if self._dqbits is None:
             dqmask = np.isfinite(image_model.data).astype(dtype=np.uint8)


### PR DESCRIPTION
Remove `maker_util` usage in:
- MultibandCatalogStep
- RampFitStep
- SkymatchStep

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14247918530

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
