### PR TITLE
remove use of stpipe log delegator

### DIFF
--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -6,16 +6,18 @@ A requirement for the larger mission verification project is to have
 tests tied to reqirements.
 """
 
+import logging
 from pathlib import Path
 
 import pytest
 import roman_datamodels as rdm
-from stpipe import log as stpipe_log
 
 from romancal.lib.suffix import replace_suffix
 from romancal.ramp_fitting import RampFitStep
 
 from .regtestdata import compare_asdf
+
+logger = logging.getLogger(__name__)
 
 
 def log_result(requirement, message, result):
@@ -32,7 +34,6 @@ def log_result(requirement, message, result):
     result : bool
         The result of the test
     """
-    logger = stpipe_log.delegator.log
     result_text = "PASS" if result else "FAIL"
     log_msg = f"{requirement} MSG: {message}.......{result_text}"
     logger.info(log_msg)


### PR DESCRIPTION
This PR removes use of `stpipe.log.delegator` in the ramp fitting regtests and replaces it with a named logger. `stpipe.log.delegator` has issues (and is incompatible with python 3.13.4 and 3.13.5) and the logging usage here better fits a named logger.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/15713445434

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
