### PR TITLE
remove uses of MosaicModel.append_individual_meta

### DIFF
--- a/changes/1688.resample.rst
+++ b/changes/1688.resample.rst
@@ -1,0 +1,1 @@
+Allow resample to run on files with ``None`` and missing values in metadata.

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -75,7 +75,7 @@ class TableBuilder:
 
 class MetaBlender:
     def __init__(self):
-        self._tables = defaultdict(lambda: TableBuilder())
+        self._tables = defaultdict(TableBuilder)
         self._n_rows = 0
 
     def _blend_first(self, model):

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -26,7 +26,7 @@ class TableBuilder:
             self._columns[name] = [MISSING_CELL] * row_index
         return self._columns[name]
 
-    def _santize_value(self, value):
+    def _sanitize_value(self, value):
         if isinstance(value, list | dict | AsdfDictNode | AsdfListNode):
             return str(value)
         return value

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -34,7 +34,7 @@ class TableBuilder:
     def add_row(self, data_dict, row_index):
         updated = set()
         for key, value in data_dict.items():
-            svalue = self._santize_value(value)
+            svalue = self._sanitize_value(value)
             if svalue is None:
                 self._flagged_columns.add(key)
             self._get_column(key, row_index).append(svalue)

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
 from asdf.tags.core.ndarray import NDArrayType
-from astropy.table import QTable
+from astropy.table import Table
 from roman_datamodels import datamodels, maker_utils, stnode
 
 
@@ -70,7 +70,7 @@ class TableBuilder:
             # if all else fails, convert everything to a string
             array_columns[name] = [str(v) for v in values]
 
-        return QTable(array_columns)
+        return Table(array_columns)
 
 
 class MetaBlender:
@@ -119,7 +119,7 @@ class MetaBlender:
 
             if isinstance(value, stnode.DNode):
                 self._tables[key].add_row(value, self._n_rows)
-            elif not isinstance(value, dict | NDArrayType | QTable | AsdfDictNode):
+            elif not isinstance(value, dict | NDArrayType | Table | AsdfDictNode):
                 basic_data[key] = value
         if basic_data:
             self._tables["basic"].add_row(basic_data, self._n_rows)

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -1,8 +1,50 @@
+from collections import defaultdict
+
 import numpy as np
-from roman_datamodels import datamodels, maker_utils
+from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
+from astropy.table import QTable
+from roman_datamodels import datamodels, maker_utils, stnode
+
+
+class MissingCellType:
+    pass
+
+
+MISSING_CELL = MissingCellType()
+
+
+class TableBuilder:
+    def __init__(self):
+        self._columns = {}
+        self._nrows = 0
+
+    def _get_column(self, name):
+        if name not in self._columns:
+            self._columns[name] = [MISSING_CELL] * self._nrows
+        return self._columns[name]
+
+    def _santize_value(self, value):
+        if isinstance(value, list | dict | AsdfDictNode | AsdfListNode):
+            return str(value)
+        return value
+
+    def add_row(self, data_dict):
+        updated = set()
+        for key, value in data_dict.items():
+            self._get_column(key).append(self._santize_value(value))
+            updated.add(key)
+        for key in self._columns.keys() - updated:
+            self._columns[key].append(MISSING_CELL)
+
+    def to_table(self):
+        # TODO fix None and MISSING_CELL values
+        return QTable(self._columns)
 
 
 class MetaBlender:
+    def __init__(self):
+        self._tables = defaultdict(lambda: TableBuilder())
+
     def _blend_first(self, model):
         # make a blank mosic metdata node
         self._model = maker_utils.mk_datamodel(
@@ -36,6 +78,19 @@ class MetaBlender:
                     getattr(model.meta.cal_step, step_name),
                 )
 
+    def _update_tables(self, meta):
+        basic_data = {}
+        for key, value in meta.to_flat_dict().items():
+            if key in {"wcs", "cal_logs"}:
+                continue
+
+            if isinstance(value, stnode.DNode):
+                self._tables[key].add_row(value)
+            else:
+                basic_data[key] = value
+        if basic_data:
+            self._tables["basic"].add_row(basic_data)
+
     def blend(self, model):
         if not hasattr(self, "_model"):
             self._blend_first(model)
@@ -57,15 +112,11 @@ class MetaBlender:
         )
         self._mid_mjds.append(mid_time)
 
-        # FIXME this is an existing hack that we have to reproduce here
-        # since roman_datamodels was never updated
-        cal_logs = model.meta.cal_logs
-        del model.meta["cal_logs"]
-        try:
-            self._model.append_individual_image_meta(model.meta)
-        finally:
-            model.meta.cal_logs = cal_logs
+        self._update_tables(model.meta)
 
     def finalize(self):
         self._meta.basic.time_mean_mjd = np.mean(self._mid_mjds)
+        self._meta.individual_image_meta = stnode.IndividualImageMeta()
+        for table_name, builder in self._tables.items():
+            self._meta.individual_image_meta[table_name] = builder.to_table()
         return self._model

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
+from asdf.tags.core.ndarray import NDArrayType
 from astropy.table import QTable
 from roman_datamodels import datamodels, maker_utils, stnode
 
@@ -118,7 +119,7 @@ class MetaBlender:
 
             if isinstance(value, stnode.DNode):
                 self._tables[key].add_row(value, self._n_rows)
-            else:
+            elif not isinstance(value, dict | NDArrayType | QTable | AsdfDictNode):
                 basic_data[key] = value
         if basic_data:
             self._tables["basic"].add_row(basic_data, self._n_rows)

--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -6,7 +6,7 @@ from asdf import AsdfFile
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling import models
-from astropy.table import QTable
+from astropy.table import Table
 from astropy.time import Time
 from gwcs import WCS
 from gwcs import coordinate_frames as cf
@@ -188,7 +188,7 @@ def test_individual_image_meta(base_image):
     # Assert sizes are expected
     n_inputs = len(input_models)
     for value in output_model.meta.individual_image_meta.values():
-        assert isinstance(value, QTable)
+        assert type(value) is Table
         assert len(value) == n_inputs
 
     # Assert spot check on filename, which is different for each mock input

--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -207,8 +207,7 @@ def test_individual_image_meta(base_image):
     assert output_tables["photometry"]["pixel_area"][1] == 1
 
     assert "extra" not in output_tables
-    assert "extra" in output_tables["basic"].colnames
-    assert isinstance(output_tables["basic"]["extra"][0], str)
+    assert "extra" not in output_tables["basic"].colnames
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR updates the resample "meta_blender" to build tables out of L2 metadata and insert them in the L3 "individual_image_meta" list. This was previously handled by `MosaicModel.append_individual_meta` which:
- crashes when `cal_logs` are provided
- crashes when a None value is provided
- crashes if the L2 metadata form each input image is not structured in the same way ("outlier_detection" missing from 1 L2 input will result in an exception)

There are a few cases to consider (with decisions made in this PR) that are caused by constructing tables of L2 metadata. These issues would not be present if instead the L2 metadata was copied as-is into the L3 metadata (and tables could be created via MosaicModel methods with user input about these decisions).

- What is the appropriate datatype for a list of floats and a None? For example let's say 3 files are appended with backgrounds of `[1.1, None 0.1]`. This PR sets the `None` to `np.nan` in this case.
- What is the appropriate datatype for a list of ints and a None (`[1, None, 0]`). For this PR the `None` is converted to `np.nan` and the other values are converted to floats.
- What is the appropriate datatype for all `None`s? For this PR these are converted to strings.
- How should missing values be handled? This PR treats them (mostly) as `None` (see above). The one exception is that they are converted to a string of `MISSING_CELL` instead of `None`.

Regtests show no failures: https://github.com/spacetelescope/RegressionTests/actions/runs/14339854988/job/40509434891

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
