### PR TITLE
[RCAL-1084] include distortion when matching sky cells to image footprint

### DIFF
--- a/changes/1772.skycell.rst
+++ b/changes/1772.skycell.rst
@@ -1,0 +1,1 @@
+create extra vertices along the edges of the image footprint to account for image distortion

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -43,14 +43,18 @@ class ImageFootprint:
         wcs: WCS,
         extra_vertices_per_edge: int = 0,
     ) -> "ImageFootprint":
-        """
-        create an image footprint from a GWCS object (and image shape, if no bounding box is present)
+        """create an image footprint from a GWCS object (and image shape, if no bounding box is present)
 
         Parameters
         ----------
+        wcs: WCS :
+            WCS object
+        extra_vertices_per_edge: int :
+            extra vertices to create on each edge to capture distortion (Default value = 0)
 
-        wcs: WCS object
-        extra_vertices_per_edge: extra vertices to create on each edge to capture distortion
+        Returns
+        -------
+        image footprint object
         """
 
         # if `.pixel_shape` is not defined, try deriving it from the `.bounding_box`
@@ -195,13 +199,7 @@ class ImageFootprint:
 
     @cached_property
     def possibly_intersecting_projregions(self) -> int:
-        """
-        number of possibly intersecting projection regions
-
-        NOTES
-        -----
-        this assumes a non-degenerate tesselation!
-        """
+        """number of possibly intersecting projection regions"""
         if self.area > sc.SkyCell.area:
             return (
                 # the number of times the smallest projection region could fit in the image footprint
@@ -215,13 +213,7 @@ class ImageFootprint:
 
     @cached_property
     def possibly_intersecting_skycells(self) -> int:
-        """
-        number of possibly intersecting skycells
-
-        NOTES
-        -----
-        this assumes a non-degenerate tesselation!
-        """
+        """number of possibly intersecting skycells"""
         if self.polygon.area() > sc.SkyCell.area:
             return (
                 # number of times a skycell could fit in the image footprint
@@ -254,17 +246,16 @@ def find_skycell_matches(
     image_corners: list[tuple[float, float]] | NDArray[float] | WCS,
     skymap: sc.SkyMap = None,
 ) -> list[int]:
-    """
-    Find sky cells overlapping the provided image footprint
+    """Find sky cells overlapping the provided image footprint
 
     Parameters
     ----------
-    image_corners :
+    image_corners : list | np.ndarray | WCS :
         Either a squence of 4 (ra, dec) pairs, or
         equivalent 2-d numpy array, or a GWCS instance.
         A GWCS instance must have `.bounding_box` or `.pixel_shape` attribute defined.
-    skymap: SkyMap
-        sky map instance (defaults to global SKYMAP)
+    skymap : sc.SkyMap :
+        sky map instance; defaults to global SKYMAP (Default value = None)
 
     Returns
     -------

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -13,7 +13,6 @@ import spherical_geometry.polygon as sgp
 import spherical_geometry.vector as sgv
 from gwcs import WCS
 from numpy.typing import NDArray
-from stcal.alignment.util import wcs_bbox_from_shape
 
 import romancal.skycell.skymap as sc
 
@@ -57,20 +56,13 @@ class ImageFootprint:
         image footprint object
         """
 
-        # if `.pixel_shape` is not defined, try deriving it from the `.bounding_box`
-        if not hasattr(wcs, "pixel_shape") or wcs.pixel_shape is None:
-            if hasattr(wcs, "bounding_box") and wcs.bounding_box is not None:
-                wcs.pixel_shape = wcs_pixel_shape_from_bbox(wcs.bounding_box)
-            else:
-                raise ValueError(
-                    "Cannot infer image footprint from WCS without `.pixel_shape` nor `.bounding_box`."
-                )
+        if not hasattr(wcs, "bounding_box") or wcs.bounding_box is None:
+            raise ValueError(
+                "Cannot infer image footprint from WCS without a bounding box."
+            )
 
         image_shape = wcs.array_shape
         if extra_vertices_per_edge <= 0:
-            if not hasattr(wcs, "bounding_box") or wcs.bounding_box is None:
-                wcs.bounding_box = wcs_bbox_from_shape(image_shape)
-
             vertex_points = wcs.footprint(center=False)
         else:
             # constrain number of vertices to the maximum number of pixels on an edge, excluding the corners

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -77,18 +77,6 @@ class ImageFootprint:
                 extra_vertices_per_edge = max(array_shape) - 2
 
             # build a list of pixel indices that represent equally-spaced edge vertices
-            edge_xs = np.linspace(
-                0,
-                array_shape[0],
-                num=extra_vertices_per_edge + 1,
-                endpoint=False,
-            )
-            edge_ys = np.linspace(
-                0,
-                array_shape[1],
-                num=extra_vertices_per_edge + 1,
-                endpoint=False,
-            )
             edge_indices = np.round(
                 np.concatenate(
                     [
@@ -96,14 +84,24 @@ class ImageFootprint:
                         np.stack(
                             [
                                 [0] * (extra_vertices_per_edge + 1),
-                                edge_ys,
+                                np.linspace(
+                                    0,
+                                    array_shape[1],
+                                    num=extra_vertices_per_edge + 1,
+                                    endpoint=False,
+                                ),
                             ],
                             axis=1,
                         ),
                         # east edge
                         np.stack(
                             [
-                                edge_xs,
+                                np.linspace(
+                                    0,
+                                    array_shape[0],
+                                    num=extra_vertices_per_edge + 1,
+                                    endpoint=False,
+                                ),
                                 [array_shape[1] - 1] * (extra_vertices_per_edge + 1),
                             ],
                             axis=1,
@@ -112,14 +110,24 @@ class ImageFootprint:
                         np.stack(
                             [
                                 [array_shape[0] - 1] * (extra_vertices_per_edge + 1),
-                                list(reversed(edge_ys)),
+                                np.linspace(
+                                    array_shape[1],
+                                    0,
+                                    num=extra_vertices_per_edge + 1,
+                                    endpoint=False,
+                                ),
                             ],
                             axis=1,
                         ),
                         # west edge
                         np.stack(
                             [
-                                list(reversed(edge_xs)),
+                                np.linspace(
+                                    array_shape[0],
+                                    0,
+                                    num=extra_vertices_per_edge + 1,
+                                    endpoint=False,
+                                ),
                                 [0] * (extra_vertices_per_edge + 1),
                             ],
                             axis=1,

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -77,64 +77,28 @@ class ImageFootprint:
                 extra_vertices_per_edge = max(array_shape) - 2
 
             # build a list of pixel indices that represent equally-spaced edge vertices
-            edge_indices = np.round(
-                np.concatenate(
-                    [
-                        # north edge
-                        np.stack(
-                            [
-                                [0] * (extra_vertices_per_edge + 1),
-                                np.linspace(
-                                    0,
-                                    array_shape[1],
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                ),
-                            ],
-                            axis=1,
-                        ),
-                        # east edge
-                        np.stack(
-                            [
-                                np.linspace(
-                                    0,
-                                    array_shape[0],
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                ),
-                                [array_shape[1] - 1] * (extra_vertices_per_edge + 1),
-                            ],
-                            axis=1,
-                        ),
-                        # south edge
-                        np.stack(
-                            [
-                                [array_shape[0] - 1] * (extra_vertices_per_edge + 1),
-                                np.linspace(
-                                    array_shape[1],
-                                    0,
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                ),
-                            ],
-                            axis=1,
-                        ),
-                        # west edge
-                        np.stack(
-                            [
-                                np.linspace(
-                                    array_shape[0],
-                                    0,
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                ),
-                                [0] * (extra_vertices_per_edge + 1),
-                            ],
-                            axis=1,
-                        ),
-                    ],
-                    axis=0,
-                )
+            vertices_per_edge = 2 + extra_vertices_per_edge
+            origin_indices = np.zeros(vertices_per_edge - 1)
+            x_end_indices = array_shape[0] - origin_indices
+            y_end_indices = array_shape[1] - origin_indices
+            vertices_x = np.linspace(
+                0, array_shape[0], num=vertices_per_edge - 1, endpoint=False
+            )
+            vertices_y = np.linspace(
+                0, array_shape[1], num=vertices_per_edge - 1, endpoint=False
+            )
+            edge_indices = np.concatenate(
+                [
+                    # north edge
+                    np.stack([origin_indices, vertices_y], axis=1),
+                    # east edge
+                    np.stack([vertices_x, y_end_indices], axis=1),
+                    # south edge
+                    np.stack([x_end_indices, y_end_indices - vertices_y], axis=1),
+                    # west edge
+                    np.stack([x_end_indices - vertices_x, origin_indices], axis=1),
+                ],
+                axis=0,
             )
 
             # query the WCS for pixel indices at the edges

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -78,7 +78,7 @@ class ImageFootprint:
 
             # build a list of pixel indices that represent equally-spaced edge vertices
             vertices_per_edge = 2 + extra_vertices_per_edge
-            origin_indices = np.zeros(vertices_per_edge - 1)
+            origin_indices = np.zeros(vertices_per_edge - 1) - 0.5
             x_end_indices = array_shape[0] - origin_indices
             y_end_indices = array_shape[1] - origin_indices
             vertices_x = np.linspace(

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -264,7 +264,7 @@ def find_skycell_matches(
     """
 
     if isinstance(image_corners, WCS):
-        footprint = ImageFootprint.from_wcs(image_corners, extra_vertices_per_edge=48)
+        footprint = ImageFootprint.from_wcs(image_corners, extra_vertices_per_edge=3)
     else:
         footprint = ImageFootprint(image_corners)
 

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -105,14 +105,14 @@ class ImageFootprint:
                         np.stack(
                             [
                                 [image_shape[0] - 1] * (extra_vertices_per_edge + 1),
-                                reversed(edge_ys),
+                                list(reversed(edge_ys)),
                             ],
                             axis=1,
                         ),
                         # west edge
                         np.stack(
                             [
-                                reversed(edge_xs),
+                                list(reversed(edge_xs)),
                                 [0] * (extra_vertices_per_edge + 1),
                             ],
                             axis=1,

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -61,24 +61,31 @@ class ImageFootprint:
                 "Cannot infer image footprint from WCS without a bounding box."
             )
 
-        image_shape = wcs.array_shape
+        array_shape = (
+            wcs.array_shape
+            if hasattr(wcs, "array_shape") and wcs.array_shape is not None
+            else tuple(
+                wcs.bounding_box[index][1] - wcs.bounding_box[index][0]
+                for index in range(len(wcs.bounding_box))
+            )
+        )
         if extra_vertices_per_edge <= 0:
             vertex_points = wcs.footprint(center=False)
         else:
             # constrain number of vertices to the maximum number of pixels on an edge, excluding the corners
-            if extra_vertices_per_edge > max(image_shape) - 2:
-                extra_vertices_per_edge = max(image_shape) - 2
+            if extra_vertices_per_edge > max(array_shape) - 2:
+                extra_vertices_per_edge = max(array_shape) - 2
 
             # build a list of pixel indices that represent equally-spaced edge vertices
             edge_xs = np.linspace(
                 0,
-                image_shape[0],
+                array_shape[0],
                 num=extra_vertices_per_edge + 1,
                 endpoint=False,
             )
             edge_ys = np.linspace(
                 0,
-                image_shape[1],
+                array_shape[1],
                 num=extra_vertices_per_edge + 1,
                 endpoint=False,
             )
@@ -97,14 +104,14 @@ class ImageFootprint:
                         np.stack(
                             [
                                 edge_xs,
-                                [image_shape[1] - 1] * (extra_vertices_per_edge + 1),
+                                [array_shape[1] - 1] * (extra_vertices_per_edge + 1),
                             ],
                             axis=1,
                         ),
                         # south edge
                         np.stack(
                             [
-                                [image_shape[0] - 1] * (extra_vertices_per_edge + 1),
+                                [array_shape[0] - 1] * (extra_vertices_per_edge + 1),
                                 list(reversed(edge_ys)),
                             ],
                             axis=1,

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -80,7 +80,7 @@ class ImageFootprint:
                 [
                     np.stack(
                         [
-                            np.repeat(0, repeats=extra_vertices_per_edge + 1),
+                            [0] * (extra_vertices_per_edge + 1),
                             np.round(
                                 np.linspace(
                                     0,
@@ -102,17 +102,13 @@ class ImageFootprint:
                                     endpoint=False,
                                 )
                             ),
-                            np.repeat(
-                                image_shape[1], repeats=extra_vertices_per_edge + 1
-                            ),
+                            [image_shape[1]] * (extra_vertices_per_edge + 1),
                         ],
                         axis=1,
                     ),
                     np.stack(
                         [
-                            np.repeat(
-                                image_shape[0] - 1, repeats=extra_vertices_per_edge + 1
-                            ),
+                            [image_shape[0] - 1] * (extra_vertices_per_edge + 1),
                             np.round(
                                 np.linspace(
                                     image_shape[1],
@@ -134,7 +130,7 @@ class ImageFootprint:
                                     endpoint=False,
                                 )
                             ),
-                            np.repeat(0, repeats=extra_vertices_per_edge + 1),
+                            [0] * (extra_vertices_per_edge + 1),
                         ],
                         axis=1,
                     ),

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -76,71 +76,61 @@ class ImageFootprint:
                 extra_vertices_per_edge = max(image_shape) - 2
 
             # build a list of pixel indices that represent equally-spaced edge vertices
-            edge_pixel_indices = np.concatenate(
-                [
-                    np.stack(
-                        [
-                            [0] * (extra_vertices_per_edge + 1),
-                            np.round(
-                                np.linspace(
-                                    0,
-                                    image_shape[1],
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                )
-                            ),
-                        ],
-                        axis=1,
-                    ),
-                    np.stack(
-                        [
-                            np.round(
-                                np.linspace(
-                                    0,
-                                    image_shape[0],
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                )
-                            ),
-                            [image_shape[1]] * (extra_vertices_per_edge + 1),
-                        ],
-                        axis=1,
-                    ),
-                    np.stack(
-                        [
-                            [image_shape[0] - 1] * (extra_vertices_per_edge + 1),
-                            np.round(
-                                np.linspace(
-                                    image_shape[1],
-                                    0,
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                )
-                            ),
-                        ],
-                        axis=1,
-                    ),
-                    np.stack(
-                        [
-                            np.round(
-                                np.linspace(
-                                    image_shape[0],
-                                    0,
-                                    num=extra_vertices_per_edge + 1,
-                                    endpoint=False,
-                                )
-                            ),
-                            [0] * (extra_vertices_per_edge + 1),
-                        ],
-                        axis=1,
-                    ),
-                ],
-                axis=0,
+            edge_xs = np.linspace(
+                0,
+                image_shape[0],
+                num=extra_vertices_per_edge + 1,
+                endpoint=False,
+            )
+            edge_ys = np.linspace(
+                0,
+                image_shape[1],
+                num=extra_vertices_per_edge + 1,
+                endpoint=False,
+            )
+            edge_indices = np.round(
+                np.concatenate(
+                    [
+                        # north edge
+                        np.stack(
+                            [
+                                [0] * (extra_vertices_per_edge + 1),
+                                edge_ys,
+                            ],
+                            axis=1,
+                        ),
+                        # east edge
+                        np.stack(
+                            [
+                                edge_xs,
+                                [image_shape[1] - 1] * (extra_vertices_per_edge + 1),
+                            ],
+                            axis=1,
+                        ),
+                        # south edge
+                        np.stack(
+                            [
+                                [image_shape[0] - 1] * (extra_vertices_per_edge + 1),
+                                reversed(edge_ys),
+                            ],
+                            axis=1,
+                        ),
+                        # west edge
+                        np.stack(
+                            [
+                                reversed(edge_xs),
+                                [0] * (extra_vertices_per_edge + 1),
+                            ],
+                            axis=1,
+                        ),
+                    ],
+                    axis=0,
+                )
             )
 
             # query the WCS for pixel indices at the edges
             vertex_points = np.stack(
-                wcs(*edge_pixel_indices.T, with_bounding_box=False),
+                wcs(*edge_indices.T, with_bounding_box=False),
                 axis=1,
             )
 

--- a/romancal/skycell/match.py
+++ b/romancal/skycell/match.py
@@ -62,9 +62,7 @@ class ImageFootprint:
                     "Cannot infer image footprint from WCS without `.pixel_shape` nor `.bounding_box`."
                 )
 
-        # pixel_shape is in x, y order contrary to numpy convention.
-        image_shape = (wcs.pixel_shape[1], wcs.pixel_shape[0])
-
+        image_shape = wcs.array_shape
         if extra_vertices_per_edge <= 0:
             if not hasattr(wcs, "bounding_box") or wcs.bounding_box is None:
                 wcs.bounding_box = wcs_bbox_from_shape(image_shape)

--- a/romancal/skycell/plot.py
+++ b/romancal/skycell/plot.py
@@ -195,7 +195,7 @@ def plot_image_footprint_and_skycells(
             sgv.lonlat_to_vector(*projregion.radec_tangent)
         )
         image_corners_tangentplane = veccoords_to_tangent_plane(
-            footprint.vectorpoint_corners,
+            footprint.vectorpoint_vertices,
             tangent_vectorpoint,
         )
         plot_field(image_corners_tangentplane, fill="lightgrey", color="black")

--- a/romancal/skycell/plot.py
+++ b/romancal/skycell/plot.py
@@ -37,7 +37,7 @@ def find_intersecting_projregions(
     Parameters
     ----------
     footprint: sm.ImageFootprint :
-        sequence of 4 points (ra, dec) or an `ImageFootprint` object
+        sequence of points (ra, dec) or an `ImageFootprint` object
     skymap: sc.SkyMap :
         sky map instance; defaults to global SKYMAP (Default value = None)
 
@@ -166,7 +166,7 @@ def plot_image_footprint_and_skycells(
     Parameters
     ----------
     footprint : list | sm.ImageFootprint :
-        sequence of 4 points (ra, dec) or an `ImageFootprint` object
+        sequence of points (ra, dec) or an `ImageFootprint` object
     skymap : sc.SkyMap :
         sky map instance; defaults to global SKYMAP (Default value = None)
     """

--- a/romancal/skycell/plot.py
+++ b/romancal/skycell/plot.py
@@ -32,13 +32,14 @@ def find_intersecting_projregions(
     footprint: sm.ImageFootprint,
     skymap: sc.SkyMap = None,
 ) -> list[int]:
-    """
-    Out of all projection regions, find ones that intersect the given image footprint
+    """Out of all projection regions, find ones that intersect the given image footprint
 
     Parameters
     ----------
-    footprint: sequence of 4 points (ra, dec) or an `ImageFootprint` object
-    skymap: sky map instance (defaults to global SKYMAP)
+    footprint: sm.ImageFootprint :
+        sequence of 4 points (ra, dec) or an `ImageFootprint` object
+    skymap: sc.SkyMap :
+        sky map instance; defaults to global SKYMAP (Default value = None)
 
     Returns
     -------
@@ -69,8 +70,7 @@ def veccoords_to_tangent_plane(
     vertices: list[tuple[float, float, float]],
     tangent_vectorpoint: tuple[float, float, float],
 ) -> NDArray[float]:
-    """
-    Convert the spherical geometry vectors to tangent plane coordinates
+    """Convert the spherical geometry vectors to tangent plane coordinates
     in arcseconds. This algorithm is not precise, but should be good
     enough for now (and besides, the goal here is visualizaion, not
     ultra-precision). This also breaks down numerically very near the
@@ -159,16 +159,16 @@ def plot_image_footprint_and_skycells(
     footprint: list[tuple[float, float]] | sm.ImageFootprint,
     skymap: sc.SkyMap = None,
 ) -> list[tuple[Axis, tuple[float, float, float]]]:
-    """
-    This plots a list of skycell footprints against the image footprint.
+    """This plots a list of skycell footprints against the image footprint.
 
     Both the touched skycells as well as nearby skycells are plotted.
 
-
     Parameters
     ----------
-    footprint: sequence of 4 points (ra, dec) or an `ImageFootprint` object
-    skymap: sky map instance (defaults to global SKYMAP)
+    footprint : list | sm.ImageFootprint :
+        sequence of 4 points (ra, dec) or an `ImageFootprint` object
+    skymap : sc.SkyMap :
+        sky map instance; defaults to global SKYMAP (Default value = None)
     """
 
     if not isinstance(footprint, sm.ImageFootprint):

--- a/romancal/skycell/skymap.py
+++ b/romancal/skycell/skymap.py
@@ -27,9 +27,7 @@ __all__ = ["SKYMAP", "ProjectionRegion", "SkyCell", "SkyMap"]
 
 
 class SkyCell:
-    """
-    Square subregion of a projection region, 4.6 arcminutes per side.
-    """
+    """Square subregion of a projection region, 4.6 arcminutes per side."""
 
     _index: int | None
     _data: np.void
@@ -60,15 +58,14 @@ class SkyCell:
 
     @classmethod
     def from_name(cls, name: str, skymap: "SkyMap" = None) -> "SkyCell":
-        """
-        Retrieve a sky cell from the sky map by its name (see handbook [1] for explanation).
+        """Retrieve a sky cell from the sky map by its name (see handbook [1] for explanation).
 
         Parameters
         ----------
         name : str
             Name of a sky cell, for instance `315p86x50y75`.
-        skymap: SkyMap
-            sky map instance (defaults to global SKYMAP)
+        skymap : SkyMap
+            sky map instance; defaults to global SKYMAP (Default value = None)
 
         References
         ----------
@@ -90,15 +87,14 @@ class SkyCell:
 
     @classmethod
     def from_data(cls, data: np.void, skymap: "SkyMap" = None) -> "SkyCell":
-        """
-        build an index-less sky cell instance from a data array
+        """build an index-less sky cell instance from a data array
 
         Parameters
         ----------
-        data : numpy.void
+        data : np.void
             array with sky cell parameters (see schema)
         skymap: SkyMap
-            sky map instance (defaults to global SKYMAP)
+            sky map instancel; defaults to global SKYMAP (Default value = None)
         """
         instance = cls(index=None, skymap=skymap)
         instance._data = data
@@ -106,8 +102,7 @@ class SkyCell:
 
     @classmethod
     def from_asn(cls, asn: dict | str, skymap: "SkyMap" = None) -> "SkyCell":
-        """
-        retrieve a sky cell from WCS info or a target specified in an association
+        """retrieve a sky cell from WCS info or a target specified in an association
 
         Attempts to find a sky cell name from the following in order:
             - `skycell_wcs_info.name`
@@ -118,7 +113,7 @@ class SkyCell:
         asn : dict | str
             association dictionary or a path to an association file to load
         skymap: SkyMap
-            sky map instance (defaults to global SKYMAP)
+            sky map instance; defaults to global SKYMAP (Default value = None)
         """
 
         if isinstance(asn, str | os.PathLike):
@@ -143,8 +138,7 @@ class SkyCell:
 
     @property
     def data(self) -> np.void:
-        """
-        Sky cell data.
+        """Sky cell data.
 
         ("name", "ra_center", "dec_center", "orientat", "x_tangent", "y_tangent", "ra_corn1", "dec_corn1", "ra_corn2", "dec_corn2", "ra_corn3", "dec_corn3", "ra_corn4", "dec_corn4")
         """
@@ -154,8 +148,7 @@ class SkyCell:
 
     @property
     def name(self) -> str:
-        """
-        name of this sky cell, for instance `315p86x50y75`
+        """name of this sky cell, for instance `315p86x50y75`
 
         NOTE
         ----
@@ -313,15 +306,14 @@ class ProjectionRegion:
 
     @classmethod
     def from_data(cls, data: np.void, skymap: "SkyMap" = None) -> "ProjectionRegion":
-        """
-        build a projection region instance from a data array
+        """build a projection region instance from a data array
 
         Parameters
         ----------
         data : numpy.void
             array with projection region parameters (see schema)
         skymap: SkyMap
-            sky map instance (defaults to global SKYMAP)
+            sky map instance; defaults to global SKYMAP (Default value = None)
         """
         instance = cls(index=data["index"], skymap=skymap)
         instance._data = data
@@ -336,8 +328,8 @@ class ProjectionRegion:
         ----------
         index : int
             index of the sky cell
-        skymap: SkyMap
-            sky map instance (defaults to global SKYMAP)
+        skymap : SkyMap
+            sky map instance; defaults to global SKYMAP (Default value = None)
 
         Returns
         -------
@@ -369,8 +361,7 @@ class ProjectionRegion:
 
     @property
     def data(self) -> np.void:
-        """
-        Projection region data.
+        """Projection region data.
 
         ("index", "ra_tangent", "dec_tangent", "ra_min", "ra_max", "dec_min", "dec_max", "orientat", "x_tangent", "y_tangent", "nx", "ny", "skycell_start", "skycell_end")
         """
@@ -412,8 +403,7 @@ class ProjectionRegion:
 
     @cached_property
     def skycells_kdtree(self) -> KDTree:
-        """
-        LOCAL k-d tree of skycells in this projection region, using normalized center vectorpoints in 3D space
+        """LOCAL k-d tree of skycells in this projection region, using normalized center vectorpoints in 3D space
 
         NOTE
         ----
@@ -514,8 +504,7 @@ class ProjectionRegion:
 
 
 class SkyMap:
-    """
-    Abstract representation of the sky map, comprising of 4058 overlapping rectangular "projection regions" defining gnomonic projection on to uniform pixel grids.
+    """Abstract representation of the sky map, comprising of 4058 overlapping rectangular "projection regions" defining gnomonic projection on to uniform pixel grids.
     The pixel scale for all projection regions is identical.
 
     Each projection region is subdivided into ~2000 square subregions ("sky cells", ~8 million in total), each 4.6' across. These sky cells also overlap each other by a standard number of pixels.
@@ -570,8 +559,7 @@ class SkyMap:
 
     @cached_property
     def skycells_kdtree(self) -> KDTree:
-        """
-        k-d tree of all skycells in the skymap, using normalized center vectorpoints in 3D space
+        """k-d tree of all skycells in the skymap, using normalized center vectorpoints in 3D space
 
         NOTE
         ----

--- a/romancal/skycell/tests/test_skycell_match.py
+++ b/romancal/skycell/tests/test_skycell_match.py
@@ -122,7 +122,7 @@ def mk_gwcs(ra, dec, pa, bounding_box=None) -> WCS:
         wcsobj.bounding_box = bounding_box
         wcsobj.array_shape = tuple(
             int(bounding_box[index][1] - bounding_box[index][0])
-            for index in range(len(bounding_box), 0, -1)
+            for index in range(len(bounding_box))
         )
     return wcsobj
 

--- a/romancal/skycell/tests/test_skycell_match.py
+++ b/romancal/skycell/tests/test_skycell_match.py
@@ -470,46 +470,9 @@ def test_skycell_match(
         )
     ],
 )
-def test_match_from_wcs(test_point, expected_skycell_names, skymap_subset):
-    wcsobj = mk_gwcs(*test_point, 45)
-    imshape = (4096, 4096)
-
-    intersecting_skycells = sm.find_skycell_matches(
-        wcsobj, image_shape=imshape, skymap=skymap_subset
-    )
-
-    skycell_names = np.array(
-        [skymap_subset.model.skycells[index]["name"] for index in intersecting_skycells]
-    ).tolist()
-
-    assert skycell_names == expected_skycell_names
-
-
-@pytest.mark.parametrize(
-    "test_point,expected_skycell_names",
-    [
-        (
-            TEST_POINTS[1],
-            [
-                "000p86x62y69",
-                "000p86x62y68",
-                "000p86x61y69",
-                "000p86x61y68",
-                "000p86x63y69",
-                "000p86x61y70",
-                "000p86x62y67",
-                "000p86x60y68",
-                "045p86x37y69",
-                "045p86x37y68",
-                "045p86x38y69",
-            ],
-        )
-    ],
-)
 def test_match_from_wcs_with_imshape(test_point, expected_skycell_names, skymap_subset):
     wcsobj = mk_gwcs(*test_point, 45)
-    imshape = (4096, 4096)
-    wcsobj.pixel_shape = imshape
+    wcsobj.pixel_shape = (4096, 4096)
 
     intersecting_skycells = sm.find_skycell_matches(wcsobj, skymap=skymap_subset)
 

--- a/romancal/skycell/tests/test_skycell_match.py
+++ b/romancal/skycell/tests/test_skycell_match.py
@@ -458,8 +458,8 @@ def test_skycell_match(
             TEST_POINTS[1],
             [
                 "000p86x62y69",
-                "000p86x62y68",
                 "000p86x61y69",
+                "000p86x62y68",
                 "000p86x61y68",
                 "000p86x63y69",
                 "000p86x61y70",

--- a/romancal/skycell/tests/test_skycell_match.py
+++ b/romancal/skycell/tests/test_skycell_match.py
@@ -99,7 +99,7 @@ def mk_im_corners(
     return radecrect
 
 
-def mk_gwcs(ra, dec, pa, bounding_box=None, pixel_shape=None) -> WCS:
+def mk_gwcs(ra, dec, pa, bounding_box=None) -> WCS:
     """
     Construct a GWCS model for testing the patch matching when provided a WCS
     This just implements a basic tangent projection with specified ra, dec, and
@@ -118,10 +118,12 @@ def mk_gwcs(ra, dec, pa, bounding_box=None, pixel_shape=None) -> WCS:
         reference_frame=coord.ICRS(), name="icrs", unit=(u.deg, u.deg)
     )
     wcsobj = WCS([(detector_frame, transform), (sky_frame, None)])
-    if pixel_shape is not None:
-        wcsobj.pixel_shape = pixel_shape
     if bounding_box is not None:
         wcsobj.bounding_box = bounding_box
+        wcsobj.array_shape = tuple(
+            int(bounding_box[index][1] - bounding_box[index][0])
+            for index in range(len(bounding_box), 0, -1)
+        )
     return wcsobj
 
 
@@ -475,7 +477,6 @@ def test_match_from_wcs_with_bbox(test_point, expected_skycell_names, skymap_sub
         *test_point,
         45,
         bounding_box=((-0.5, 4096 - 0.5), (-0.5, 4096 - 0.5)),
-        pixel_shape=(4096, 4096),
     )
 
     intersecting_skycells = sm.find_skycell_matches(wcsobj, skymap=skymap_subset)

--- a/romancal/skycell/tests/test_skycell_match.py
+++ b/romancal/skycell/tests/test_skycell_match.py
@@ -470,43 +470,13 @@ def test_skycell_match(
         )
     ],
 )
-def test_match_from_wcs_with_imshape(test_point, expected_skycell_names, skymap_subset):
-    wcsobj = mk_gwcs(*test_point, 45)
-    wcsobj.pixel_shape = (4096, 4096)
-
-    intersecting_skycells = sm.find_skycell_matches(wcsobj, skymap=skymap_subset)
-
-    skycell_names = np.array(
-        [skymap_subset.model.skycells[index]["name"] for index in intersecting_skycells]
-    ).tolist()
-
-    assert skycell_names == expected_skycell_names
-
-
-@pytest.mark.parametrize(
-    "test_point,expected_skycell_names",
-    [
-        (
-            TEST_POINTS[1],
-            [
-                "000p86x62y69",
-                "000p86x62y68",
-                "000p86x61y69",
-                "000p86x61y68",
-                "000p86x63y69",
-                "000p86x61y70",
-                "000p86x62y67",
-                "000p86x60y68",
-                "045p86x37y69",
-                "045p86x37y68",
-                "045p86x38y69",
-            ],
-        )
-    ],
-)
 def test_match_from_wcs_with_bbox(test_point, expected_skycell_names, skymap_subset):
-    wcsobj = mk_gwcs(*test_point, 45)
-    wcsobj.bounding_box = ((-0.5, 4096 - 0.5), (-0.5, 4096 - 0.5))
+    wcsobj = mk_gwcs(
+        *test_point,
+        45,
+        bounding_box=((-0.5, 4096 - 0.5), (-0.5, 4096 - 0.5)),
+        pixel_shape=(4096, 4096),
+    )
 
     intersecting_skycells = sm.find_skycell_matches(wcsobj, skymap=skymap_subset)
 
@@ -518,9 +488,8 @@ def test_match_from_wcs_with_bbox(test_point, expected_skycell_names, skymap_sub
 
 
 @pytest.mark.parametrize("test_point", [TEST_POINTS[1]])
-def test_match_from_wcs_without_imshape_or_bbox(test_point):
+def test_match_from_wcs_without_bbox(test_point):
     wcsobj = mk_gwcs(*test_point, 45)
-    wcsobj.bounding_box = None
 
     with pytest.raises(ValueError):
         sm.find_skycell_matches(wcsobj, skymap=skymap_subset)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1084](https://jira.stsci.edu/browse/RCAL-1084)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue referenced in https://github.com/spacetelescope/romancal/issues/1765, namely that the image footprint is not necessarily a rectangle with perfectly straight sides; rather, it may be distorted (modeled by the WCS).

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
