### PR TITLE
[scripts] remove `typer` dependency from `roman_static_preview` by using builtin `argparse` instead, and reorder CLI arguments

### DIFF
--- a/changes/1788.scripts.rst
+++ b/changes/1788.scripts.rst
@@ -1,0 +1,1 @@
+remove `typer` dependency from `roman_static_preview` script (use builtin `argparse` instead), and reorder CLI arguments (see docs)

--- a/docs/roman/pipeline_static_preview.rst
+++ b/docs/roman/pipeline_static_preview.rst
@@ -74,8 +74,7 @@ Examples
 using ``stpreview`` directly
 ----------------------------
 
-The ``roman_static_preview`` script is merely a wrapper over ``stpreview to``, which
-offers more options for fine-grained control of the output image. ``stpreview`` offers
-the ``to`` and ``by`` commands (for resampling ``to`` a desired image shape, or ``by``
-a desired factor, respectively). Refer to `the documentation <https://github.com/spacetelescope/stpreview#usage>`_
-for usage instructions.
+The ``roman_static_preview`` script is merely a wrapper over ``stpreview INPUT OUTPUT to SHAPE``,
+filling in defaults for previews and thumbnails. ``stpreview`` offers the ``to`` and ``by`` commands
+(for resampling ``to`` a desired image shape, or ``by`` a desired factor, respectively).
+Refer to `its documentation <https://github.com/spacetelescope/stpreview#usage>`_ for usage instructions.

--- a/docs/roman/pipeline_static_preview.rst
+++ b/docs/roman/pipeline_static_preview.rst
@@ -32,49 +32,41 @@ default options to the static preview requirements.
 
 .. code-block:: shell
 
-	❯ roman_static_preview preview --help
-	Usage: roman_static_preview preview [OPTIONS] INPUT [OUTPUT] [SHAPE]...
+	❯ roman_static_preview input.asdf output.png preview --help
+	usage: roman_static_preview INPUT OUTPUT preview [-h] [--no-compass] SHAPE [SHAPE ...]
 
-	  create a preview image with a north arrow overlay indicating orientation
+	positional arguments:
+	  SHAPE         desired pixel shape of output image
 
-	Arguments:
-	  INPUT       path to ASDF file with 2D image data  [required]
-	  [OUTPUT]    path to output image file
-	  [SHAPE]...  desired pixel resolution of output image  [default: 1080, 1080]
-
-	Options:
-	  --compass / --no-compass  whether to draw a north arrow on the image
-	                            [default: compass]
-	  --help                    Show this message and exit.
+	options:
+	  -h, --help    show this help message and exit
+	  --no-compass  do not draw a north arrow on the image
 
 .. code-block:: shell
 
 	❯ roman_static_preview thumbnail --help
-	Usage: roman_static_preview thumbnail [OPTIONS] INPUT [OUTPUT] [SHAPE]...
+	usage: roman_static_preview INPUT OUTPUT thumbnail [-h] [--compass] SHAPE [SHAPE ...]
 
-	Arguments:
-	  INPUT       path to ASDF file with 2D image data  [required]
-	  [OUTPUT]    path to output image file
-	  [SHAPE]...  desired pixel resolution of output image  [default: 300, 300]
+	positional arguments:
+	  SHAPE       desired pixel shape of output image
 
-	Options:
-	  --compass / --no-compass  whether to draw a north arrow on the image
-	                            [default: no-compass]
-	  --help                    Show this message and exit.
+	options:
+	  -h, --help  show this help message and exit
+	  --compass   draw a north arrow on the image
 
 Examples
 --------
 
 .. code-block:: shell
 
-	roman_static_preview preview r0000501001001001001_0001_wfi01_cal.asdf r0000501001001001001_0001_wfi01_cal.png 400 400
+	roman_static_preview r0000501001001001001_0001_wfi01_cal.asdf r0000501001001001001_0001_wfi01_cal.png preview 400 400
 
 .. image:: ../images/r0000501001001001001_0001_wfi01_cal.png
    :alt: preview of Roman imagery, with compass rose showing orientation
 
 .. code-block:: shell
 
-	roman_static_preview thumbnail r0000501001001001001_0001_wfi01_cal.asdf r0000501001001001001_0001_wfi01_cal_thumb.png
+	roman_static_preview r0000501001001001001_0001_wfi01_cal.asdf r0000501001001001001_0001_wfi01_cal_thumb.png thumbnail
 
 .. image:: ../images/r0000501001001001001_0001_wfi01_cal_thumb.png
    :alt: thumbnail of Roman imagery

--- a/romancal/scripts/static_preview.py
+++ b/romancal/scripts/static_preview.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 
 import asdf
@@ -6,9 +7,6 @@ import numpy
 
 def command():
     try:
-        from typing import Annotated
-
-        import typer
         from stpreview.downsample import downsample_asdf_to
         from stpreview.image import (
             north_pole_angle,
@@ -20,89 +18,75 @@ def command():
             'SDP requirements not installed; do `pip install "romancal[sdp]"`'
         ) from err
 
-    app = typer.Typer()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("INPUT", type=Path, help="path to ASDF file with 2D image data")
+    parser.add_argument("OUTPUT", type=Path, help="path to output image file")
 
-    @app.command()
-    def preview(
-        input: Annotated[
-            Path, typer.Argument(help="path to ASDF file with 2D image data")
-        ],
-        output: Annotated[
-            Path | None, typer.Argument(help="path to output image file")
-        ] = None,
-        shape: Annotated[
-            tuple[int, int] | None,
-            typer.Argument(help="desired pixel resolution of output image"),
-        ] = (1080, 1080),
-        compass: Annotated[
-            bool | None,
-            typer.Option(help="whether to draw a north arrow on the image"),
-        ] = True,
-    ):
-        """
-        create a preview image with a north arrow overlay indicating orientation
-        """
+    subparsers = parser.add_subparsers(dest="subcommand")
 
-        if output is None:
-            output = Path.cwd()
-        if output.is_dir():
-            output = output / f"{input.stem}.png"
+    preview_parser = subparsers.add_parser(
+        "preview", help="downsample the given ASDF image by the given integer factor"
+    )
+    preview_parser.add_argument(
+        "SHAPE",
+        type=int,
+        nargs="+",
+        default=(1080, 1080),
+        help="desired pixel shape of output image",
+    )
+    preview_parser.add_argument(
+        "--no-compass",
+        action="store_true",
+        help="do not draw a north arrow on the image",
+    )
 
-        with asdf.open(input) as file:
-            model = file["roman"]["meta"]["model_type"]
-            if "image" not in model.lower() and "mosaic" not in model.lower():
-                raise NotImplementedError(f'"{model}" model not supported')
-            wcs = file["roman"]["meta"]["wcs"]
+    thumbnail_parser = subparsers.add_parser(
+        "thumbnail",
+        help="downsample the given ASDF image to the desired shape (the output image may be smaller than the desired shape, if no even factor exists)",
+    )
+    thumbnail_parser.add_argument(
+        "SHAPE",
+        type=int,
+        nargs="+",
+        default=(300, 300),
+        help="desired pixel shape of output image",
+    )
+    thumbnail_parser.add_argument(
+        "--compass",
+        action="store_true",
+        help="draw a north arrow on the image",
+    )
 
-        data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
+    arguments = parser.parse_args()
 
-        write_image(
-            data,
-            output,
-            shape=shape,
-            normalization=percentile_normalization(data, percentile=90),
-            colormap="afmhot",
-            north_arrow_angle=north_pole_angle(wcs).degree - 90,
+    output = arguments.OUTPUT
+    if output is None:
+        output = Path.cwd()
+    if output.is_dir():
+        output = (
+            output / f"{input.stem}.png"
+            if arguments.subcommand == "preview"
+            else f"{input.stem}_thumb.png"
         )
 
-    @app.command()
-    def thumbnail(
-        input: Annotated[
-            Path, typer.Argument(help="path to ASDF file with 2D image data")
-        ],
-        output: Annotated[
-            Path | None, typer.Argument(help="path to output image file")
-        ] = None,
-        shape: Annotated[
-            tuple[int, int] | None,
-            typer.Argument(help="desired pixel resolution of output image"),
-        ] = (300, 300),
-        compass: Annotated[
-            bool | None,
-            typer.Option(help="whether to draw a north arrow on the image"),
-        ] = False,
-    ):
-        if output is None:
-            output = Path.cwd()
-        if output.is_dir():
-            output = output / f"{input.stem}_thumb.png"
+    with asdf.open(arguments.INPUT) as file:
+        model = file["roman"]["meta"]["model_type"]
+        if "image" not in model.lower() and "mosaic" not in model.lower():
+            raise NotImplementedError(f'"{model}" model not supported')
+        wcs = file["roman"]["meta"]["wcs"]
 
-        with asdf.open(input) as file:
-            model = file["roman"]["meta"]["model_type"]
-            if "image" not in model.lower() and "mosaic" not in model.lower():
-                raise NotImplementedError(f'"{model}" model not supported')
+    data = downsample_asdf_to(input=input, shape=arguments.SHAPE, func=numpy.nanmean)
 
-        data = downsample_asdf_to(input=input, shape=shape, func=numpy.nanmean)
-
-        write_image(
-            data,
-            output,
-            shape=shape,
-            normalization=percentile_normalization(data, percentile=90),
-            colormap="afmhot",
-        )
-
-    app()
+    write_image(
+        data,
+        output,
+        shape=arguments.SHAPE,
+        normalization=percentile_normalization(data, percentile=90),
+        colormap="afmhot",
+        north_arrow_angle=north_pole_angle(wcs).degree - 90
+        if arguments.subcommand == "preview"
+        else None,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR removes the dependence on Typer from the `roman_static_preview` script by using the builtin `argparse` instead. This change also reorders the order of CLI arguments so that the choice of subcommand `preview` or `thumbnail` goes AFTER the input and output paths:

```diff
- roman_static_preview preview [--no-compass] INPUT [OUTPUT] [SHAPE]...
+ roman_static_preview INPUT OUTPUT preview [--no-compass] SHAPE...
```

```diff
- roman_static_preview thumbnail [--compass] INPUT [OUTPUT] [SHAPE]...
+ roman_static_preview INPUT OUTPUT thumbnail [--compass] SHAPE...
```

examples of how real usages of `stpreview` change:
```diff
- roman_static_preview preview image.asdf image.png
+ roman_static_preview image.asdf image.png preview
- roman_static_preview thumbnail image.asdf image_thumb.png
+ roman_static_preview image.asdf image_thumb.png thumbnail
```

**As this is a breaking CLI change, we will need to consult with downstream people who are using `roman_static_preview` to ask them to reorder their arguments in their scripts.**

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
