### PR TITLE
Ignore the meta.file_date field when doing a comparison of asdf files

### DIFF
--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -8,7 +8,7 @@ from romancal.regtest.regtestdata import compare_asdf
 
 
 @pytest.mark.parametrize("modification", [None, "small", "large"])
-def test_compare_asdf(tmp_path, modification, base_image):
+def test_compare_asdf(tmp_path, modification, base_image, ignore_asdf_paths):
     # Need to use different directories for the files because the filenames are
     #    now always updated as part of writing a datamodel, see spacetelescope/datamodels#295
     file0 = tmp_path / "test0"
@@ -27,7 +27,7 @@ def test_compare_asdf(tmp_path, modification, base_image):
     elif modification == "large":
         l2.data += atol * 2
     l2.save(file1)
-    diff = compare_asdf(file0, file1, atol=atol)
+    diff = compare_asdf(file0, file1, atol=atol, **ignore_asdf_paths)
     if modification == "large":
         assert not diff.identical, diff.report()
         assert "arrays_differ" in diff.diff


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This RDM will begin setting the `meta.file_date` value to the current time upon file save, see spacetelescope/roman_datamodels#539. This means we should no longer check that as it will always be slightly different.

This PR purposefully excludes this information when running `compare_asdf`.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
