### PR TITLE
use module specific loggers

### DIFF
--- a/changes/1723.general.rst
+++ b/changes/1723.general.rst
@@ -1,0 +1,1 @@
+Replace root logger usage with module specific loggers.

--- a/docs/roman/stpipe/devel_logging.rst
+++ b/docs/roman/stpipe/devel_logging.rst
@@ -31,7 +31,7 @@ normal::
     import logging
 
     # ...
-    log = logging.getLogger()
+    log = logging.getLogger(__name__)
 
     # If the log on its own won’t emit, neither will it in the
     # context of an stpipe step, so make sure the level is set to

--- a/romancal/lib/save_wcs.py
+++ b/romancal/lib/save_wcs.py
@@ -5,7 +5,7 @@ import logging
 from roman_datamodels.datamodels import WfiWcsModel
 
 # Define logging
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 __all__ = ["ExposurePipeline"]
 
 # Define logging
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 

--- a/romancal/pipeline/mosaic_pipeline.py
+++ b/romancal/pipeline/mosaic_pipeline.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 __all__ = ["MosaicPipeline"]
 
 # Define logging
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
Follow-up to https://github.com/spacetelescope/roman_datamodels/pull/506

This PR changes the calls to `getLogger()` to `getLogger(__name__)` to avoid changes to the root logger.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14759527893
show only failures related to the new crds context.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
