### PR TITLE
Include visit in skycell_asn filenames and update default name.

### DIFF
--- a/changes/1751.associations.rst
+++ b/changes/1751.associations.rst
@@ -1,0 +1,3 @@
+Adds the visit ID to skycell_asn association file outputs.
+
+

--- a/changes/1751.associations.rst
+++ b/changes/1751.associations.rst
@@ -1,3 +1,1 @@
 Adds the visit ID to skycell_asn association file outputs.
-
-

--- a/romancal/associations/skycell_asn.py
+++ b/romancal/associations/skycell_asn.py
@@ -31,8 +31,9 @@ def skycell_asn(filelist, output_file_root, product_type, release_product):
     ----------
     filelist : list of str
         List of file names to be processed.
-    output_file_root : str
+    output_file_root : str or None
         Root string for the output association file.
+        If None, default to r<PROGRAM>.
     product_type : str
         Type of product when creating the association (e.g., 'visit', 'daily').
     release_product : str
@@ -64,6 +65,8 @@ def skycell_asn(filelist, output_file_root, product_type, release_product):
         projcell_info = get_projectioncell_wcs(item)
         parsed_visit_id = parse_visitID(member_list[0][1:20])
         program_id = parsed_visit_id["Program"]
+        if output_file_root is None:
+            output_file_root = 'r' + program_id
         root_asn_name = output_file_root
         product_release = release_product
         sep = "_"
@@ -73,7 +76,8 @@ def skycell_asn(filelist, output_file_root, product_type, release_product):
             + parsed_visit_id["Execution"]
             + parsed_visit_id["Pass"]
             + parsed_visit_id["Segment"]
-            + parsed_visit_id["Observation"],
+            + parsed_visit_id["Observation"]
+            + parsed_visit_id["Visit"],
             "daily": "d"
             + parsed_visit_id["Execution"]
             + parsed_visit_id["Pass"]
@@ -136,8 +140,8 @@ def _cli(args=None):
         "-o",
         "--output-file-root",
         type=str,
-        required=True,
         help="Root string for file to write association to",
+        default=None,
     )
 
     parser.add_argument(

--- a/romancal/regtest/test_skycell_generation.py
+++ b/romancal/regtest/test_skycell_generation.py
@@ -13,12 +13,12 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 pytestmark = [pytest.mark.bigdata]
 
 EXPECTED_FILENAMES = [
-    "r00001_p_v01001001001_r274dp63x31y80_f158_asn.json",
-    "r00001_p_v01001001001_r274dp63x31y81_f158_asn.json",
-    "r00001_p_v01001001001_r274dp63x32y82_f158_asn.json",
-    "r00001_p_v01001001001_r274dp63x32y80_f158_asn.json",
-    "r00001_p_v01001001001_r274dp63x32y81_f158_asn.json",
-    "r00001_p_v01001001001_r274dp63x32y82_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x31y80_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x31y81_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x32y82_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x32y80_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x32y81_f158_asn.json",
+    "r00001_p_v01001001001001_r274dp63x32y82_f158_asn.json",
 ]
 
 


### PR DESCRIPTION
This PR adds the VISIT component to the file names of prompt visit association tables producted by skycell_asn.  It also updates the default root product name to be the usual r<PROGRAM> that begins each file name.

With this PR, skycell_asn r*_f158_cal.asdf for our regression test files creates the following files:
r00001_p_v01001001001001_r274dp63x33y81_f158_asn.json
...
while without this PR the file names are
r00001_p_v01001001001_r274dp63x33y81_f158_asn.json

We want the "001" to fully specify the visit and match the L3 cal file names.

Regtest running here: https://github.com/spacetelescope/RegressionTests/actions/runs/14930782626

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [X] update or add relevant tests
  - [X] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)