### PR TITLE
RCAL-1031: allow flat regtests to be okified once

### DIFF
--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -95,10 +95,9 @@ f = asdf.open(f'{basename}_uncal.asdf')
 f['roman']['meta']['exposure']['start_time'] = Time('2020-01-01T00:00:00', format='isot')
 f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_changetime_uncal.asdf')
 f.write_to(f'{basename}_changetime_uncal.asdf')"
-strun roman_elp ${basename}_changetime_uncal.asdf --steps.assign_wcs.save_results True --steps.flatfield.save_results True
+strun roman_elp ${basename}_changetime_uncal.asdf --steps.assign_wcs.save_results True
 # copy input and truth files into location
 cp ${basename}_changetime_assignwcs.asdf $outdir/roman-pipeline/dev/WFI/image
-cp ${basename}_changetime_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/image
 
 
 # need to make a special ALL_SATURATED file for the all saturated test.

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -80,26 +80,6 @@ cp r0000101001001001001_0002_wfi01_f158_cal.asdf $outdir/roman-pipeline/dev/WFI/
 strun roman_elp r0000101001001001001_0002_wfi10_f158_uncal.asdf
 cp r0000101001001001001_0002_wfi10_f158_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
 
-
-# CRDS test needs the "usual" r00001..._0001_wfi01 files.
-# It also needs a hacked r00001..._0001_wfi01 file, with the time changed.
-# this makes the hacked version.
-echo "Creating regtest files for CRDS tests..."
-basename="r0000101001001001001_0001_wfi01_f158"
-python -c "
-import asdf
-from roman_datamodels import stnode
-from astropy.time import Time
-basename = '$basename'
-f = asdf.open(f'{basename}_uncal.asdf')
-f['roman']['meta']['exposure']['start_time'] = Time('2020-01-01T00:00:00', format='isot')
-f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_changetime_uncal.asdf')
-f.write_to(f'{basename}_changetime_uncal.asdf')"
-strun roman_elp ${basename}_changetime_uncal.asdf --steps.assign_wcs.save_results True
-# copy input and truth files into location
-cp ${basename}_changetime_assignwcs.asdf $outdir/roman-pipeline/dev/WFI/image
-
-
 # need to make a special ALL_SATURATED file for the all saturated test.
 echo "Creating regtest files for all saturated tests..."
 basename="r0000101001001001001_0001_wfi01_f158"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -4,7 +4,7 @@
     "romancal.regtest.test_wfi_dq_init.test_dq_init_image_step"
   ],
   "DMS79": [
-    "romancal.regtest.test_wfi_flat_field.test_flat_field_crds_match_image_step"
+    "romancal.regtest.test_wfi_flat_field.test_ref_file_query"
   ],
   "DMS86": [
     "romancal.regtest.test_wfi_image_pipeline.test_steps_ran",


### PR DESCRIPTION
This PR reorganizes the flat regtests so they can be okified once.

In addition to test shuffling this PR:
- remove the duplicate run of r0000101001001001001_0001_wfi01_f158_assignwcs.asdf
- removes the need for r0000101001001001001_0001_wfi01_f158_changetime_assignwcs.asdf (this is also removed from `make_regtest_data.sh` script)

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14778335299

Regtest generator script running at: https://github.com/spacetelescope/RegressionTests/actions/runs/14778983273

Closes #1650

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
