### PR TITLE
Add multiband catalog tests with PSF fitting

### DIFF
--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -64,6 +64,7 @@ def library_model(mosaic_model):
     return ModelLibrary([mosaic_model, model2])
 
 
+@pytest.mark.parametrize("fit_psf", (True, False))
 @pytest.mark.parametrize(
     "snr_threshold, npixels, save_results",
     (
@@ -72,7 +73,7 @@ def library_model(mosaic_model):
     ),
 )
 def test_multiband_catalog(
-    library_model, snr_threshold, npixels, save_results, tmp_path
+    library_model, fit_psf, snr_threshold, npixels, save_results, tmp_path
 ):
     os.chdir(tmp_path)
     step = MultibandCatalogStep()
@@ -82,7 +83,7 @@ def test_multiband_catalog(
         bkg_boxsize=50,
         snr_threshold=snr_threshold,
         npixels=npixels,
-        fit_psf=False,
+        fit_psf=fit_psf,
         save_results=save_results,
     )
 

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -54,6 +54,8 @@ def mosaic_model():
     model.weight = 1.0 / err
     model.meta.basic.optical_element = "F184"
     model.meta.basic.time_first_mjd = Time("2027-01-01T00:00:00").mjd
+    model.meta.wcsinfo.pixel_scale = 0.11 / 3600  # degrees
+    model.meta.resample.pixfrac = 0.5
     return model
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1103](https://jira.stsci.edu/browse/RCAL-1103)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1826

<!-- describe the changes comprising this PR here -->
This PR adds multiband catalog tests with PSF fitting.  This is not a fix, but adds tests to show the issue.  There were not any tests with PSF fitting enabled, which is why https://jira.stsci.edu/browse/RCAL-1103 was not noticed.


<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
