### PR TITLE
strip read tags when ramp step constructs the output image model

### DIFF
--- a/changes/1785.ramp_fitting.rst
+++ b/changes/1785.ramp_fitting.rst
@@ -1,0 +1,1 @@
+Use ``ImageModel.create_minimal`` to create output model.

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -189,6 +189,7 @@ def create_image_model(input_model, image_info):
     im = rdm.ImageModel()
     # use getitem here to avoid copying the DNode
     im.meta = copy.deepcopy(input_model["meta"])
+    im.meta.model_type = "ImageModel"
     # since we've copied nodes let's remove any "read" tags
     for node in asdf.treeutil.iter_tree(im):
         if hasattr(node, "_read_tag"):

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -2,9 +2,11 @@
 #
 from __future__ import annotations
 
+import copy
 import logging
 from typing import TYPE_CHECKING
 
+import asdf
 import numpy as np
 from roman_datamodels import datamodels as rdm
 from roman_datamodels import stnode
@@ -184,11 +186,13 @@ def create_image_model(input_model, image_info):
         The output ``ImageModel`` to be returned from the ramp fit step.
     """
     data, dq, var_poisson, var_rnoise, err = image_info
-    im = rdm.ImageModel.create_minimal(
-        {
-            "meta": input_model.meta,
-        }
-    )
+    im = rdm.ImageModel()
+    # use getitem here to avoid copying the DNode
+    im.meta = copy.deepcopy(input_model["meta"])
+    # since we've copied nodes let's remove any "read" tags
+    for node in asdf.treeutil.iter_tree(im):
+        if hasattr(node, "_read_tag"):
+            del node._read_tag
     im.meta.product_type = "l2"
     im.meta.cal_step = stnode.L2CalStep.create_minimal(input_model.meta.cal_step)
     im.meta.cal_logs = stnode.CalLogs.create_minimal()


### PR DESCRIPTION
This PR addresses a few failures in the devdeps due to existing rad changes. Here is the latest run showing several failures for ramp fitting due to a tag mismatch:
https://github.com/spacetelescope/RegressionTests/actions/runs/15430372053

This PR updates ramp fitting to copy the input nodes and strip their "read tags" to allow them to be saved with the newest tag versions.

Regtests with this PR: https://github.com/spacetelescope/RegressionTests/actions/runs/15443040145
show 1 failure for the elp run of tvac data:
```
{'dictionary_item_removed': ["root['roman']['meta']['cal_step']['jump']", "root['roman']['meta']['cal_step']['source_detection']"]}
```
showing that the output image model now no longer contains cal_step entries for the non-existent jump and source_detection steps.

I think it makes sense to also update the rad pin in roman_datamodels back to "main" so that rad changes result in nightly instead of devdeps failures. https://github.com/spacetelescope/roman_datamodels/pull/528

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
