### PR TITLE
Update source catalog column units and add placeholder columns

### DIFF
--- a/changes/1731.source_catalog.rst
+++ b/changes/1731.source_catalog.rst
@@ -1,0 +1,1 @@
+Updated column units and added placeholder columns.

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -97,8 +97,12 @@ def test_multiband_catalog(
         assert np.max(cat["y_centroid"]) < 100.0
 
         for colname in cat.colnames:
-            if "flux" in colname and "fluxfrac" not in colname:
-                assert cat[colname].unit == u.nJy
+            if (
+                "flux" in colname
+                and "fluxfrac" not in colname
+                and "aper_bkg_flux" not in colname
+            ):
+                assert cat[colname].unit == "nJy"
                 assert "f158" in colname or "f184" in colname
             if colname.endswith("_flux"):
                 assert f"{colname}_err" in cat.colnames

--- a/romancal/source_catalog/aperture.py
+++ b/romancal/source_catalog/aperture.py
@@ -71,6 +71,7 @@ class ApertureCatalog:
             warnings.simplefilter("ignore", category=RuntimeWarning)
             warnings.simplefilter("ignore", category=AstropyUserWarning)
 
+            unit = self.model.data.unit
             nvalues = []
             bkg_median = []
             bkg_std = []
@@ -83,14 +84,14 @@ class ApertureCatalog:
                 if values.size == 0:
                     # handle case where source is completely masked due to
                     # forced photometry
-                    med *= self.model.data.unit
-                    std *= self.model.data.unit
+                    med <<= unit
+                    std <<= unit
                 bkg_median.append(med)
                 bkg_std.append(std)
 
             nvalues = np.array(nvalues)
-            bkg_median = u.Quantity(bkg_median)
-            bkg_std = u.Quantity(bkg_std)
+            bkg_median = u.Quantity(bkg_median) / u.pix
+            bkg_std = u.Quantity(bkg_std) / u.pix
 
             # standard error of the median
             bkg_median_err = np.sqrt(np.pi / (2.0 * nvalues)) * bkg_std

--- a/romancal/source_catalog/aperture.py
+++ b/romancal/source_catalog/aperture.py
@@ -90,8 +90,9 @@ class ApertureCatalog:
                 bkg_std.append(std)
 
             nvalues = np.array(nvalues)
-            bkg_median = u.Quantity(bkg_median) / u.pix
-            bkg_std = u.Quantity(bkg_std) / u.pix
+            pixel_area = self.pixel_scale**2
+            bkg_median = u.Quantity(bkg_median) / pixel_area
+            bkg_std = u.Quantity(bkg_std) / pixel_area
 
             # standard error of the median
             bkg_median_err = np.sqrt(np.pi / (2.0 * nvalues)) * bkg_std

--- a/romancal/source_catalog/psf.py
+++ b/romancal/source_catalog/psf.py
@@ -409,11 +409,11 @@ class PSFCatalog:
         """
         The uncertainty in ra_psf.
         """
-        return np.zeros(self.ra_psf.shape, dtype=np.float32) * u.deg
+        return np.zeros(self.ra_psf.shape, dtype=np.float32) * u.arcsec
 
     @lazyproperty
     def dec_psf_err(self):
         """
         The uncertainty in dec_psf.
         """
-        return np.zeros(self.dec_psf.shape, dtype=np.float32) * u.deg
+        return np.zeros(self.dec_psf.shape, dtype=np.float32) * u.arcsec

--- a/romancal/source_catalog/psf.py
+++ b/romancal/source_catalog/psf.py
@@ -306,7 +306,7 @@ class PSFCatalog:
         self.mask = mask
 
         self.names = list(self._name_map.values())
-        self.names.extend(["ra_psf", "dec_psf"])
+        self.names.extend(["ra_psf", "dec_psf", "ra_psf_err", "dec_psf_err"])
 
         self.calc_psf_photometry()
 
@@ -403,3 +403,17 @@ class PSFCatalog:
         Declination of the fitted-PSF pixel position.
         """
         return self._sky_psf.dec
+
+    @lazyproperty
+    def ra_psf_err(self):
+        """
+        The uncertainty in ra_psf.
+        """
+        return np.zeros(self.ra_psf.shape, dtype=np.float32) * u.deg
+
+    @lazyproperty
+    def dec_psf_err(self):
+        """
+        The uncertainty in dec_psf.
+        """
+        return np.zeros(self.dec_psf.shape, dtype=np.float32) * u.deg

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -233,6 +233,10 @@ class SegmentCatalog:
                     np.float32
                 )
 
+            # remove dimensionless units
+            if new_name == "ellipticity":
+                value = value.value
+
             # split the sky_centroid values into separate RA and Dec
             # values
             if new_name == "sky_centroid":

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -291,7 +291,7 @@ class SegmentCatalog:
             "ra_centroid_win_err",
             "dec_centroid_win_err",
         )
-        sky_value = np.zeros(self.source_cat.nlabels, dtype=np.float32) * u.deg
+        sky_value = np.zeros(self.source_cat.nlabels, dtype=np.float32) * u.arcsec
         for name in sky_columns:
             if not hasattr(self, name):
                 setattr(self, name, sky_value)

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -128,8 +128,9 @@ class SegmentCatalog:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
 
-            abmag = flux.to(u.ABmag).value
+            abmag = flux.to(u.ABmag)
             abmag_err = 2.5 * np.log10(1.0 + (flux_err / flux))
+            abmag_err = abmag_err.value * u.ABmag
 
             # handle negative fluxes
             idx = flux.value < 0
@@ -301,14 +302,14 @@ class SegmentCatalog:
         """
         The Kron magnitude in AB magnitudes.
         """
-        return self._kron_abmag[0] * u.mag
+        return self._kron_abmag[0]
 
     @lazyproperty
     def kron_abmag_err(self):
         """
         The Kron magnitude error in AB magnitudes.
         """
-        return self._kron_abmag[1] * u.mag
+        return self._kron_abmag[1]
 
     @lazyproperty
     def fluxfrac_radius_50(self):

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -222,13 +222,6 @@ class SegmentCatalog:
             new_name = name_map.get(name, name)
             value = getattr(segm_cat, name)
 
-            # change the photutils dtypes
-            if new_name not in ("sky_centroid", "sky_centroid_win"):
-                if np.issubdtype(value.dtype, np.integer):
-                    value = value.astype(np.int32)
-                elif np.issubdtype(value.dtype, np.floating):
-                    value = value.astype(np.float32)
-
             # handle any unit conversions
             if new_name in (
                 "x_centroid",
@@ -240,9 +233,7 @@ class SegmentCatalog:
 
             # pix**2 -> arcsec**2
             if new_name == "segment_area":
-                value = (value.value * self.pixel_area.to(u.arcsec**2)).astype(
-                    np.float32
-                )
+                value = value.value * self.pixel_area.to(u.arcsec**2)
 
             # pix -> arcsec
             if new_name in ("semimajor", "semiminor", "fwhm", "kron_radius"):
@@ -255,6 +246,13 @@ class SegmentCatalog:
             # remove dimensionless units
             if new_name == "ellipticity":
                 value = value.value
+
+            # change the photutils dtypes
+            if new_name not in ("sky_centroid", "sky_centroid_win"):
+                if np.issubdtype(value.dtype, np.integer):
+                    value = value.astype(np.int32)
+                elif np.issubdtype(value.dtype, np.floating):
+                    value = value.astype(np.float32)
 
             # split the sky_centroid values into separate RA and Dec
             # values
@@ -334,5 +332,5 @@ class SegmentCatalog:
         """
         The radius (in arcsec) at which the flux fraction is 50%.
         """
-        value = self.source_cat.fluxfrac_radius(0.5).astype(np.float32)
-        return value.value * self.pixel_scale
+        value = self.source_cat.fluxfrac_radius(0.5)
+        return (value.value * self.pixel_scale).astype(np.float32)

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -93,6 +93,9 @@ class SegmentCatalog:
         for name in self._lazyproperties:
             self.names.append(name)
 
+        # add the placeholder attributes
+        self.add_placeholders()
+
     @property
     def _lazyproperties(self):
         """
@@ -238,6 +241,37 @@ class SegmentCatalog:
             else:
                 setattr(self, new_name, value)
                 self.names.append(new_name)
+
+    def add_placeholders(self):
+        """
+        Add placeholder attributes to the class instance.
+        """
+        # pixel columns
+        pix_columns = (
+            "x_centroid_err",
+            "y_centroid_err",
+            "x_centroid_win_err",
+            "y_centroid_win_err",
+        )
+        pix_value = np.zeros(self.source_cat.nlabels, dtype=np.float32) * u.pix
+        for name in pix_columns:
+            if not hasattr(self, name):
+                setattr(self, name, pix_value)
+
+        # sky columns
+        sky_columns = (
+            "ra_centroid_err",
+            "dec_centroid_err",
+            "ra_centroid_win_err",
+            "dec_centroid_win_err",
+        )
+        sky_value = np.zeros(self.source_cat.nlabels, dtype=np.float32) * u.deg
+        for name in sky_columns:
+            if not hasattr(self, name):
+                setattr(self, name, sky_value)
+
+        for name in [*pix_columns, *sky_columns]:
+            self.names.append(name)
 
     @lazyproperty
     def orientation_sky(self):

--- a/romancal/source_catalog/segment.py
+++ b/romancal/source_catalog/segment.py
@@ -221,7 +221,12 @@ class SegmentCatalog:
                     value = value.astype(np.float32)
 
             # handle any unit conversions
-            if new_name in ("x_centroid", "y_centroid"):
+            if new_name in (
+                "x_centroid",
+                "y_centroid",
+                "x_centroid_win",
+                "y_centroid_win",
+            ):
                 value *= u.pix
             if new_name == "segment_area":
                 value = (value.value * self.pixel_area.to(u.arcsec**2)).astype(

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -441,8 +441,8 @@ class RomanSourceCatalog:
         col = {}
         col["label"] = "Label of the source segment in the segmentation image"
         col["flagged_spatial_index"] = (
-            "Spatial index bit flag encoding the projection, skycell, and "
-            "pixel coordinate of the source"
+            "Bit flag encoding the overlap flag, projection, skycell, and "
+            "pixel coordinates of the source"
         )
 
         col["x_centroid"] = (
@@ -470,8 +470,8 @@ class RomanSourceCatalog:
             "Right ascension (ICRS) of the windowed source centroid"
         )
         col["dec_centroid_win"] = "Declination (ICRS) of the windowed source centroid"
-        col["ra_psf"] = "Right ascension (ICRS) of the fitted-PSF position"
-        col["dec_psf"] = "Declination (ICRS) of the fitted_PSF position"
+        col["ra_psf"] = "Right ascension (ICRS) of the PSF-fitted position"
+        col["dec_psf"] = "Declination (ICRS) of the PSF-fitted position"
 
         col["bbox_xmin"] = (
             "Column index of the left edge of the source bounding box (0 indexed)"
@@ -498,10 +498,10 @@ class RomanSourceCatalog:
         )
         col["ellipticity"] = "Source ellipticity as 1 - (semimajor / semiminor)"
         col["orientation_pix"] = (
-            "Angle measured counter-clockwise from the positive X axis to the major axis computed from image moments"
+            "Angle measured counter-clockwise from the positive X axis to the source major axis computed from image moments"
         )
         col["orientation_sky"] = (
-            "Position angle from North of the major axis computed from image moments"
+            "Position angle from North of the source major axis computed from image moments"
         )
 
         col["cxx"] = (
@@ -516,30 +516,29 @@ class RomanSourceCatalog:
 
         col["segment_flux"] = "Isophotal flux"
         col["segment_area"] = "Area of the source segment"
-        col["kron_radius"] = (
-            "Unscaled first-moment Kron radius defined as r = Sum_i "
-            "(r_i * I_i) / Sum_i (I_i), with r_i as an elliptical radius"
-        )
+        col["kron_radius"] = "Unscaled first-moment Kron radius"
         col["fluxfrac_radius_50"] = (
-            "Circular radius that encloses 50% of the source Kron flux"
+            "Radius of a circle centered on the source centroid that encloses 50% of the Kron flux"
         )
         col["kron_flux"] = "Flux within the elliptical Kron aperture"
         col["kron_abmag"] = "AB magnitude within the elliptical Kron aperture"
         col["aper_bkg_flux"] = "Local background estimated within a circular annulus"
 
-        col["x_psf"] = "Column position of the source from PSF fitting (0 indexed)"
-        col["y_psf"] = "Row position of the source from PSF fitting (0 indexed)"
+        col["x_psf"] = "Column coordinate of the source from PSF fitting (0 indexed)"
+        col["y_psf"] = "Row coordinate of the source from PSF fitting (0 indexed)"
         col["psf_flux"] = "Total PSF flux"
         col["psf_gof"] = "PSF goodness of fit metric"
-        col["psf_flags"] = "PSF fitting bit flags"
+        col["psf_flags"] = "PSF fitting bit flags (0 = good)"
 
-        col["warning_flags"] = "Warning bit flags"
-        col["image_flags"] = "Image quality bit flags"
+        col["warning_flags"] = "Warning bit flags (0 = good)"
+        col["image_flags"] = "Image quality bit flags (0 = good)"
 
-        col["is_extended"] = "Flag indicating whether the source is extended"
+        col["is_extended"] = (
+            "Flag indicating that the source appears to be more extended than a point source"
+        )
         col["sharpness"] = "Photutils DAOStarFinder sharpness statistic"
         col["roundness1"] = "Photutils DAOStarFinder roundness1 statistic"
-        col["nn_label"] = "Label number of the nearest neighbor in this skycell"
+        col["nn_label"] = "Segment label of the nearest neighbor in this skycell"
         col["nn_dist"] = "Distance to the nearest neighbor in this skycell"
 
         # add the aperture flux column descriptions

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -462,8 +462,8 @@ class RomanSourceCatalog:
             "detection image from image moments (0 indexed)"
         )
 
-        col["ra"] = "The best estimate of the right ascension (ICRS)"
-        col["dec"] = "The best estimate of the declination (ICRS)"
+        col["ra"] = "Best estimate of the right ascension (ICRS)"
+        col["dec"] = "Best estimate of the declination (ICRS)"
         col["ra_centroid"] = "Right ascension (ICRS) of the source centroid"
         col["dec_centroid"] = "Declination (ICRS) of the source centroid"
         col["ra_centroid_win"] = (
@@ -486,10 +486,10 @@ class RomanSourceCatalog:
             "Row index of the top edge of the source bounding box (0 indexed)"
         )
         col["semimajor"] = (
-            "The length of the source semimajor axis computed from image moments"
+            "Length of the source semimajor axis computed from image moments"
         )
         col["semiminor"] = (
-            "The length of the source semiminor axis computed from image moments"
+            "Length of the source semiminor axis computed from image moments"
         )
         col["fwhm"] = (
             "Circularized full width at half maximum (FWHM) "
@@ -498,11 +498,10 @@ class RomanSourceCatalog:
         )
         col["ellipticity"] = "Source ellipticity as 1 - (semimajor / semiminor)"
         col["orientation_pix"] = (
-            "The angle measured counter-clockwise from the positive X axis to the major axis computed from image moments"
+            "Angle measured counter-clockwise from the positive X axis to the major axis computed from image moments"
         )
         col["orientation_sky"] = (
-            "The position angle from North of the major axis computed from "
-            "image moments"
+            "Position angle from North of the major axis computed from image moments"
         )
 
         col["cxx"] = (
@@ -522,13 +521,11 @@ class RomanSourceCatalog:
             "(r_i * I_i) / Sum_i (I_i), with r_i as an elliptical radius"
         )
         col["fluxfrac_radius_50"] = (
-            "The circular radius that encloses 50% of the source Kron flux"
+            "Circular radius that encloses 50% of the source Kron flux"
         )
         col["kron_flux"] = "Flux within the elliptical Kron aperture"
         col["kron_abmag"] = "AB magnitude within the elliptical Kron aperture"
-        col["aper_bkg_flux"] = (
-            "The local background estimated within a circular annulus"
-        )
+        col["aper_bkg_flux"] = "Local background estimated within a circular annulus"
 
         col["x_psf"] = "Column position of the source from PSF fitting (0 indexed)"
         col["y_psf"] = "Row position of the source from PSF fitting (0 indexed)"
@@ -540,10 +537,10 @@ class RomanSourceCatalog:
         col["image_flags"] = "Image quality bit flags"
 
         col["is_extended"] = "Flag indicating whether the source is extended"
-        col["sharpness"] = "The DAOFind sharpness statistic"
-        col["roundness1"] = "The DAOFind roundness1 statistic"
-        col["nn_label"] = "The label number of the nearest neighbor in this skycell"
-        col["nn_dist"] = "The distance to the nearest neighbor in this skycell"
+        col["sharpness"] = "Photutils DAOStarFinder sharpness statistic"
+        col["roundness1"] = "Photutils DAOStarFinder roundness1 statistic"
+        col["nn_label"] = "Label number of the nearest neighbor in this skycell"
+        col["nn_dist"] = "Distance to the nearest neighbor in this skycell"
 
         # add the aperture flux column descriptions
         if self.aperture_cat is not None:

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -644,6 +644,8 @@ class RomanSourceCatalog:
         skypsf_colnames = [
             "ra_psf",
             "dec_psf",
+            "ra_psf_err",
+            "dec_psf_err",
         ]
         segm_colnames = [
             "bbox_xmin",

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -366,6 +366,16 @@ class RomanSourceCatalog:
 
         return flags
 
+    @lazyproperty
+    def image_flags(self):
+        """
+        Data quality bit flag.
+
+        Non-zero if a pixel within the segment was flagged in one of the
+        input images.
+        """
+        return np.zeros(self.n_sources, dtype=np.int32)
+
     def update_metadata(self):
         """
         Update the metadata dictionary with the package version
@@ -508,6 +518,8 @@ class RomanSourceCatalog:
         col["psf_flags"] = "PSF fitting bit flags"
 
         col["warning_flags"] = "Warning bit flags"
+        col["image_flags"] = "Image quality bit flags"
+
         col["is_extended"] = "Flag indicating whether the source is extended"
         col["sharpness"] = "The DAOFind sharpness statistic"
         col["roundness1"] = "The DAOFind roundness1 statistic"
@@ -639,9 +651,13 @@ class RomanSourceCatalog:
             "y_psf",
             "y_psf_err",
         ]
+        flag_columns = [
+            "warning_flags",
+            "image_flags",
+        ]
         psf_flags_colnames = [
-            "psf_gof",
             "psf_flags",
+            "psf_gof",
         ]
 
         det_colnames = []
@@ -673,7 +689,8 @@ class RomanSourceCatalog:
             colnames.extend(det_colnames)
             colnames.extend(othershape_colnames)
             colnames.extend(self.flux_colnames)
-            colnames.append("warning_flags")
+
+            colnames.extend(flag_columns)
             if self.fit_psf:
                 colnames.extend(psf_flags_colnames)
 
@@ -691,7 +708,7 @@ class RomanSourceCatalog:
             colnames.extend(sky_colnames)
             colnames.extend(skywin_colnames)
             colnames.extend(det_colnames)
-            colnames.append("warning_flags")
+            colnames.extend(flag_columns)
 
         elif self.cat_type == "dr_band":
             colnames = band_colnames.copy()

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -323,6 +323,20 @@ class RomanSourceCatalog:
         return np.zeros(self.n_sources, dtype=np.int64)
 
     @lazyproperty
+    def ra(self):
+        """
+        The best estimate of the right ascension (ICRS).
+        """
+        return np.zeros(self.n_sources, dtype=np.float64) * u.deg
+
+    @lazyproperty
+    def dec(self):
+        """
+        The best estimate of the declination (ICRS).
+        """
+        return np.zeros(self.n_sources, dtype=np.float64) * u.deg
+
+    @lazyproperty
     def is_extended(self):
         """
         Boolean indicating whether the source is extended.
@@ -447,6 +461,9 @@ class RomanSourceCatalog:
             "Row coordinate of the windowed source centroid in the "
             "detection image from image moments (0 indexed)"
         )
+
+        col["ra"] = "The best estimate of the right ascension (ICRS)"
+        col["dec"] = "The best estimate of the declination (ICRS)"
         col["ra_centroid"] = "Right ascension (ICRS) of the source centroid"
         col["dec_centroid"] = "Declination (ICRS) of the source centroid"
         col["ra_centroid_win"] = (
@@ -604,6 +621,10 @@ class RomanSourceCatalog:
             "x_centroid_win",
             "y_centroid_win",
         ]
+        skybest_colnames = [
+            "ra",
+            "dec",
+        ]
         sky_colnames = [
             "ra_centroid",
             "dec_centroid",
@@ -682,6 +703,7 @@ class RomanSourceCatalog:
             colnames.extend(xywin_colnames)
             if self.fit_psf:
                 colnames.extend(xypsf_colnames)
+            colnames.extend(skybest_colnames)
             colnames.extend(sky_colnames)
             colnames.extend(skywin_colnames)
             if self.fit_psf:
@@ -697,6 +719,7 @@ class RomanSourceCatalog:
         elif self.cat_type == "forced_det":
             colnames = ["label"]  # needed to join the forced catalogs
             colnames.extend(base_colnames)
+            colnames.extend(skybest_colnames)
             colnames.extend(sky_colnames)
             colnames.extend(shape_colnames)
             colnames.extend(nn_colnames)
@@ -705,6 +728,7 @@ class RomanSourceCatalog:
             colnames = []
             colnames.extend(base_colnames)
             colnames.extend(xywin_colnames)
+            colnames.extend(skybest_colnames)
             colnames.extend(sky_colnames)
             colnames.extend(skywin_colnames)
             colnames.extend(det_colnames)

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -616,10 +616,14 @@ class RomanSourceCatalog:
             "flagged_spatial_index",
             "x_centroid",
             "y_centroid",
+            "x_centroid_err",
+            "y_centroid_err",
         ]
         xywin_colnames = [
             "x_centroid_win",
             "y_centroid_win",
+            "x_centroid_win_err",
+            "y_centroid_win_err",
         ]
         skybest_colnames = [
             "ra",
@@ -628,10 +632,14 @@ class RomanSourceCatalog:
         sky_colnames = [
             "ra_centroid",
             "dec_centroid",
+            "ra_centroid_err",
+            "dec_centroid_err",
         ]
         skywin_colnames = [
             "ra_centroid_win",
             "dec_centroid_win",
+            "ra_centroid_win_err",
+            "dec_centroid_win_err",
         ]
         skypsf_colnames = [
             "ra_psf",

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -486,10 +486,10 @@ class RomanSourceCatalog:
             "Row index of the top edge of the source bounding box (0 indexed)"
         )
         col["semimajor"] = (
-            "1-sigma standard deviation along the semimajor axis of the 2D Gaussian function that has the same second-order central moments as the source"
+            "The length of the source semimajor axis computed from image moments"
         )
         col["semiminor"] = (
-            "1-sigma standard deviation along the semiminor axis of the 2D Gaussian function that has the same second-order central moments as the source"
+            "The length of the source semiminor axis computed from image moments"
         )
         col["fwhm"] = (
             "Circularized full width at half maximum (FWHM) "
@@ -522,11 +522,13 @@ class RomanSourceCatalog:
             "(r_i * I_i) / Sum_i (I_i), with r_i as an elliptical radius"
         )
         col["fluxfrac_radius_50"] = (
-            "The circular radius that encloses 50% of the source Kron flux."
+            "The circular radius that encloses 50% of the source Kron flux"
         )
         col["kron_flux"] = "Flux within the elliptical Kron aperture"
         col["kron_abmag"] = "AB magnitude within the elliptical Kron aperture"
-        col["aper_bkg_flux"] = "The local background estimate for aperture photometry"
+        col["aper_bkg_flux"] = (
+            "The local background estimated within a circular annulus"
+        )
 
         col["x_psf"] = "Column position of the source from PSF fitting (0 indexed)"
         col["y_psf"] = "Row position of the source from PSF fitting (0 indexed)"

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -314,6 +314,15 @@ class RomanSourceCatalog:
             setattr(self, name, getattr(nn_cat, name))
 
     @lazyproperty
+    def flagged_spatial_index(self):
+        """
+        The spatial index bit flag encoding the projection, skycell,
+        and (x, y) pixel coordinate of the source and whether the
+        object is inside the skycell core region.
+        """
+        return np.zeros(self.n_sources, dtype=np.int64)
+
+    @lazyproperty
     def is_extended(self):
         """
         Boolean indicating whether the source is extended.
@@ -407,6 +416,11 @@ class RomanSourceCatalog:
         """
         col = {}
         col["label"] = "Label of the source segment in the segmentation image"
+        col["flagged_spatial_index"] = (
+            "Spatial index bit flag encoding the projection, skycell, and "
+            "pixel coordinate of the source"
+        )
+
         col["x_centroid"] = (
             "Column coordinate of the source centroid in the detection "
             "image from image moments (0 indexed)"
@@ -570,6 +584,7 @@ class RomanSourceCatalog:
         """
         base_colnames = [
             "label",
+            "flagged_spatial_index",
             "x_centroid",
             "y_centroid",
         ]

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -155,9 +155,13 @@ def test_l2_source_catalog(
     assert len(cat) == nsources
 
     if nsources > 0:
-        for col in cat.columns:
-            if "flux" in col and "fluxfrac" not in col:
-                assert cat[col].unit == "nJy"
+        for colname in cat.colnames:
+            if (
+                "flux" in colname
+                and "fluxfrac" not in colname
+                and "aper_bkg_flux" not in colname
+            ):
+                assert cat[colname].unit == "nJy"
         assert np.min(cat["x_centroid"]) > 0.0
         assert np.min(cat["y_centroid"]) > 0.0
         assert np.max(cat["x_centroid"]) < 100.0
@@ -198,9 +202,13 @@ def test_l3_source_catalog(
     assert len(cat) == nsources
 
     if nsources > 0:
-        for col in cat.columns:
-            if "flux" in col and "fluxfrac" not in col:
-                assert cat[col].unit == "nJy"
+        for colname in cat.colnames:
+            if (
+                "flux" in colname
+                and "fluxfrac" not in colname
+                and "aper_bkg_flux" not in colname
+            ):
+                assert cat[colname].unit == "nJy"
         assert np.min(cat["x_centroid"]) > 0.0
         assert np.min(cat["y_centroid"]) > 0.0
         assert np.max(cat["x_centroid"]) < 100.0
@@ -309,7 +317,11 @@ def test_psf_photometry(tmp_path, image_model):
     assert len(cat) == 7
 
     for colname in cat.colnames:
-        if "flux" in colname and "fluxfrac" not in colname:
+        if (
+            "flux" in colname
+            and "fluxfrac" not in colname
+            and "aper_bkg_flux" not in colname
+        ):
             assert cat[colname].unit == "nJy"
 
     for colname in cat.colnames:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1061](https://jira.stsci.edu/browse/RCAL-1061)
Resolves [RCAL-1062](https://jira.stsci.edu/browse/RCAL-1062)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1729
Closes #1730

<!-- describe the changes comprising this PR here -->
All of the columns listed in the `L4_Static_catalog_schema_v0.95.xlsx` document are now included, although some of them contain only placeholder values.

With this PR the (prompt) source catalog column names, dtypes, units, and descriptions are:

```
label                   int32        None            Label of the source segment in the segmentation image
flagged_spatial_index   int64        None            Spatial index bit flag encoding the projection, skycell, and pixel coordinate of the source
x_centroid              float32      pix             Column coordinate of the source centroid in the detection image from image moments (0 indexed)
y_centroid              float32      pix             Row coordinate of the source centroid in the detection image from image moments (0 indexed)
x_centroid_err          float32      pix             Uncertainty in x_centroid
y_centroid_err          float32      pix             Uncertainty in y_centroid
x_centroid_win          float32      pix             Column coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
y_centroid_win          float32      pix             Row coordinate of the windowed source centroid in the detection image from image moments (0 indexed)
x_centroid_win_err      float32      pix             Uncertainty in x_centroid_win
y_centroid_win_err      float32      pix             Uncertainty in y_centroid_win
x_psf                   float32      pix             Column position of the source from PSF fitting (0 indexed)
x_psf_err               float32      pix             Uncertainty in x_psf
y_psf                   float32      pix             Row position of the source from PSF fitting (0 indexed)
y_psf_err               float32      pix             Uncertainty in y_psf
ra                      float64      deg             The best estimate of the right ascension (ICRS)
dec                     float64      deg             The best estimate of the declination (ICRS)
ra_centroid             float64      deg             Right ascension (ICRS) of the source centroid
dec_centroid            float64      deg             Declination (ICRS) of the source centroid
ra_centroid_err         float32      deg             Uncertainty in ra_centroid
dec_centroid_err        float32      deg             Uncertainty in dec_centroid
ra_centroid_win         float64      deg             Right ascension (ICRS) of the windowed source centroid
dec_centroid_win        float64      deg             Declination (ICRS) of the windowed source centroid
ra_centroid_win_err     float32      deg             Uncertainty in ra_centroid_win
dec_centroid_win_err    float32      deg             Uncertainty in dec_centroid_win
ra_psf                  float64      deg             Right ascension (ICRS) of the fitted-PSF position
dec_psf                 float64      deg             Declination (ICRS) of the fitted_PSF position
ra_psf_err              float32      deg             Uncertainty in ra_psf
dec_psf_err             float32      deg             Uncertainty in dec_psf
bbox_xmin               int32        None            Column index of the left edge of the source bounding box (0 indexed)
bbox_xmax               int32        None            Column index of the right edge of the source bounding box (0 indexed)
bbox_ymin               int32        None            Row index of the bottom edge of the source bounding box (0 indexed)
bbox_ymax               int32        None            Row index of the top edge of the source bounding box (0 indexed)
segment_area            float32      arcsec2         Area of the source segment
semimajor               float64      arcsec          The length of the source semimajor axis computed from image moments
semiminor               float64      arcsec          The length of the source semiminor axis computed from image moments
fwhm                    float64      arcsec          Circularized full width at half maximum (FWHM) calculated from the semimajor and semiminor axes as 2*sqrt(ln(2) * (semimajor**2 + semiminor**2))
ellipticity             float32      None            Source ellipticity as 1 - (semimajor / semiminor)
orientation_pix         float32      deg             The angle measured counter-clockwise from the positive X axis to the major axis computed from image moments
orientation_sky         float32      deg             The position angle from North of the major axis computed from image moments
cxx                     float64      1 / arcsec2     Coefficient for the x**2 term in the generalized quadratic ellipse equation
cxy                     float64      1 / arcsec2     Coefficient for the x*y term in the generalized quadratic ellipse equation
cyy                     float64      1 / arcsec2     Coefficient for the y**2 term in the generalized quadratic ellipse equation
kron_radius             float64      arcsec          Unscaled first-moment Kron radius defined as r = Sum_i (r_i * I_i) / Sum_i (I_i), with r_i as an elliptical radius
nn_label                int32        None            The label number of the nearest neighbor in this skycell
nn_dist                 float32      arcsec          The distance to the nearest neighbor in this skycell
sharpness               float32      None            The DAOFind sharpness statistic
roundness1              float32      None            The DAOFind roundness1 statistic
is_extended             bool         None            Flag indicating whether the source is extended
fluxfrac_radius_50      float64      arcsec          The circular radius that encloses 50% of the source Kron flux
aper_bkg_flux           float32      nJy / arcsec2   The local background estimated within a circular annulus
aper_bkg_flux_err       float32      nJy / arcsec2   Uncertainty in aper_bkg_flux
aper01_flux             float32      nJy             Flux within a circular aperture of radius=0.1 arcsec
aper01_flux_err         float32      nJy             Uncertainty in aper01_flux
aper02_flux             float32      nJy             Flux within a circular aperture of radius=0.2 arcsec
aper02_flux_err         float32      nJy             Uncertainty in aper02_flux
aper04_flux             float32      nJy             Flux within a circular aperture of radius=0.4 arcsec
aper04_flux_err         float32      nJy             Uncertainty in aper04_flux
aper08_flux             float32      nJy             Flux within a circular aperture of radius=0.8 arcsec
aper08_flux_err         float32      nJy             Uncertainty in aper08_flux
aper16_flux             float32      nJy             Flux within a circular aperture of radius=1.6 arcsec
aper16_flux_err         float32      nJy             Uncertainty in aper16_flux
psf_flux                float32      nJy             Total PSF flux
psf_flux_err            float32      nJy             Uncertainty in psf_flux
segment_flux            float32      nJy             Isophotal flux
segment_flux_err        float32      nJy             Uncertainty in segment_flux
kron_flux               float32      nJy             Flux within the elliptical Kron aperture
kron_flux_err           float32      nJy             Uncertainty in kron_flux
kron_abmag              float32      mag(AB)         AB magnitude within the elliptical Kron aperture
kron_abmag_err          float32      mag(AB)         Uncertainty in kron_abmag
warning_flags           int32        None            Warning bit flags
image_flags             int32        None            Image quality bit flags
psf_flags               int32        None            PSF fitting bit flags
psf_gof                 float32      None            PSF goodness of fit metric
```

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
