### PR TITLE
save intermediate products as "vanilla" asdf files

### DIFF
--- a/changes/1715.outlier_detection.rst
+++ b/changes/1715.outlier_detection.rst
@@ -1,0 +1,1 @@
+Save intermediate products as asdf files with data and wcs keys.

--- a/romancal/outlier_detection/_fileio.py
+++ b/romancal/outlier_detection/_fileio.py
@@ -1,43 +1,28 @@
 import logging
 
+import asdf
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def save_median(example_model, median_data, median_wcs, make_output_path):
+def save_median(median_data, median_wcs, make_output_path):
     _save_intermediate_output(
-        _make_median_model(example_model, median_data, median_wcs),
-        "median",
-        make_output_path,
+        median_data,
+        median_wcs,
+        make_output_path("drizzled_median.asdf", suffix="median"),
     )
 
 
 def save_drizzled(drizzled_model, make_output_path):
-    _save_intermediate_output(drizzled_model, "outlier_coadd", make_output_path)
+    input_path = drizzled_model.meta.filename.replace("_outlier_", "_")
+    _save_intermediate_output(
+        drizzled_model.data,
+        drizzled_model.meta.wcs,
+        make_output_path(input_path, suffix="outlier_coadd"),
+    )
 
 
-def _make_median_model(example_model, data, wcs):
-    model = example_model.copy()
-    model.data = data
-    model.meta.filename = "drizzled_median.asdf"
-    model.meta.wcs = wcs
-    return model
-
-
-def _save_intermediate_output(model, suffix, make_output_path):
-    """
-    Ensure all intermediate outputs from OutlierDetectionStep have consistent file naming conventions
-
-    Notes
-    -----
-    self.make_output_path() is updated globally for the step in the main pipeline
-    to include the asn_id in the output path, so no need to handle it here.
-    """
-
-    # outlier_?2d is not a known suffix, and make_output_path cannot handle an
-    # underscore in an unknown suffix, so do a manual string replacement
-    input_path = model.meta.filename.replace("_outlier_", "_")
-
-    output_path = make_output_path(input_path, suffix=suffix)
-    model.save(output_path)
-    log.info(f"Saved {suffix} model in {output_path}")
+def _save_intermediate_output(data, wcs, output_path):
+    asdf.AsdfFile({"data": data, "wcs": wcs}).write_to(output_path)
+    log.info(f"Saved intermediate product to {output_path}")

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -61,7 +61,6 @@ def _median_with_resampling(
     in_memory = not input_models._on_disk
     indices_by_group = list(input_models.group_indices.values())
     nresultants = len(indices_by_group)
-    example_model = None
     median_wcs = resamp.output_wcs
 
     with input_models:
@@ -76,7 +75,6 @@ def _median_with_resampling(
                 input_shape = (nresultants, *drizzled_model.data.shape)
                 dtype = drizzled_model.data.dtype
                 computer = MedianComputer(input_shape, in_memory, buffer_size, dtype)
-                example_model = drizzled_model
 
             weight_threshold = compute_weight_threshold(drizzled_model.weight, maskpt)
             drizzled_model.data[drizzled_model.weight < weight_threshold] = np.nan
@@ -89,7 +87,6 @@ def _median_with_resampling(
     if save_intermediate_results:
         # drizzled model already contains asn_id
         _fileio.save_median(
-            example_model,
             median_data,
             median_wcs,
             partial(make_output_path, asn_id=None),
@@ -141,7 +138,6 @@ def _median_without_resampling(
     """
     in_memory = not input_models._on_disk
     nresultants = len(input_models)
-    example_model = None
 
     with input_models:
         for i in range(len(input_models)):
@@ -162,7 +158,6 @@ def _median_without_resampling(
                 input_shape = (nresultants, *model.data.shape)
                 dtype = model.data.dtype
                 computer = MedianComputer(input_shape, in_memory, buffer_size, dtype)
-                example_model = model
                 median_wcs = copy.deepcopy(model.meta.wcs)
 
             weight_threshold = compute_weight_threshold(wht, maskpt)
@@ -178,7 +173,7 @@ def _median_without_resampling(
     median_data = computer.evaluate()
 
     if save_intermediate_results:
-        _fileio.save_median(example_model, median_data, median_wcs, make_output_path)
+        _fileio.save_median(median_data, median_wcs, make_output_path)
 
     return median_data, median_wcs
 


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1682

<!-- describe the changes comprising this PR here -->
This PR switches the "save_intermediate_products" files optionally generated during outlier detection to use a "vanilla" asdf file containing the following:
- "data" either the resampled data array or the median array depending on the type of the intermediate product
- "wcs" the wcs of the intermediate product

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/14626199505

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
