### PR TITLE
Improve wcsinfo accuracy.

### DIFF
--- a/changes/1843.resample.rst
+++ b/changes/1843.resample.rst
@@ -1,0 +1,1 @@
+Improve orientation accuracy by increasing separation between points used for computing PA.

--- a/romancal/lib/wcsinfo_to_wcs.py
+++ b/romancal/lib/wcsinfo_to_wcs.py
@@ -58,7 +58,7 @@ def wcsinfo_to_wcs(
                     )
                 ),
                 v3i_yangle=0.0,
-                vparity=-1,
+                vparity=1,
             ),
             (2, 2),
         )

--- a/romancal/lib/wcsinfo_to_wcs.py
+++ b/romancal/lib/wcsinfo_to_wcs.py
@@ -58,7 +58,7 @@ def wcsinfo_to_wcs(
                     )
                 ),
                 v3i_yangle=0.0,
-                vparity=1,
+                vparity=-1,
             ),
             (2, 2),
         )

--- a/romancal/regtest/util.py
+++ b/romancal/regtest/util.py
@@ -28,8 +28,12 @@ def comp_wcs_grids_arcs(wcs_a, wcs_b, npix=4088, interval=10):
     ra_b, dec_b = wcs_b(xx, yy, with_bounding_box=False)
     dec_med = np.nanmedian(dec_b)
 
-    ra_mad = mad_std((ra_a - ra_b) * np.cos(np.radians(dec_med)), ignore_nan=True
-                     ) * 60.0 * 60.0 * 1000.0
+    ra_mad = (
+        mad_std((ra_a - ra_b) * np.cos(np.radians(dec_med)), ignore_nan=True)
+        * 60.0
+        * 60.0
+        * 1000.0
+    )
     dec_mad = mad_std(dec_a - dec_b, ignore_nan=True) * 60.0 * 60.0 * 1000.0
 
     return ra_mad, dec_mad

--- a/romancal/regtest/util.py
+++ b/romancal/regtest/util.py
@@ -21,13 +21,15 @@ def comp_wcs_grids_arcs(wcs_a, wcs_b, npix=4088, interval=10):
     Returns
     -------
     mad_std : float
-        The numpy MAD_STD in arcseconds
+        The numpy mad_std in mas
     """
     xx, yy = np.meshgrid(np.linspace(0, npix, interval), np.linspace(0, npix, interval))
     ra_a, dec_a = wcs_a(xx, yy, with_bounding_box=False)
     ra_b, dec_b = wcs_b(xx, yy, with_bounding_box=False)
+    dec_med = np.nanmedian(dec_b)
 
-    ra_mad = mad_std(ra_a - ra_b, ignore_nan=True) * 60.0 * 60.0 * 1000.0
+    ra_mad = mad_std((ra_a - ra_b) * np.cos(np.radians(dec_med)), ignore_nan=True
+                     ) * 60.0 * 60.0 * 1000.0
     dec_mad = mad_std(dec_a - dec_b, ignore_nan=True) * 60.0 * 60.0 * 1000.0
 
     return ra_mad, dec_mad

--- a/romancal/resample/l3_wcs.py
+++ b/romancal/resample/l3_wcs.py
@@ -113,7 +113,7 @@ def calc_pa(wcs, ra, dec):
 
     """
     delta_pix = [v for v in wcs.invert(ra, dec, with_bounding_box=False)]
-    delta_pix[1] += 1
+    delta_pix[1] += 100
     delta_coord = SkyCoord(
         *wcs(*delta_pix, with_bounding_box=False), frame="icrs", unit="deg"
     )


### PR DESCRIPTION
This PR improves the accuracy with which the wcsinfo round trips in romancal.

romancal computes a bunch of information for the wcs.  One of these terms is the orientation, and another is the projection matrix.  The former is used directly in the WCS, while the latter contains the same information but is a slightly different computation (e.g., it can be computed as `np.degrees(np.arcsin(w.forward_transform.matrix_2.value[0, 1]))`.  In the new L3 metadata, Tyler proposes removing the rotation matrix and keeping only the orientation, so that the wcsinfo does not contain redundant information.  When making that change, the WCS began to fail a round-trip test.  This PR makes a few changes so that that round-trip test continues to pass.

As Brett & Nadia reported, this was only a roundoff error; there were no real code errors.  The regtest test documentation was incorrect, and the errors were reported in mas; the test required that the WCS agree at the 10^-5 mas level.  That's fairly stringent!  This PR does a few things:
- it changes the rotation computation to have a longer level arm to reduce the error in the orientation computation
- it scales the error in the ra direction by the cosine of the declination, so that locations near the pole do not artificially get large ra errors.
- it _does not_ fix a bug Brett noticed in the use of vparity.
- it updates the docs

The parity is a challenge.  We don't record the parity in the L3 metadata; in romancal, we assume +1.  If that assumption is wrong and the original WCS had reversed parity, we don't record that anywhere except in the rotation matrix.  However, stcal uses -1 by default, while our skycells use +1.  I've left in the +1 until the skycells reference file is updated.  Then we will probably need to update this to use -1 and also update some unit tests.

With this PR, the test now passes.  Formerly the standard deviation was ~8e-5 mas; now it is ~2e-7 mas.  Roman WCS accuracy requirements are ~1 mas, so this is in any case incredibly small.

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
