### PR TITLE
Do not subtract local background from aperture fluxes

### DIFF
--- a/changes/1701.source_catalog.rst
+++ b/changes/1701.source_catalog.rst
@@ -1,0 +1,1 @@
+Local background is no longer subtracted from aperture fluxes.

--- a/romancal/source_catalog/aperture.py
+++ b/romancal/source_catalog/aperture.py
@@ -146,7 +146,7 @@ class ApertureCatalog:
             descriptions[colname] = desc
         return descriptions
 
-    def calc_aperture_photometry(self):
+    def calc_aperture_photometry(self, subtract_local_bkg=False):
         """
         Calculate the aperture photometry.
 
@@ -164,9 +164,10 @@ class ApertureCatalog:
             tmp_flux_col = f"aperture_sum_{i}"
             tmp_flux_err_col = f"aperture_sum_err_{i}"
 
-            # subtract the local background measured in the annulus
-            aper_areas = aperture.area_overlap(self.model.data)
-            aper_phot[tmp_flux_col] -= self.aper_bkg_flux * aper_areas
+            if subtract_local_bkg:
+                # subtract the local background measured in the annulus
+                aper_areas = aperture.area_overlap(self.model.data)
+                aper_phot[tmp_flux_col] -= self.aper_bkg_flux * aper_areas
 
             # set the flux and error attributes
             flux_col = self.aperture_flux_colnames[i]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
The aperture background measurements are reported in the table but are not subtracted from the aperture fluxes.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
