### PR TITLE
Handle invalid input to the SourceCatalogStep

### DIFF
--- a/changes/1767.source_catalog.rst
+++ b/changes/1767.source_catalog.rst
@@ -1,0 +1,2 @@
+Update the source catalog step to handle the case where there are no
+valid pixels in the input data.

--- a/romancal/source_catalog/save_utils.py
+++ b/romancal/source_catalog/save_utils.py
@@ -43,7 +43,8 @@ def save_segment_image(self, segment_img, source_catalog_model, output_filename)
 
     # Set the data and detection image
     segmentation_model.data = segment_img.data.astype(np.uint32)
-    segmentation_model["detection_image"] = segment_img.detection_image
+    if hasattr(segment_img, "detection_image"):
+        segmentation_model["detection_image"] = segment_img.detection_image
 
     # Save the segmentation image to the output file
     self.output_ext = "asdf"

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -125,6 +125,7 @@ class SourceCatalogStep(RomanStep):
             cat = Table()
             return self.save_all_results(input_model, segment_img, cat)
 
+        self.log.info("Calculating and subtracting background")
         bkg = RomanBackground(
             model.data,
             box_size=self.bkg_boxsize,
@@ -132,10 +133,12 @@ class SourceCatalogStep(RomanStep):
         )
         model.data -= bkg.background
 
+        self.log.info("Creating detection image")
         detection_image = convolve_data(
             model.data, kernel_fwhm=self.kernel_fwhm, mask=mask
         )
 
+        self.log.info("Detecting sources")
         if not self.forced_segmentation:
             segment_img = make_segmentation_image(
                 detection_image,
@@ -175,6 +178,7 @@ class SourceCatalogStep(RomanStep):
             cat = Table()
             return self.save_all_results(input_model, segment_img, cat)
 
+        self.log.info("Creating source catalog")
         cat_type = "prompt" if not self.forced_segmentation else "forced_det"
         fit_psf = self.fit_psf & (not self.forced_segmentation)  # skip when forced
         catobj = RomanSourceCatalog(

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -231,6 +231,36 @@ class SourceCatalogStep(RomanStep):
         return self.save_all_results(input_model, segment_img, cat)
 
     def save_all_results(self, model, segment_img, cat):
+        """
+        Return and save the results of the source catalog step.
+
+        The segmentation image is always saved.
+
+        If ``save_results`` is True, then either the input model with
+        updated metadata or the source catalog model is saved/returned.
+        If ``return_updated_model`` is True, then the input model is
+        saved/returned with updated metadata. If False, then the source
+        catalog model is saved/returned.
+
+        The source catalog is saved as a parquet file.
+
+        Parameters
+        ----------
+        model : `ImageModel` or `MosaicModel`
+            The input model to the source catalog step.
+
+        segment_img : `photutils.segmentation.SegmentationImage`
+            The segmentation image created by the source catalog step.
+
+        cat : `astropy.table.Table`
+            The source catalog created by the source catalog step.
+
+        Returns
+        -------
+        result : `ImageModel`, `MosaicModel`, or `SourceCatalog`
+            The source catalog model or the input model with updated
+            metadata.
+        """
         if isinstance(segment_img, np.ndarray):
             # convert the segmentation image to a SegmentationImage
             segment_img = SegmentationImage(segment_img)

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -293,10 +293,21 @@ def test_l3_input_model_unchanged(mosaic_model, tmp_path):
 
 
 @pytest.mark.stpsf
-def test_inputs(mosaic_model):
-    data = np.ones((3, 3), dtype=int)
-    data[1, 1] = 1
-    segm = SegmentationImage(data)
+def test_invalid_step_inputs(image_model, mosaic_model):
+    for input_model in (image_model, mosaic_model):
+        model = input_model.copy()
+        model.data = np.full(model.data.shape, np.nan)
+        step = SourceCatalogStep()
+        result = step.call(model)
+        cat = result.source_catalog
+        assert isinstance(cat, Table)
+        assert len(cat) == 0
+
+
+@pytest.mark.stpsf
+def test_inputs():
+    segm_data = np.ones((3, 3), dtype=int)
+    segm = SegmentationImage(segm_data)
     cdata = np.ones((3, 3))
     kernel_fwhm = 2.0
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1082](https://jira.stsci.edu/browse/RCAL-1082)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Partially addresses #1765
Closes #1768 

<!-- describe the changes comprising this PR here -->
This PR updates the SourceCatalogStep to handle the case where there are no valid pixels in the input image (e.g., all non-finite values or all pixels are masked).  For the issue reported in #1765, the coadd model input to `SourceCatalogStep` has NaN values in every pixel.

As part of this effort, I refactored all the save machinery into a separate function.

The current approach is that the step still saves the same files as usual, but these files are empty or contain all-zeros (segmentation image, and source catalog or input model). If desired, I can update this PR to not save files.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/15146463903

CC: @schlafly 

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
