### PR TITLE
Fix tweakreg tests to remove old exposure types

### DIFF
--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -1212,10 +1212,7 @@ def update_catalog_coordinates(tweakreg_catalog_name, tweaked_wcs):
     catalog.write(tweakreg_catalog_name, overwrite=True)
 
 
-@pytest.mark.parametrize(
-    "exposure_type",
-    ["WFI_GRISM", "WFI_PRISM", "WFI_DARK", "WFI_FLAT", "WFI_WFSC"],
-)
+@pytest.mark.parametrize("exposure_type", ["WFI_FLAT", "WFI_WFSC"])
 def test_tweakreg_skips_invalid_exposure_types(exposure_type, tmp_path, base_image):
     """Test that TweakReg updates meta.cal_step with tweakreg = COMPLETE."""
     img1 = base_image(shift_1=1000, shift_2=1000)
@@ -1271,21 +1268,21 @@ def test_tweakreg_handles_mixed_exposure_types(tmp_path, base_image):
     """Test that TweakReg can handle mixed exposure types
     (non-WFI_IMAGE data will be marked as SKIPPED only and won't be processed)."""
     img1 = base_image(shift_1=1000, shift_2=1000)
-    img1.meta.exposure.type = "WFI_GRISM"
+    img1.meta.exposure.type = "WFI_IM_DARK"
 
     img2 = base_image(shift_1=1000, shift_2=1000)
     add_tweakreg_catalog_attribute(tmp_path, img2, catalog_filename="img2")
     img2.meta.exposure.type = "WFI_IMAGE"
 
     img3 = base_image(shift_1=1000, shift_2=1000)
-    img3.meta.exposure.type = "WFI_GRISM"
+    img3.meta.exposure.type = "WFI_SP_DARK"
 
     img4 = base_image(shift_1=1000, shift_2=1000)
     add_tweakreg_catalog_attribute(tmp_path, img4, catalog_filename="img4")
     img4.meta.exposure.type = "WFI_IMAGE"
 
     img5 = base_image(shift_1=1000, shift_2=1000)
-    img5.meta.exposure.type = "WFI_GRISM"
+    img5.meta.exposure.type = "WFI_IM_DARK"
 
     res = trs.TweakRegStep.call([img1, img2, img3, img4, img5])
 


### PR DESCRIPTION
spacetelescope/rad#636 removed the deprecated exposure types from rad. This PR is a followup to fix the tests that were broken by this. No actual pipeline code was touched only these tests.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
