### PR TITLE
Add `dms_logger` fixture for logging `DMSXX` requirement log messages to stderr

### DIFF
--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -2,7 +2,9 @@
 
 import inspect
 import json
+import logging
 import os
+import sys
 from io import StringIO
 
 import pytest
@@ -26,6 +28,21 @@ def slow(request):
     has been specified
     """
     return request.config.getoption("--slow")
+
+
+@pytest.fixture(scope="session")
+def dms_logger():
+    logger = logging.getLogger("DMS")
+    # Don't propagate to root logger to avoid double reporting
+    # during stpipe API calls (like Step.call).
+    logger.propagate = False
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
 
 
 @pytest.fixture(scope="function")

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -32,6 +32,12 @@ def slow(request):
 
 @pytest.fixture(scope="session")
 def dms_logger():
+    """Set up a 'DMS' logger for use in tests.
+
+    The primary use is to report DMS requirement log
+    messages to stderr but can also be used for general
+    stderr logging in tests.
+    """
     logger = logging.getLogger("DMS")
     # Don't propagate to root logger to avoid double reporting
     # during stpipe API calls (like Step.call).

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -3,7 +3,6 @@
 import pytest
 from astropy.table import Table
 
-from romancal.multiband_catalog.multiband_catalog_step import MultibandCatalogStep
 from romancal.stpipe import RomanStep
 
 # mark all tests in this module
@@ -31,7 +30,7 @@ fieldlist = [
 ]
 
 
-def test_multiband_catalog(rtdata_module, resource_tracker, request):
+def test_multiband_catalog(rtdata_module, resource_tracker, request, dms_logger):
     rtdata = rtdata_module
     inputasnfn = "L3_skycell_mbcat_asn.json"
     # note that this input association currently only has a single
@@ -56,8 +55,7 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request):
     for field in fieldlist:
         assert field in cat.dtype.names
 
-    step = MultibandCatalogStep()
-    step.log.info(
+    dms_logger.info(
         "DMS374, 399, 375, 386, 387, 392, 394, 395: source catalog includes fields: "
         + ", ".join(fieldlist)
     )
@@ -71,9 +69,9 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request):
     # the same, but we can easily check that the columns match up
     # by name.
 
-    step.log.info("DMS391: successfully used multiple kernels to detect sources.")
-    step.log.info("DMS393: successfully used deblending to separate blended sources.")
-    step.log.info(
+    dms_logger.info("DMS391: successfully used multiple kernels to detect sources.")
+    dms_logger.info("DMS393: successfully used deblending to separate blended sources.")
+    dms_logger.info(
         "DMS399: successfully tested that catalogs contain aperture "
         "fluxes and uncertainties."
     )

--- a/romancal/regtest/test_ramp_fit_likelihood.py
+++ b/romancal/regtest/test_ramp_fit_likelihood.py
@@ -3,14 +3,15 @@
 import pytest
 import roman_datamodels as rdm
 
-from romancal.step import RampFitStep
 from romancal.stpipe import RomanStep
 
 from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_liklihood_rampfit(rtdata, ignore_asdf_paths, resource_tracker, request):
+def test_liklihood_rampfit(
+    rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger
+):
     """Testing ramp fitting  using the likelihood method"""
 
     input_data = "r0000101001001001001_0001_wfi01_f158_darkcurrent.asdf"
@@ -18,11 +19,9 @@ def test_liklihood_rampfit(rtdata, ignore_asdf_paths, resource_tracker, request)
     rtdata.input = input_data
 
     # Define step (for running and log access)
-    step = RampFitStep()
+    dms_logger.info("Testing ramp fitting with the likelihood algorithm. ")
 
-    step.log.info("Testing ramp fitting with the likelihood algorithm. ")
-
-    step.log.info(f"Image data file: {rtdata.input.rsplit('/', 1)[1]}")
+    dms_logger.info(f"Image data file: {rtdata.input.rsplit('/', 1)[1]}")
 
     # Test Likelihood ramp fitting
     output = "r0000101001001001001_0001_wfi01_f158_like_rampfit.asdf"
@@ -32,13 +31,13 @@ def test_liklihood_rampfit(rtdata, ignore_asdf_paths, resource_tracker, request)
         rtdata.input,
         "--output_file=r0000101001001001001_0001_wfi01_f158_like_rampfit.asdf",
     ]
-    step.log.info("Testing the likelihood fitting for ramps")
+    dms_logger.info("Testing the likelihood fitting for ramps")
     with resource_tracker.track(log=request):
         RomanStep.from_cmdline(args)
 
     ramp_results = rdm.open(rtdata.output)
 
-    step.log.info(
+    dms_logger.info(
         "RampFit step recorded as complete? :"
         f" {ramp_results.meta.cal_step.ramp_fit == 'COMPLETE'}"
     )
@@ -46,5 +45,5 @@ def test_liklihood_rampfit(rtdata, ignore_asdf_paths, resource_tracker, request)
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    step.log.info(f"Was the rate image data produced? : {diff.identical}")
+    dms_logger.info(f"Was the rate image data produced? : {diff.identical}")
     assert diff.identical, diff.report()

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -6,7 +6,6 @@ A requirement for the larger mission verification project is to have
 tests tied to reqirements.
 """
 
-import logging
 from pathlib import Path
 
 import pytest
@@ -17,10 +16,8 @@ from romancal.ramp_fitting import RampFitStep
 
 from .regtestdata import compare_asdf
 
-logger = logging.getLogger(__name__)
 
-
-def log_result(requirement, message, result):
+def log_result(requirement, message, result, logger):
     """Log individual test results that relate to a requirement
 
     Parameters
@@ -42,64 +39,64 @@ def log_result(requirement, message, result):
 # ##########
 # Conditions
 # ##########
-def cond_is_asdf(requirement, model, expected_path):
+def cond_is_asdf(requirement, model, expected_path, logger):
     """Check that the filename has the correct file type"""
     msg = 'Testing that result file path has file type "asdf"'
     result = expected_path.exists() and expected_path.suffix == ".asdf"
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
-def cond_is_imagemodel(requirement, model, expected_path):
+def cond_is_imagemodel(requirement, model, expected_path, logger):
     """Check that the result is an ImageModel"""
     msg = "Testing that the result model is Level 2"
     result = isinstance(model, rdm.datamodels.ImageModel)
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
-def cond_is_rampfit(requirement, model, expected_path):
+def cond_is_rampfit(requirement, model, expected_path, logger):
     """Check that the calibration suffix is 'rampfit'"""
     msg = 'Testing that the result file has the suffix "rampfit"'
     result = expected_path.exists() and expected_path.stem.endswith("rampfit")
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
-def cond_is_step_complete(requirement, model, expected_path):
+def cond_is_step_complete(requirement, model, expected_path, logger):
     """Check that the calibration step is marked complete"""
     msg = "Testing that RampFitStep completed"
     result = model.meta.cal_step.ramp_fit == "COMPLETE"
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
-def cond_is_truncated(requirement, model, expected_path):
+def cond_is_truncated(requirement, model, expected_path, logger):
     """Check if the data represents a truncated MA table/read pattern"""
     msg = "Testing if data represents a truncated MA table"
     result = model.meta.exposure.truncated
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
-def cond_is_uneven(requirement, model, expected_path):
+def cond_is_uneven(requirement, model, expected_path, logger):
     """Verify that the provided model represents uneven ramps"""
     msg = "Testing that the ramps are uneven"
     length_set = {len(resultant) for resultant in model.meta.exposure.read_pattern}
     result = len(length_set) > 1
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, msg
 
 
 def cond_science_verification(
-    requirement, model, expected_path, rtdata_module, ignore_asdf_paths
+    requirement, model, expected_path, rtdata_module, ignore_asdf_paths, logger
 ):
     """Check against expected data results"""
     msg = "Testing science veracity"
     diff = compare_asdf(rtdata_module.output, rtdata_module.truth, **ignore_asdf_paths)
 
     result = diff.identical
-    log_result(requirement, msg, result)
+    log_result(requirement, msg, result, logger)
     assert result, diff.report()
 
 
@@ -189,13 +186,13 @@ def test_log_tracked_resources(log_tracked_resources, rampfit_result):
 
 
 @pytest.mark.bigdata
-def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths):
+def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths, dms_logger):
     """Test rampfit result against various conditions"""
     requirement, model, expected_path, conditions = rampfit_result
     error_msgs = []
     for condition in conditions:
         try:
-            condition(requirement, model, expected_path)
+            condition(requirement, model, expected_path, dms_logger)
         except AssertionError as e:
             error_msgs.append(str(e))
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -199,7 +199,12 @@ def test_rampfit_step(rampfit_result, rtdata_module, ignore_asdf_paths, dms_logg
     # Always do a full regression check.
     try:
         cond_science_verification(
-            requirement, model, expected_path, rtdata_module, ignore_asdf_paths
+            requirement,
+            model,
+            expected_path,
+            rtdata_module,
+            ignore_asdf_paths,
+            dms_logger,
         )
     except AssertionError as e:
         error_msgs.append(str(e))

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -3,7 +3,6 @@
 import pytest
 from astropy.table import Table
 
-from romancal.source_catalog.source_catalog_step import SourceCatalogStep
 from romancal.stpipe import RomanStep
 
 # mark all tests in this module
@@ -74,7 +73,7 @@ def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
     log_tracked_resources()
 
 
-def test_forced_catalog(rtdata_module):
+def test_forced_catalog(rtdata_module, dms_logger):
     rtdata = rtdata_module
     input_deep_segm = "r00001_p_v01001001001001_270p65x49y70_f158_segm.asdf"
     input_shallow_coadd = "r00001_p_e01001001001001_0001_270p65x49y70_f158_coadd.asdf"
@@ -108,8 +107,7 @@ def test_forced_catalog(rtdata_module):
     for field in fieldlist:
         assert field in cat.dtype.names
 
-    step = SourceCatalogStep()
-    step.log.info(
+    dms_logger.info(
         "DMS397: source catalog includes fields: "
         + ", ".join(fieldlist)
         + ", indicating measurements of morphology and photometry "

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -5,13 +5,14 @@ from astropy import units as u
 from roman_datamodels import datamodels as rdm
 
 from romancal.stpipe import RomanStep
-from romancal.tweakreg.tweakreg_step import TweakRegStep
 
 from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request):
+def test_tweakreg(
+    rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request, dms_logger
+):
     # N.B.: uncal file is from simulator
     # ``shifted'' version is created in make_regtestdata.sh; cal file is taken,
     # the wcsinfo is perturbed, and AssignWCS is run to update the WCS with the
@@ -30,9 +31,6 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
     rtdata.input = input_data
     rtdata.output = output_data
 
-    # instantiate TweakRegStep (for running and log access)
-    step = TweakRegStep()
-
     args = [
         "romancal.step.TweakRegStep",
         rtdata.input,
@@ -44,19 +42,19 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
 
     tweakreg_out = rdm.open(rtdata.output)
 
-    step.log.info(
+    dms_logger.info(
         "DMS280 MSG: TweakReg step recorded as complete? :"
         f" {tweakreg_out.meta.cal_step.tweakreg == 'COMPLETE'}"
     )
     assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
 
-    step.log.info(
+    dms_logger.info(
         f"""DMS280 MSG: TweakReg created new attribute with fit results? :\
             {"wcs_fit_results" in tweakreg_out.meta}"""
     )
     assert "wcs_fit_results" in tweakreg_out.meta
 
-    step.log.info(
+    dms_logger.info(
         f"""DMS280 MSG: TweakReg created new coordinate frame 'v2v3corr'? :\
             {"v2v3corr" in tweakreg_out.meta.wcs.available_frames}"""
     )
@@ -72,11 +70,11 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
     diff = coordtrue.separation(coordtweak).to(u.arcsec).value
     rms = np.sqrt(np.mean(diff**2)) * 1000  # rms difference in mas
     passmsg = "PASS" if rms < 1.3 / np.sqrt(2) else "FAIL"
-    step.log.info(
+    dms_logger.info(
         f"DMS488 MSG: WCS agrees with true WCS to {rms:5.2f} mas, less than "
         f"1.3 / sqrt(2)?  {passmsg}"
     )
-    step.log.info(
+    dms_logger.info(
         f"DMS405 MSG: WCS agrees with true WCS to {rms:5.2f} mas, less than "
         f"5 / sqrt(2)?  {passmsg}"
     )
@@ -84,7 +82,7 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request
     assert rms < 1.3 / np.sqrt(2)
 
     diff = compare_asdf(rtdata.output, rtdata.truth, atol=1e-3, **ignore_asdf_paths)
-    step.log.info(
+    dms_logger.info(
         f"DMS280 MSG: Was the proper TweakReg data produced? : {diff.identical}"
     )
     assert diff.identical, diff.report()

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -12,7 +12,9 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request):
+def test_dq_init_image_step(
+    rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger
+):
     """DMS25 Test: Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
@@ -23,16 +25,16 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Testing retrieval of best "
         "ref file for image data, "
         "Success is creation of a ramp file with CRDS selected "
         "mask file applied."
     )
 
-    step.log.info(f"DMS25 MSG: First data file: {rtdata.input.rsplit('/', 1)[1]}")
+    dms_logger.info(f"DMS25 MSG: First data file: {rtdata.input.rsplit('/', 1)[1]}")
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(
+    dms_logger.info(
         f"DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit('/', 1)[1]}"
     )
     ref_file_name = os.path.split(ref_file_path)[-1]
@@ -43,7 +45,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
     output = "r0000101001001001001_0001_wfi01_f158_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Running data quality initialization step."
         " The first ERROR is expected, due to extra CRDS parameters"
         " not having been implemented yet."
@@ -52,7 +54,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
         RomanStep.from_cmdline(args)
 
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Does ramp data contain pixeldq from mask file? :"
         f" {('roman.pixeldq' in ramp_out.to_flat_dict())}"
     )
@@ -60,7 +62,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
 
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Was the proper data quality array initialized"
         " for the ramp data produced? : "
         f"{diff.identical}"
@@ -69,7 +71,9 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths, resource_tracker, request
 
 
 @pytest.mark.bigdata
-def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request):
+def test_dq_init_grism_step(
+    rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger
+):
     """DMS25 Test: Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
@@ -80,16 +84,16 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
     # Test CRDS
     step = DQInitStep()
     model = rdm.open(rtdata.input)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Testing retrieval of best "
         "ref file for grism data, "
         "Success is creation of a ramp file with CRDS selected "
         "mask file applied."
     )
 
-    step.log.info(f"DMS25 MSG: First data file: {rtdata.input.rsplit('/', 1)[1]}")
+    dms_logger.info(f"DMS25 MSG: First data file: {rtdata.input.rsplit('/', 1)[1]}")
     ref_file_path = step.get_reference_file(model, "mask")
-    step.log.info(
+    dms_logger.info(
         f"DMS25 MSG: CRDS matched mask file: {ref_file_path.rsplit('/', 1)[1]}"
     )
     ref_file_name = os.path.split(ref_file_path)[-1]
@@ -100,7 +104,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
     output = "r0000201001001001001_0001_wfi01_grism_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Running data quality initialization step."
         "The first ERROR is expected, due to extra CRDS parameters "
         "not having been implemented yet."
@@ -109,7 +113,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
         RomanStep.from_cmdline(args)
 
     ramp_out = rdm.open(rtdata.output)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Does ramp data contain pixeldq from mask file? :"
         f" {('roman.pixeldq' in ramp_out.to_flat_dict())}"
     )
@@ -117,7 +121,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths, resource_tracker, request
 
     rtdata.get_truth(f"truth/WFI/grism/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
-    step.log.info(
+    dms_logger.info(
         "DMS25 MSG: Was proper data quality initialized "
         "ramp data produced? : "
         f"{diff.identical}"


### PR DESCRIPTION
Add a `dms_logger` fixture for DMS requirement log messages. These go to stderr and are always outside of a normal step call (so these are lost with stpipe 0.9.0 and python 3.13.3/4 or with https://github.com/spacetelescope/stpipe/pull/240 which restricts the stpipe logging configuration to the duration of `Step.call`).

This PR restores those messages in a format that has the same log level, timestamp and message but differs in the logger name (similar to the other log messages with the stpipe fix).

For example, with stpipe 0.9.0 and python <3.13.3:
```
2025-07-03 09:51:44,489 - stpipe.TweakRegStep - INFO - DMS280 MSG: TweakReg step recorded as complete? : True
```
with stpipe 0.9.0 and python 3.13.3/4 no log message
with this PR and stpipe 0.9.0 (or with the linked stpipe PR) and any supported python:
```
2025-07-03 09:51:44,489 - DMS - INFO - DMS280 MSG: TweakReg step recorded as complete? : True
```

Note that this is also compatible with: https://github.com/spacetelescope/stpipe/pull/238 (since the `dms_logger` doesn't use anything from stpipe).

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/16052128356
all passed

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
