### PR TITLE
Skip retrieval of ePSF reference file if fit_psf=False

### DIFF
--- a/changes/1823.source_catalog.rst
+++ b/changes/1823.source_catalog.rst
@@ -1,0 +1,1 @@
+Retrieval of ePSF reference file is skipped if fit_psf is set to False.

--- a/romancal/multiband_catalog/multiband_catalog_step.py
+++ b/romancal/multiband_catalog/multiband_catalog_step.py
@@ -155,11 +155,15 @@ class MultibandCatalogStep(RomanStep):
                         | (model.err <= 0)
                     )
 
-                    filter_name = model.meta.basic.optical_element  # L3
-                    log.info(f"Creating catalog for {filter_name} image")
-                    ref_file = self.get_reference_file(model, "epsf")
-                    self.log.info("Using ePSF reference file: %s", ref_file)
-                    psf_ref_model = datamodels.open(ref_file)
+                    if self.fit_psf:
+                        filter_name = model.meta.basic.optical_element  # L3
+                        log.info(f"Creating catalog for {filter_name} image")
+                        ref_file = self.get_reference_file(model, "epsf")
+                        self.log.info("Using ePSF reference file: %s", ref_file)
+                        psf_ref_model = datamodels.open(ref_file)
+                    else:
+                        psf_ref_model = None
+
                     catobj = RomanSourceCatalog(
                         model,
                         segment_img,

--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -123,6 +123,12 @@ class RomanSourceCatalog:
             u.Unit(self.flux_unit)
         )
 
+        if self.fit_psf and self.psf_ref_model is None:
+            log.error(
+                "PSF fitting is requested but no PSF reference model is provided. Skipping PSF photometry."
+            )
+            self.fit_psf = False
+
     def __len__(self):
         return self.n_sources
 

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -61,9 +61,12 @@ class SourceCatalogStep(RomanStep):
             raise ValueError("The input model must be an ImageModel or MosaicModel.")
 
         # get the name of the psf reference file
-        self.ref_file = self.get_reference_file(input_model, "epsf")
-        self.log.info("Using ePSF reference file: %s", self.ref_file)
-        psf_ref_model = datamodels.open(self.ref_file)
+        if self.fit_psf:
+            self.ref_file = self.get_reference_file(input_model, "epsf")
+            self.log.info("Using ePSF reference file: %s", self.ref_file)
+            psf_ref_model = datamodels.open(self.ref_file)
+        else:
+            psf_ref_model = None
 
         # Define a boolean mask for pixels to be excluded
         mask = (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1102](https://jira.stsci.edu/browse/RCAL-1102)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1824

<!-- describe the changes comprising this PR here -->
The ePSF files are not used unless PSF fitting is performed.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
