### PR TITLE
remove description of non-working logging configuration

### DIFF
--- a/changes/1805.docs.rst
+++ b/changes/1805.docs.rst
@@ -1,0 +1,1 @@
+Remove description of non-working step-specific log configuration.

--- a/docs/roman/stpipe/user_logging.rst
+++ b/docs/roman/stpipe/user_logging.rst
@@ -40,18 +40,8 @@ ignored:
 
     - ``/etc/stpipe-log.cfg``
 
-The logging configuration file is in the standard ini-file format.
-
-Each section name is a Unix-style filename glob pattern used to match
-a particular Step’s logger.  The settings in that section apply only
-to that Steps that match that pattern.  For example, to have the
-settings apply to all steps, create a section called ``[*]``.  To have
-the settings apply only to a Step called ``MyStep``, create a section
-called ``[*.MyStep]``.  To apply settings to all Steps that are
-substeps of a step called ``MyStep``, call the section
-``[*.MyStep.*]``.
-
-In each section, the following may be configured:
+The logging configuration file is in the standard ini-file format
+and should have a single section called ``[*]`` that contains:
 
     - ``level``: The level at and above which logging messages will be
       displayed.  May be one of (from least important to most
@@ -84,8 +74,8 @@ In each section, the following may be configured:
       <https://docs.python.org/3/library/logging.html#logrecord-attributes>`_
       section of the Python standard library.
 
-Examples
-========
+Example
+=======
 
 The following configuration turns on all log messages and saves them
 in the file myrun.log:
@@ -95,16 +85,3 @@ in the file myrun.log:
     [*]
     level = INFO
     handler = file:myrun.log
-
-In a scenario where the user is debugging a particular Step, they may
-want to hide all logging messages except for that Step, and stop when
-hitting any warning for that Step:
-
-.. code-block:: ini
-
-    [*]
-    level = CRITICAL
-
-    [*.MyStep]
-    level = INFO
-    break_level = WARNING


### PR DESCRIPTION
This PR cleans up the docs section pertaining to logging configuration removing descriptions of per-step configuration (which does not work: https://github.com/spacetelescope/stpipe/issues/241).

Link to updated page: https://roman-pipeline--1805.org.readthedocs.build/en/1805/roman/stpipe/user_logging.html

As this is only a docs change no regtests will be run.

xref: https://github.com/spacetelescope/jwst/pull/9565

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
