### PR TITLE
Remove maker_utils usage from resample

### DIFF
--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -100,10 +100,12 @@ def test_outlier_do_detection_write_files_to_custom_location(tmp_path, base_imag
     """
     img_1 = base_image()
     img_1.meta.filename = "img1_cal.asdf"
+    img_1.meta.observation.observation_id = "abc"
     img_1.meta.background.level = 0
     img_2 = base_image()
     img_2.meta.filename = "img2_cal.asdf"
     img_2.meta.background.level = 0
+    img_2.meta.observation.observation_id = "abc"
     input_models = ModelLibrary([img_1, img_2])
 
     outlier_step = OutlierDetectionStep(

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -59,13 +59,14 @@ def _median_with_resampling(
         resampled image.
     """
     in_memory = not input_models._on_disk
-    indices_by_group = list(input_models.group_indices.values())
-    nresultants = len(indices_by_group)
+    group_indices_by_id = input_models.group_indices
+    nresultants = len(group_indices_by_id)
     median_wcs = resamp.output_wcs
 
     with input_models:
-        for i, indices in enumerate(indices_by_group):
+        for i, (group_id, indices) in enumerate(group_indices_by_id.items()):
             drizzled_model = resamp.resample_group(indices)
+            drizzled_model.meta.filename = group_id
 
             if save_intermediate_results:
                 # write the drizzled model to file

--- a/romancal/resample/meta_blender.py
+++ b/romancal/resample/meta_blender.py
@@ -4,7 +4,9 @@ import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
 from asdf.tags.core.ndarray import NDArrayType
 from astropy.table import Table
-from roman_datamodels import datamodels, maker_utils, stnode
+from roman_datamodels import stnode
+
+from .resample_utils import _make_empty_mosaic_model
 
 
 class MissingCellType:
@@ -80,9 +82,7 @@ class MetaBlender:
 
     def _blend_first(self, model):
         # make a blank mosic metdata node
-        self._model = maker_utils.mk_datamodel(
-            datamodels.MosaicModel, n_images=0, shape=(0, 0)
-        )
+        self._model = _make_empty_mosaic_model()
         self._meta = self._model.meta
 
         self._model["individual_image_cal_logs"] = []

--- a/romancal/resample/resample.py
+++ b/romancal/resample/resample.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-from roman_datamodels import datamodels, dqflags, maker_utils
+from roman_datamodels import dqflags
 from stcal.resample import Resample
 
 from romancal.patch_match.patch_match import to_skycell_wcs
@@ -9,7 +9,7 @@ from romancal.patch_match.patch_match import to_skycell_wcs
 from .exptime_resampler import ExptimeResampler
 from .l3_wcs import assign_l3_wcs
 from .meta_blender import MetaBlender
-from .resample_utils import make_output_wcs
+from .resample_utils import _make_empty_mosaic_model, make_output_wcs
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -208,9 +208,7 @@ class ResampleData(Resample):
         if self.blend_meta:
             output_model = self._meta_blender.finalize()
         else:
-            output_model = maker_utils.mk_datamodel(
-                datamodels.MosaicModel, n_images=0, shape=(0, 0)
-            )
+            output_model = _make_empty_mosaic_model()
 
         output_model.meta.resample.good_bits = self.good_bits
         output_model.meta.resample.weight_type = self.weight_type

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -22,7 +22,12 @@ def _make_empty_mosaic_model():
         "product_type": stnode.ProductType("l2"),
         "sdf_software_version": stnode.SdfSoftwareVersion("7.7.7"),
         "telescope": stnode.Telescope("ROMAN"),
-        "asn": stnode.MosaicAssociations(),
+        "asn": stnode.MosaicAssociations(
+            {
+                "pool_name": "?",
+                "table_name": "?",
+            }
+        ),
         "basic": stnode.MosaicBasic(
             {
                 "survey": "?",
@@ -52,19 +57,21 @@ def _make_empty_mosaic_model():
         "program": stnode.Program(),
         "ref_file": stnode.RefFile(
             {
-                "crds": {},
+                "apcorr": "N/A",
+                "area": "N/A",
                 "dark": "N/A",
                 "distortion": "N/A",
-                "mask": "N/A",
+                "epsf": "N/A",
                 "flat": "N/A",
                 "gain": "N/A",
-                "readnoise": "N/A",
-                "linearity": "N/A",
                 "inverse_linearity": "N/A",
+                "linearity": "N/A",
+                "mask": "N/A",
                 "photom": "N/A",
-                "area": "N/A",
-                "saturation": "N/A",
+                "readnoise": "N/A",
                 "refpix": "N/A",
+                "saturation": "N/A",
+                "crds": {},
             }
         ),
         "resample": stnode.Resample({"members": []}),

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -1,8 +1,77 @@
 import math
 
 import numpy as np
+from astropy.table import QTable
+from astropy.time import Time
+from roman_datamodels import stnode
+from roman_datamodels.datamodels import MosaicModel
 from stcal.alignment.util import compute_scale, wcs_from_sregions
 from stcal.resample.utils import compute_mean_pixel_area
+
+
+def _make_empty_mosaic_model():
+    m = MosaicModel()
+    m.meta = {
+        "calibration_software_name": stnode.CalibrationSoftwareName("RomanCAL"),
+        "file_date": stnode.FileDate(
+            Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+        ),
+        "model_type": stnode.ModelType("MosaicModel"),
+        "origin": stnode.Origin("STSCI/SOC"),
+        "prd_version": stnode.PrdVersion("8.8.8"),
+        "product_type": stnode.ProductType("l2"),
+        "sdf_software_version": stnode.SdfSoftwareVersion("7.7.7"),
+        "telescope": stnode.Telescope("ROMAN"),
+        "asn": stnode.MosaicAssociations(),
+        "basic": stnode.MosaicBasic(
+            {
+                "survey": "?",
+            }
+        ),
+        "cal_step": stnode.L3CalStep(
+            {
+                "flux": "INCOMPLETE",
+                "outlier_detection": "INCOMPLETE",
+                "skymatch": "INCOMPLETE",
+                "resample": "INCOMPLETE",
+            }
+        ),
+        "individual_image_meta": stnode.IndividualImageMeta(
+            {
+                "basic": QTable({"dummy": [-1]}),
+            }
+        ),
+        "coordinates": stnode.Coordinates(),
+        "photometry": stnode.Photometry(
+            {
+                "pixel_area": -999999.0,
+                "conversion_megajanskys": -999999.0,
+                "conversion_megajanskys_uncertainty": -999999.0,
+            }
+        ),
+        "program": stnode.Program(),
+        "ref_file": stnode.RefFile(
+            {
+                "crds": {},
+                "dark": "N/A",
+                "distortion": "N/A",
+                "mask": "N/A",
+                "flat": "N/A",
+                "gain": "N/A",
+                "readnoise": "N/A",
+                "linearity": "N/A",
+                "inverse_linearity": "N/A",
+                "photom": "N/A",
+                "area": "N/A",
+                "saturation": "N/A",
+                "refpix": "N/A",
+            }
+        ),
+        "resample": stnode.Resample({"members": []}),
+        "wcsinfo": stnode.MosaicWcsinfo(),
+    }
+    m.cal_logs = stnode.CalLogs()
+    return m
 
 
 def make_output_wcs(

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -50,8 +50,8 @@ def _make_empty_mosaic_model():
         "photometry": stnode.Photometry(
             {
                 "pixel_area": -999999.0,
-                "conversion_megajanskys": -999999.0,
-                "conversion_megajanskys_uncertainty": -999999.0,
+                "conversion_megajanskys": -999999,
+                "conversion_megajanskys_uncertainty": -999999,
             }
         ),
         "program": stnode.Program(),

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -74,6 +74,11 @@ class RomanStep(Step):
         """
 
         model.meta.calibration_software_version = importlib.metadata.version("romancal")
+        if hasattr(model.meta, "ref_file"):
+            model.meta.ref_file.crds.version = crds_client.get_svn_version()
+            model.meta.ref_file.crds.context = crds_client.get_context_used(
+                model.crds_observatory
+            )
 
         # FIXME: should cal_logs be brought back into meta for a MosaicModel?
         if isinstance(model, ImageModel):
@@ -86,7 +91,6 @@ class RomanStep(Step):
             for ref_name, ref_file in reference_files_used:
                 if hasattr(model.meta.ref_file, ref_name):
                     setattr(model.meta.ref_file, ref_name, ref_file)
-                    # getattr(model.meta.ref_file, ref_name).name = ref_file
             model.meta.ref_file.crds.version = crds_client.get_svn_version()
             model.meta.ref_file.crds.context = crds_client.get_context_used(
                 model.crds_observatory


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
