### PR TITLE
Rcal-1108 Add decorators for SOC requirements for the astrometry and ePSF regression tests

### DIFF
--- a/changes/1862.source_catalog.rst
+++ b/changes/1862.source_catalog.rst
@@ -1,0 +1,1 @@
+Add the DMS identifier for the astrometry and ePSF tests as well as updating the tests

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -58,5 +58,7 @@ def test_psf_library(rtdata, dms_logger):
             diff = psf_offcenter - psf_center
             # check to make sure the difference is not zero over the array
             psf_diff = diff.any()
+            assert psf_diff
             passmsg = "PASS" if psf_diff else "FAIL"
             dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same")
+            

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -7,7 +7,7 @@ from romancal.step import SourceCatalogStep
 
 
 @pytest.mark.bigdata
-def test_psf_library( rtdata, dms_logger):
+def test_psf_library(rtdata, dms_logger):
 
     input_data = "r0000101001001001001_0001_wfi01_f158_cal.asdf"
 
@@ -21,9 +21,9 @@ def test_psf_library( rtdata, dms_logger):
     ref_file = step.get_reference_file(rtdata.input, "epsf")
     has_ref_file = ref_file != "N/A"
     assert has_ref_file
-    passmsg = "PASS" if has_ref_file  else "FAIL"
+    passmsg = "PASS" if has_ref_file else "FAIL"
     dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
-    passmsg = "PASS" if has_ref_file  else "FAIL"
+    passmsg = "PASS" if has_ref_file else "FAIL"
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
     # DMS 535 identify an appropriate PSF for WFI source

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -32,10 +32,10 @@ def get_InputFile(rtdata_module, request, resource_tracker):
     return rtdata
 
 @pytest.mark.bigdata
-def test_psf_library_reffile(get_InputFile ,dms_logger):
+def test_psf_library_reffile(get_input_file ,dms_logger):
     """ Test the retrieval of the PSF reference file """
 
-    rtdata = get_InputFile
+    rtdata = get_input_file
 
     # DMS 531 is to check that a PSF library has been provided and
     # DMS 532 is that we have access to the PSF library. By retrieving a
@@ -49,13 +49,13 @@ def test_psf_library_reffile(get_InputFile ,dms_logger):
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
 @pytest.mark.bigdata
-def test_psf_library_crdsfile(get_InputFile, dms_logger):
+def test_psf_library_crdsfile(get_input_file, dms_logger):
     """ Test that the PSF reference file matches the observation"""
     # DMS 535 identify an appropriate PSF for WFI source
     # check that the detector and optical element for the psf ref file
     # matches the data file
 
-    rtdata = get_InputFile
+    rtdata = get_input_file
     input_data = rtdata.input
 
     step = SourceCatalogStep()
@@ -72,13 +72,13 @@ def test_psf_library_crdsfile(get_InputFile, dms_logger):
             dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
 
 @pytest.mark.bigdata
-def test_psf_library_psfinterp(get_InputFile, dms_logger):
+def test_psf_library_psfinterp(get_input_file, dms_logger):
     """ Test that the interpolation is occurring"""
     # DMS 536 interpolating empirical ePSFs given the observed-source position
     # Create two psf's one at the center and one off-center to show we can interpolate the PSF
     # and that the two are not the same
 
-    rtdata = get_InputFile
+    rtdata = get_input_file
     input_data = rtdata.input
 
     step = SourceCatalogStep()

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,23 +1,52 @@
+""" Tests for the Roman PSF Library"""
 import numpy as np
 import pytest
 from roman_datamodels import datamodels as rdm
 
 from romancal.source_catalog import psf
 from romancal.step import SourceCatalogStep
+from romancal.stpipe import RomanStep
 
+# mark all tests in this module
+pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "r0000101001001001001_0001_wfi01_f158_cal.asdf",
+    ],
+    ids =['input_file'],
+)
+
+
+def run_SourceCatalog(rtdata_module, request, resource_tracker):
+    """ Run the source catalog step"""
+
+    rtdata = rtdata_module
+    input_file = request.param
+
+
+    rtdata.get_data(f"WFI/image/{input_file}")
+    rtdata.input = input_file
+
+    args = [
+        "romancal.step.SourceCatalogStep",
+        rtdata.input,
+    ]
+    with resource_tracker.track():
+        RomanStep.from_cmdline(args)
+    return rtdata
 
 @pytest.mark.bigdata
-def test_psf_library(rtdata, dms_logger):
+def test_psf_library_reffile(run_SourceCatalog ,dms_logger):
+    """ Test the retrieval of the PSF reference file """
 
-    input_data = "r0000101001001001001_0001_wfi01_f158_cal.asdf"
+    rtdata = run_SourceCatalog
 
-    rtdata.get_data(f"WFI/image/{input_data}")
-    rtdata.input = input_data
-
-    step = SourceCatalogStep()
     # DMS 531 is to check that a PSF library has been provided and
     # DMS 532 is that we have access to the PSF library. By retrieving a
     # PSF reference file we show that the library exists and we have access.
+    step = SourceCatalogStep()
     ref_file = step.get_reference_file(rtdata.input, "epsf")
     has_ref_file = ref_file != "N/A"
     assert has_ref_file
@@ -25,9 +54,18 @@ def test_psf_library(rtdata, dms_logger):
     dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
+@pytest.mark.bigdata
+def test_psf_library_crdsfile(run_SourceCatalog, dms_logger):
+    """ Test that the PSF reference file matches the observation"""
     # DMS 535 identify an appropriate PSF for WFI source
     # check that the detector and optical element for the psf ref file
     # matches the data file
+
+    rtdata = run_SourceCatalog
+    input_data = rtdata.input
+
+    step = SourceCatalogStep()
+    ref_file = step.get_reference_file(input_data, "epsf")
     with rdm.open(ref_file) as ref_data:
         with rdm.open(rtdata.input) as wfi_data:
             psf_selection_match = (
@@ -39,26 +77,58 @@ def test_psf_library(rtdata, dms_logger):
             passmsg = "PASS" if psf_selection_match else "FAIL"
             dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
 
-            # DMS 536 interpolating empirical ePSFs given the observed-source position
-            # Create two psf's one at the center and one off-center to show we can interpolate the PSF
-            # and that the two are not the same
-            psf_model = psf.get_gridded_psf_model(ref_data)
-            center = 2044
-            szo2 = 10 # psf stamp axis lenght/2
-            oversample = 11
-            npix = szo2 * 2 * oversample + 1
-            pts = np.linspace(-szo2 + center, szo2 + center, npix)
-            xx, yy = np.meshgrid(pts, pts)
-            psf_center = psf_model.evaluate(xx, yy, 1, center, center)
-            off_center = center + 99
-            pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
-            xx, yy = np.meshgrid(pts, pts)
-            psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
-            # show that these two are different
-            diff = psf_offcenter - psf_center
-            # check to make sure the difference is not zero over the array
-            psf_diff = diff.any()
-            assert psf_diff
-            passmsg = "PASS" if psf_diff else "FAIL"
-            dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same")
-            
+@pytest.mark.bigdata
+def test_psf_library_crdselect(run_SourceCatalog, dms_logger):
+    """ Test the CRDS selection """
+    # DMS 535 identify an appropriate PSF for WFI source
+    # check that the detector and optical element for the psf ref file
+    # matches the data file
+
+    rtdata = run_SourceCatalog
+    input_data = rtdata.input
+
+    step = SourceCatalogStep()
+    ref_file = step.get_reference_file(input_data, "epsf")
+    with rdm.open(ref_file) as ref_data:
+        with rdm.open(rtdata.input) as wfi_data:
+            psf_selection_match = (
+            (wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element)
+            and
+            (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
+
+            assert psf_selection_match
+            passmsg = "PASS" if psf_selection_match else "FAIL"
+            dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
+
+@pytest.mark.bigdata
+def test_psf_library_psfinterp(run_SourceCatalog, dms_logger):
+    """ Test that the interpolation is occurring"""
+    # DMS 536 interpolating empirical ePSFs given the observed-source position
+    # Create two psf's one at the center and one off-center to show we can interpolate the PSF
+    # and that the two are not the same
+
+    rtdata = run_SourceCatalog
+    input_data = rtdata.input
+
+    step = SourceCatalogStep()
+    ref_file = step.get_reference_file(input_data, "epsf")
+    with rdm.open(ref_file) as ref_data:
+        psf_model = psf.get_gridded_psf_model(ref_data)
+        center = 2044
+        szo2 = 10 # psf stamp axis lenght/2
+        oversample = 11
+        npix = szo2 * 2 * oversample + 1
+        pts = np.linspace(-szo2 + center, szo2 + center, npix)
+        xx, yy = np.meshgrid(pts, pts)
+        psf_center = psf_model.evaluate(xx, yy, 1, center, center)
+        off_center = center + 99
+        pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
+        xx, yy = np.meshgrid(pts, pts)
+        psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
+        # show that these two are different
+        diff = psf_offcenter - psf_center
+        # check to make sure the difference is not zero over the array
+        psf_diff = diff.any()
+        assert psf_diff
+        passmsg = "PASS" if psf_diff else "FAIL"
+        dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same")

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -23,7 +23,6 @@ def test_psf_library(rtdata, dms_logger):
     assert has_ref_file
     passmsg = "PASS" if has_ref_file else "FAIL"
     dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
-    passmsg = "PASS" if has_ref_file else "FAIL"
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
     # DMS 535 identify an appropriate PSF for WFI source

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,62 +1,63 @@
 import numpy as np
 import pytest
-
 from roman_datamodels import datamodels as rdm
 
-import romancal.source_catalog.psf as psf
+from romancal.source_catalog import psf
 from romancal.step import SourceCatalogStep
 
 
 @pytest.mark.bigdata
-def test_psf_library(
-    rtdata, ignore_asdf_paths, tmp_path, resource_tracker, dms_logger):
+def test_psf_library( rtdata, dms_logger):
 
-        input_data = "r0000101001001001001_0001_wfi01_f158_cal.asdf"
+    input_data = "r0000101001001001001_0001_wfi01_f158_cal.asdf"
 
-        rtdata.get_data(f"WFI/image/{input_data}")
-        rtdata.input = input_data
+    rtdata.get_data(f"WFI/image/{input_data}")
+    rtdata.input = input_data
 
-        step = SourceCatalogStep()
-        # DMS 531 is to check that a PSF library has been provided and
-        # DMS 532 is that we have access to the PSF library. By retrieving a
-        # PSF reference file we show that the library exists and we have access. 
-        ref_file = step.get_reference_file(rtdata.input, "epsf")
-        has_ref_file = ref_file != "N/A"
-        assert has_ref_file
-        passmsg = "PASS" if has_ref_file  else "FAIL"
-        dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
-        passmsg = "PASS" if has_ref_file  else "FAIL"
-        dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
+    step = SourceCatalogStep()
+    # DMS 531 is to check that a PSF library has been provided and
+    # DMS 532 is that we have access to the PSF library. By retrieving a
+    # PSF reference file we show that the library exists and we have access.
+    ref_file = step.get_reference_file(rtdata.input, "epsf")
+    has_ref_file = ref_file != "N/A"
+    assert has_ref_file
+    passmsg = "PASS" if has_ref_file  else "FAIL"
+    dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
+    passmsg = "PASS" if has_ref_file  else "FAIL"
+    dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
-        # DMS 535 identify an appropriate PSF for WFI source
-        # check that the detector and optical element for the psf ref file
-        # matches the data file
-        with rdm.open(ref_file) as ref_data:
-                with rdm.open(rtdata.input) as wfi_data:
-                        psf_selection_match = ((wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
-                                              (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
-                        assert psf_selection_match
-                        passmsg = "PASS" if psf_selection_match else "FAIL"
-                        dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")                             
+    # DMS 535 identify an appropriate PSF for WFI source
+    # check that the detector and optical element for the psf ref file
+    # matches the data file
+    with rdm.open(ref_file) as ref_data:
+        with rdm.open(rtdata.input) as wfi_data:
+            psf_selection_match = (
+            (wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element)
+            and
+            (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
 
-                        # DMS 536 interpolating empirical ePSFs given the observed-source position
-                        # Create two psf's one at the center and one off-center to show we can interpolate the PSF
-                        # and that the two are not the same
-                        psf_model = psf.get_gridded_psf_model(ref_data)
-                        center = 2044
-                        szo2 = 10 # psf stamp axis lenght/2
-                        oversample = 11
-                        npix = szo2 * 2 * oversample + 1
-                        pts = np.linspace(-szo2 + center, szo2 + center, npix)
-                        xx, yy = np.meshgrid(pts, pts)
-                        psf_center = psf_model.evaluate(xx, yy, 1, center, center)
-                        off_center = center + 99
-                        pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
-                        xx, yy = np.meshgrid(pts, pts)
-                        psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
-                        # show that these two are different
-                        diff = psf_offcenter - psf_center
-                        # check to make sure the difference is not zero over the array
-                        psf_diff = diff.any()
-                        passmsg = "PASS" if psf_diff else "FAIL"
-                        dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same") 
+            assert psf_selection_match
+            passmsg = "PASS" if psf_selection_match else "FAIL"
+            dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
+
+            # DMS 536 interpolating empirical ePSFs given the observed-source position
+            # Create two psf's one at the center and one off-center to show we can interpolate the PSF
+            # and that the two are not the same
+            psf_model = psf.get_gridded_psf_model(ref_data)
+            center = 2044
+            szo2 = 10 # psf stamp axis lenght/2
+            oversample = 11
+            npix = szo2 * 2 * oversample + 1
+            pts = np.linspace(-szo2 + center, szo2 + center, npix)
+            xx, yy = np.meshgrid(pts, pts)
+            psf_center = psf_model.evaluate(xx, yy, 1, center, center)
+            off_center = center + 99
+            pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
+            xx, yy = np.meshgrid(pts, pts)
+            psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
+            # show that these two are different
+            diff = psf_offcenter - psf_center
+            # check to make sure the difference is not zero over the array
+            psf_diff = diff.any()
+            passmsg = "PASS" if psf_diff else "FAIL"
+            dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same")

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 )
 
 
-def get_InputFile(rtdata_module, request, resource_tracker):
+def get_input_file(rtdata_module, request, resource_tracker):
     """ Get the input file for testing"""
     
     rtdata = rtdata_module

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,4 +1,5 @@
 """ Tests for the Roman PSF Library"""
+import pdb
 import numpy as np
 import pytest
 from roman_datamodels import datamodels as rdm
@@ -21,20 +22,14 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
 def run_SourceCatalog(rtdata_module, request, resource_tracker):
     """ Run the source catalog step"""
-
+    
     rtdata = rtdata_module
+
     input_file = request.param
 
 
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
-
-    args = [
-        "romancal.step.SourceCatalogStep",
-        rtdata.input,
-    ]
-    with resource_tracker.track():
-        RomanStep.from_cmdline(args)
     return rtdata
 
 @pytest.mark.bigdata
@@ -43,6 +38,8 @@ def test_psf_library_reffile(run_SourceCatalog ,dms_logger):
 
     rtdata = run_SourceCatalog
 
+    #args = ["romancal.step.SourceCatalogStep", rtdata.input, ]
+    #RomanStep.from_cmdline(args)
     # DMS 531 is to check that a PSF library has been provided and
     # DMS 532 is that we have access to the PSF library. By retrieving a
     # PSF reference file we show that the library exists and we have access.
@@ -57,29 +54,6 @@ def test_psf_library_reffile(run_SourceCatalog ,dms_logger):
 @pytest.mark.bigdata
 def test_psf_library_crdsfile(run_SourceCatalog, dms_logger):
     """ Test that the PSF reference file matches the observation"""
-    # DMS 535 identify an appropriate PSF for WFI source
-    # check that the detector and optical element for the psf ref file
-    # matches the data file
-
-    rtdata = run_SourceCatalog
-    input_data = rtdata.input
-
-    step = SourceCatalogStep()
-    ref_file = step.get_reference_file(input_data, "epsf")
-    with rdm.open(ref_file) as ref_data:
-        with rdm.open(rtdata.input) as wfi_data:
-            psf_selection_match = (
-            (wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element)
-            and
-            (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
-
-            assert psf_selection_match
-            passmsg = "PASS" if psf_selection_match else "FAIL"
-            dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
-
-@pytest.mark.bigdata
-def test_psf_library_crdselect(run_SourceCatalog, dms_logger):
-    """ Test the CRDS selection """
     # DMS 535 identify an appropriate PSF for WFI source
     # check that the detector and optical element for the psf ref file
     # matches the data file

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -6,7 +6,6 @@ from roman_datamodels import datamodels as rdm
 
 from romancal.source_catalog import psf
 from romancal.step import SourceCatalogStep
-from romancal.stpipe import RomanStep
 
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
@@ -20,8 +19,8 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 )
 
 
-def run_SourceCatalog(rtdata_module, request, resource_tracker):
-    """ Run the source catalog step"""
+def get_InputFile(rtdata_module, request, resource_tracker):
+    """ Get the input file for testing"""
     
     rtdata = rtdata_module
 
@@ -33,13 +32,11 @@ def run_SourceCatalog(rtdata_module, request, resource_tracker):
     return rtdata
 
 @pytest.mark.bigdata
-def test_psf_library_reffile(run_SourceCatalog ,dms_logger):
+def test_psf_library_reffile(get_InputFile ,dms_logger):
     """ Test the retrieval of the PSF reference file """
 
-    rtdata = run_SourceCatalog
+    rtdata = get_InputFile
 
-    #args = ["romancal.step.SourceCatalogStep", rtdata.input, ]
-    #RomanStep.from_cmdline(args)
     # DMS 531 is to check that a PSF library has been provided and
     # DMS 532 is that we have access to the PSF library. By retrieving a
     # PSF reference file we show that the library exists and we have access.
@@ -52,13 +49,13 @@ def test_psf_library_reffile(run_SourceCatalog ,dms_logger):
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
 @pytest.mark.bigdata
-def test_psf_library_crdsfile(run_SourceCatalog, dms_logger):
+def test_psf_library_crdsfile(get_InputFile, dms_logger):
     """ Test that the PSF reference file matches the observation"""
     # DMS 535 identify an appropriate PSF for WFI source
     # check that the detector and optical element for the psf ref file
     # matches the data file
 
-    rtdata = run_SourceCatalog
+    rtdata = get_InputFile
     input_data = rtdata.input
 
     step = SourceCatalogStep()
@@ -75,13 +72,13 @@ def test_psf_library_crdsfile(run_SourceCatalog, dms_logger):
             dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
 
 @pytest.mark.bigdata
-def test_psf_library_psfinterp(run_SourceCatalog, dms_logger):
+def test_psf_library_psfinterp(get_InputFile, dms_logger):
     """ Test that the interpolation is occurring"""
     # DMS 536 interpolating empirical ePSFs given the observed-source position
     # Create two psf's one at the center and one off-center to show we can interpolate the PSF
     # and that the two are not the same
 
-    rtdata = run_SourceCatalog
+    rtdata = get_InputFile
     input_data = rtdata.input
 
     step = SourceCatalogStep()

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,18 +1,10 @@
-import pdb
-import asdf
 import numpy as np
 import pytest
-from astropy import units as u
 
-from photutils.psf import GriddedPSFModel
 from roman_datamodels import datamodels as rdm
 
-from romancal.step import SourceCatalogStep
-from romancal.stpipe import RomanStep
-
 import romancal.source_catalog.psf as psf
-
-from .regtestdata import compare_asdf
+from romancal.step import SourceCatalogStep
 
 
 @pytest.mark.bigdata

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -65,5 +65,6 @@ def test_psf_library(
         # show that these two are different
         diff = psf_offcenter - psf_center
         # check to make sure the difference is not zero over the array
-        passmsg = "PASS" if diff.any() else "FAIL"
+        psf_diff = diff.any()
+        passmsg = "PASS" if psf_diff else "FAIL"
         dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same") 

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -29,9 +29,11 @@ def test_psf_library(
         # DMS 532 is that we have access to the PSF library. By retrieving a
         # PSF reference file we show that the library exists and we have access. 
         ref_file = step.get_reference_file(rtdata.input, "epsf")
-        passmsg = "PASS" if ref_file not in"N/A"  else "FAIL"
+        has_ref_file = ref_file != "N/A"
+        assert has_ref_file
+        passmsg = "PASS" if has_ref_file  else "FAIL"
         dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
-        passmsg = "PASS" if ref_file not in"N/A"  else "FAIL"
+        passmsg = "PASS" if has_ref_file  else "FAIL"
         dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
         # DMS 535 identify an appropriate PSF for WFI source
@@ -39,8 +41,10 @@ def test_psf_library(
         # matches the data file
         ref_data = rdm.open(ref_file)
         wfi_data = rdm.open(rtdata.input)
-        passmsg = "PASS" if ((wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector)
-                             and (wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element))  else "FAIL"
+        psf_selection_match = ((wfi_dat.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
+                              (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
+        assert psf_selection_match
+        passmsg = "PASS" if psf_selection_match else "FAIL"
         dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")                             
 
         # DMS 536 interpolating empirical ePSFs given the observed-source position

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -41,7 +41,7 @@ def test_psf_library(
         # matches the data file
         ref_data = rdm.open(ref_file)
         wfi_data = rdm.open(rtdata.input)
-        psf_selection_match = ((wfi_dat.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
+        psf_selection_match = ((wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
                               (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
         assert psf_selection_match
         passmsg = "PASS" if psf_selection_match else "FAIL"

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -39,32 +39,32 @@ def test_psf_library(
         # DMS 535 identify an appropriate PSF for WFI source
         # check that the detector and optical element for the psf ref file
         # matches the data file
-        ref_data = rdm.open(ref_file)
-        wfi_data = rdm.open(rtdata.input)
-        psf_selection_match = ((wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
-                              (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
-        assert psf_selection_match
-        passmsg = "PASS" if psf_selection_match else "FAIL"
-        dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")                             
+        with rdm.open(ref_file) as ref_data:
+                with rdm.open(rtdata.input) as wfi_data:
+                        psf_selection_match = ((wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element) and
+                                              (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
+                        assert psf_selection_match
+                        passmsg = "PASS" if psf_selection_match else "FAIL"
+                        dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")                             
 
-        # DMS 536 interpolating empirical ePSFs given the observed-source position
-        # Create two psf's one at the center and one off-center to show we can interpolate the PSF
-        # and that the two are not the same
-        psf_model = psf.get_gridded_psf_model(ref_data)
-        center = 2044
-        szo2 = 10 # psf stamp axis lenght/2
-        oversample = 11
-        npix = szo2 * 2 * oversample + 1
-        pts = np.linspace(-szo2 + center, szo2 + center, npix)
-        xx, yy = np.meshgrid(pts, pts)
-        psf_center = psf_model.evaluate(xx, yy, 1, center, center)
-        off_center = center + 99
-        pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
-        xx, yy = np.meshgrid(pts, pts)
-        psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
-        # show that these two are different
-        diff = psf_offcenter - psf_center
-        # check to make sure the difference is not zero over the array
-        psf_diff = diff.any()
-        passmsg = "PASS" if psf_diff else "FAIL"
-        dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same") 
+                        # DMS 536 interpolating empirical ePSFs given the observed-source position
+                        # Create two psf's one at the center and one off-center to show we can interpolate the PSF
+                        # and that the two are not the same
+                        psf_model = psf.get_gridded_psf_model(ref_data)
+                        center = 2044
+                        szo2 = 10 # psf stamp axis lenght/2
+                        oversample = 11
+                        npix = szo2 * 2 * oversample + 1
+                        pts = np.linspace(-szo2 + center, szo2 + center, npix)
+                        xx, yy = np.meshgrid(pts, pts)
+                        psf_center = psf_model.evaluate(xx, yy, 1, center, center)
+                        off_center = center + 99
+                        pts = np.linspace(-szo2 + off_center, szo2 + off_center, npix)
+                        xx, yy = np.meshgrid(pts, pts)
+                        psf_offcenter = psf_model.evaluate(xx, yy, 1, off_center, off_center)
+                        # show that these two are different
+                        diff = psf_offcenter - psf_center
+                        # check to make sure the difference is not zero over the array
+                        psf_diff = diff.any()
+                        passmsg = "PASS" if psf_diff else "FAIL"
+                        dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same") 

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,5 +1,5 @@
-""" Tests for the Roman PSF Library"""
-import pdb
+"""Tests for the Roman PSF Library"""
+
 import numpy as np
 import pytest
 from roman_datamodels import datamodels as rdm
@@ -10,30 +10,29 @@ from romancal.step import SourceCatalogStep
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
+
 @pytest.fixture(
     scope="module",
     params=[
         "r0000101001001001001_0001_wfi01_f158_cal.asdf",
     ],
-    ids =['input_file'],
+    ids=["input_file"],
 )
-
-
 def get_input_file(rtdata_module, request, resource_tracker):
-    """ Get the input file for testing"""
-    
+    """Get the input file for testing"""
+
     rtdata = rtdata_module
 
     input_file = request.param
-
 
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
     return rtdata
 
+
 @pytest.mark.bigdata
-def test_psf_library_reffile(get_input_file ,dms_logger):
-    """ Test the retrieval of the PSF reference file """
+def test_psf_library_reffile(get_input_file, dms_logger):
+    """Test the retrieval of the PSF reference file"""
 
     rtdata = get_input_file
 
@@ -48,9 +47,10 @@ def test_psf_library_reffile(get_input_file ,dms_logger):
     dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
     dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
 
+
 @pytest.mark.bigdata
 def test_psf_library_crdsfile(get_input_file, dms_logger):
-    """ Test that the PSF reference file matches the observation"""
+    """Test that the PSF reference file matches the observation"""
     # DMS 535 identify an appropriate PSF for WFI source
     # check that the detector and optical element for the psf ref file
     # matches the data file
@@ -63,17 +63,22 @@ def test_psf_library_crdsfile(get_input_file, dms_logger):
     with rdm.open(ref_file) as ref_data:
         with rdm.open(rtdata.input) as wfi_data:
             psf_selection_match = (
-            (wfi_data.meta.instrument.optical_element == ref_data.meta.instrument.optical_element)
-            and
-            (wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector))
+                wfi_data.meta.instrument.optical_element
+                == ref_data.meta.instrument.optical_element
+            ) and (
+                wfi_data.meta.instrument.detector == ref_data.meta.instrument.detector
+            )
 
             assert psf_selection_match
             passmsg = "PASS" if psf_selection_match else "FAIL"
-            dms_logger.info(f"DMS535 {passmsg},  ePSF reference file selection matches input data file")
+            dms_logger.info(
+                f"DMS535 {passmsg},  ePSF reference file selection matches input data file"
+            )
+
 
 @pytest.mark.bigdata
 def test_psf_library_psfinterp(get_input_file, dms_logger):
-    """ Test that the interpolation is occurring"""
+    """Test that the interpolation is occurring"""
     # DMS 536 interpolating empirical ePSFs given the observed-source position
     # Create two psf's one at the center and one off-center to show we can interpolate the PSF
     # and that the two are not the same
@@ -86,7 +91,7 @@ def test_psf_library_psfinterp(get_input_file, dms_logger):
     with rdm.open(ref_file) as ref_data:
         psf_model = psf.get_gridded_psf_model(ref_data)
         center = 2044
-        szo2 = 10 # psf stamp axis lenght/2
+        szo2 = 10  # psf stamp axis lenght/2
         oversample = 11
         npix = szo2 * 2 * oversample + 1
         pts = np.linspace(-szo2 + center, szo2 + center, npix)
@@ -102,4 +107,6 @@ def test_psf_library_psfinterp(get_input_file, dms_logger):
         psf_diff = diff.any()
         assert psf_diff
         passmsg = "PASS" if psf_diff else "FAIL"
-        dms_logger.info(f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same")
+        dms_logger.info(
+            f"DMS536 {passmsg},  The interpolated ePSF for two positions are not the same"
+        )

--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -1,0 +1,28 @@
+import asdf
+import numpy as np
+import pytest
+from astropy import units as u
+from roman_datamodels import datamodels as rdm
+
+from romancal.step import SourceCatalogStep
+from romancal.stpipe import RomanStep
+
+from .regtestdata import compare_asdf
+
+
+@pytest.mark.bigdata
+def test_psf_library(
+    rtdata, ignore_asdf_paths, tmp_path, resource_tracker, dms_logger):
+
+        input_data = "r0000101001001001001_0001_wfi01_f158_cal.asdf"
+
+        rtdata.get_data(f"WFI/image/{input_data}")
+
+        step = SourceCatalogStep()
+        ref_file = step.get_reference_file(rtdata.input, "epsf")
+        passmsg = "PASS" if ref_file not in"N/A"  else "FAIL"
+        dms_logger.info(f"DMS531 {passmsg},  ePSF reference file {ref_file} exists.")
+        passmsg = "PASS" if ref_file not in"N/A"  else "FAIL"
+        dms_logger.info(f"DMS532 {passmsg},  ePSF reference file {ref_file} was retrieved.")
+
+

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -84,8 +84,10 @@ def test_tweakreg(
 
     # check if the Mean Absolute Error is less that 10 milliarcsec  (DMS406)
     abs_diff = (np.absolute(diff) *0.1)/1.e-3
-    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae * 0.1)/ 1.e-3
+    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
+    assert mean_abs_error < 10.0
     passmsg = "PASS" if  mean_abs_error < 10.0 else "FAIL"
+     assert np.max(abs_diff) < 10.0
     passmsg = "PASS" if  np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 
@@ -99,12 +101,14 @@ def test_tweakreg(
                 log_substring = entry[entry.rfind('abs_refcat'):]
                 refcat_name = log_substring[:log_substring.find('\n')]
 
+        assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
+        assert "GAIA" in refcat_name
         passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
         dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
                         f"the Gaia astrometric reference frame.")
     
     # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
-    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae * 0.1)/ 1.e-3
+    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert  mean_abs_error < 5.0
     passmsg = "PASS" if  mean_abs_error < 5.0 else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas.")
@@ -112,6 +116,7 @@ def test_tweakreg(
     passmsg = "PASS" if  tweakreg_out.meta.cal_step.tweakreg == "COMPLETE" else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the Tweakreg step is compete.")
     wcs_filename = output_data.rsplit("_", 1)[0] + "_wcs.asdf"
+    assert os.path.isfile(wcs_filename)
     passmsg = "PASS" if os.path.isfile(wcs_filename) else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the output wcs file exists.")
 

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -92,18 +92,18 @@ def test_tweakreg(
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 
     assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
-        # Find the reference catalog used by tweakreg
-        for entry in tweakreg_out.meta.cal_logs:
-            refcat_name = " "
-            if "abs_refcat" in entry:
-                log_substring = entry[entry.rfind("abs_refcat") :]
-                refcat_name = log_substring[: log_substring.find("\n")]
-        assert "GAIA" in refcat_name
-        passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
-        dms_logger.info(
-            f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
-            "the Gaia astrometric reference frame."
-        )
+    # Find the reference catalog used by tweakreg
+    for entry in tweakreg_out.meta.cal_logs:
+        refcat_name = " "
+        if "abs_refcat" in entry:
+            log_substring = entry[entry.rfind("abs_refcat") :]
+            refcat_name = log_substring[: log_substring.find("\n")]
+    assert "GAIA" in refcat_name
+    passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
+    dms_logger.info(
+        f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
+        "the Gaia astrometric reference frame."
+    )
         
     # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -93,11 +93,12 @@ def test_tweakreg(
 
     assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
     # Find the reference catalog used by tweakreg
+    refcat_name = None
     for entry in tweakreg_out.meta.cal_logs:
-        refcat_name = " "
         if "abs_refcat" in entry:
             log_substring = entry[entry.rfind("abs_refcat") :]
             refcat_name = log_substring[: log_substring.find("\n")]
+
     assert "GAIA" in refcat_name
     passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
     dms_logger.info(

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -87,7 +87,7 @@ def test_tweakreg(
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert mean_abs_error < 10.0
     passmsg = "PASS" if  mean_abs_error < 10.0 else "FAIL"
-     assert np.max(abs_diff) < 10.0
+    assert np.max(abs_diff) < 10.0
     passmsg = "PASS" if  np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -12,9 +12,7 @@ from .regtestdata import compare_asdf
 
 
 @pytest.mark.bigdata
-def test_tweakreg(
-    rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger
-):
+def test_tweakreg(rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger):
     # N.B.: uncal file is from simulator
     # ``shifted'' version is created in make_regtestdata.sh; cal file is taken,
     # the wcsinfo is perturbed, and AssignWCS is run to update the WCS with the
@@ -84,10 +82,12 @@ def test_tweakreg(
     assert rms < 1.3 / np.sqrt(2)
 
     # check if the Mean Absolute Error is less that 10 milliarcsec  (DMS406)
-    abs_diff = (np.absolute(diff))/1.e-3
+    abs_diff = (np.absolute(diff)) / 1.0e-3
     assert np.max(abs_diff) < 10.0
     passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
-    dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
+    dms_logger.info(
+        f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas."
+    )
 
     # Find the reference catalog used by tweakreg
     refcat_name = None
@@ -102,12 +102,14 @@ def test_tweakreg(
         f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
         "the Gaia astrometric reference frame."
     )
-        
+
     # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
-    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
-    assert  mean_abs_error < 5.0
-    passmsg = "PASS" if  mean_abs_error < 5.0 else "FAIL"
-    dms_logger.info(f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas.")
+    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae) / 1.0e-3
+    assert mean_abs_error < 5.0
+    passmsg = "PASS" if mean_abs_error < 5.0 else "FAIL"
+    dms_logger.info(
+        f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas."
+    )
     # check that the tweakreg step is marked complete
     wcs_filename = output_data.rsplit("_", 1)[0] + "_wcs.asdf"
     assert os.path.isfile(wcs_filename)

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -1,7 +1,9 @@
 import os
+
 import asdf
 import numpy as np
 import pytest
+
 from astropy import units as u
 from roman_datamodels import datamodels as rdm
 
@@ -86,9 +88,9 @@ def test_tweakreg(
     abs_diff = (np.absolute(diff) *0.1)/1.e-3
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert mean_abs_error < 10.0
-    passmsg = "PASS" if  mean_abs_error < 10.0 else "FAIL"
+    passmsg = "PASS" if mean_abs_error < 10.0 else "FAIL"
     assert np.max(abs_diff) < 10.0
-    passmsg = "PASS" if  np.max(abs_diff) < 10.0 else "FAIL"
+    passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 
 
@@ -97,9 +99,9 @@ def test_tweakreg(
     if tweakreg_out.meta.cal_step.tweakreg == "COMPLETE":
         # Find the reference catalog used by tweakreg
         for entry in tweakreg_out.meta.cal_logs:
-            if 'abs_refcat' in entry:
-                log_substring = entry[entry.rfind('abs_refcat'):]
-                refcat_name = log_substring[:log_substring.find('\n')]
+            if "abs_refcat" in entry:
+                log_substring = entry[entry.rfind("abs_refcat"):]
+                refcat_name = log_substring[:log_substring.find("\n")]
 
         assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
         assert "GAIA" in refcat_name
@@ -113,6 +115,7 @@ def test_tweakreg(
     passmsg = "PASS" if  mean_abs_error < 5.0 else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas.")
     # check that the tweakreg step is marked complete
+    assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
     passmsg = "PASS" if  tweakreg_out.meta.cal_step.tweakreg == "COMPLETE" else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the Tweakreg step is compete.")
     wcs_filename = output_data.rsplit("_", 1)[0] + "_wcs.asdf"

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -85,8 +85,6 @@ def test_tweakreg(
 
     # check if the Mean Absolute Error is less that 10 milliarcsec  (DMS406)
     abs_diff = (np.absolute(diff))/1.e-3
-    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
-    assert mean_abs_error < 10.0
     assert np.max(abs_diff) < 10.0
     passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -87,7 +87,6 @@ def test_tweakreg(
     abs_diff = (np.absolute(diff))/1.e-3
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert mean_abs_error < 10.0
-    passmsg = "PASS" if mean_abs_error < 10.0 else "FAIL"
     assert np.max(abs_diff) < 10.0
     passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
@@ -103,7 +102,6 @@ def test_tweakreg(
                 log_substring = entry[entry.rfind("abs_refcat"):]
                 refcat_name = log_substring[:log_substring.find("\n")]
 
-        assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
         assert "GAIA" in refcat_name
         passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
         dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -91,22 +91,20 @@ def test_tweakreg(
     passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 
-
-
-    #check that tweakreg has been run
-    if tweakreg_out.meta.cal_step.tweakreg == "COMPLETE":
+    assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
         # Find the reference catalog used by tweakreg
         for entry in tweakreg_out.meta.cal_logs:
-            refcat_name = ' '
+            refcat_name = " "
             if "abs_refcat" in entry:
-                log_substring = entry[entry.rfind("abs_refcat"):]
-                refcat_name = log_substring[:log_substring.find("\n")]
-
+                log_substring = entry[entry.rfind("abs_refcat") :]
+                refcat_name = log_substring[: log_substring.find("\n")]
         assert "GAIA" in refcat_name
         passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
-        dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
-                        f"the Gaia astrometric reference frame.")
-
+        dms_logger.info(
+            f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
+            "the Gaia astrometric reference frame."
+        )
+        
     # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert  mean_abs_error < 5.0

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -82,30 +82,39 @@ def test_tweakreg(
 
     assert rms < 1.3 / np.sqrt(2)
 
+    # check if the Mean Absolute Error is less that 10 milliarcsec  (DMS406)
+    abs_diff = (np.absolute(diff) *0.1)/1.e-3
+    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae * 0.1)/ 1.e-3
+    passmsg = "PASS" if  mean_abs_error < 10.0 else "FAIL"
+    passmsg = "PASS" if  np.max(abs_diff) < 10.0 else "FAIL"
+    dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
+
+
+
     #check that tweakreg has been run
     if tweakreg_out.meta.cal_step.tweakreg == "COMPLETE":
         # Find the reference catalog used by tweakreg
-        for s in tweakreg_out.meta.cal_logs:
-            if 'abs_refcat' in s:
-                str = s
-
-            str1 = str[str.rfind('abs_refcat'):]
-            refcat_name = str1[:str1.find('\n')]
+        for entry in tweakreg_out.meta.cal_logs:
+            if 'abs_refcat' in entry:
+                log_substring = entry[entry.rfind('abs_refcat'):]
+                refcat_name = log_substring[:log_substring.find('\n')]
 
         passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
-        dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to"
+        dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
                         f"the Gaia astrometric reference frame.")
     
-    # check if the Mean Absolute Error is less that 5 milliarcsec (10.0E-3 * pixelscale)
-    assert  tweakreg_out.meta.wcs_fit_results.mae * 0.1 < 5.0e-3 
-    passmsg = "PASS" if  tweakreg_out.meta.wcs_fit_results.mae * 0.1 < 5.0e-3 else "FAIL"
-    dms_logger.info(f"DMS406 {passmsg}, the Mean Absolute Error is less that 5 milliarcsec.")
+    # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
+    mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae * 0.1)/ 1.e-3
+    assert  mean_abs_error < 5.0
+    passmsg = "PASS" if  mean_abs_error < 5.0 else "FAIL"
+    dms_logger.info(f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas.")
     # check that the tweakreg step is marked complete
     passmsg = "PASS" if  tweakreg_out.meta.cal_step.tweakreg == "COMPLETE" else "FAIL"
-    dms_logger.info(f"DMS406 {passmsg}, the Tweakreg step is compete.")
+    dms_logger.info(f"DMS549 {passmsg} the Tweakreg step is compete.")
     wcs_filename = output_data.rsplit("_", 1)[0] + "_wcs.asdf"
     passmsg = "PASS" if os.path.isfile(wcs_filename) else "FAIL"
-    dms_logger.info(f"DMS406 {passmsg}, the output wcs file exists.")
+    dms_logger.info(f"DMS549 {passmsg} the output wcs file exists.")
+
     diff = compare_asdf(rtdata.output, rtdata.truth, atol=1e-3, **ignore_asdf_paths)
     dms_logger.info(
         f"DMS280 MSG: Was the proper TweakReg data produced? : {diff.identical}"

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -3,7 +3,6 @@ import os
 import asdf
 import numpy as np
 import pytest
-
 from astropy import units as u
 from roman_datamodels import datamodels as rdm
 
@@ -14,7 +13,7 @@ from .regtestdata import compare_asdf
 
 @pytest.mark.bigdata
 def test_tweakreg(
-    rtdata, ignore_asdf_paths, tmp_path, resource_tracker, request, dms_logger
+    rtdata, ignore_asdf_paths, resource_tracker, request, dms_logger
 ):
     # N.B.: uncal file is from simulator
     # ``shifted'' version is created in make_regtestdata.sh; cal file is taken,
@@ -99,6 +98,7 @@ def test_tweakreg(
     if tweakreg_out.meta.cal_step.tweakreg == "COMPLETE":
         # Find the reference catalog used by tweakreg
         for entry in tweakreg_out.meta.cal_logs:
+            refcat_name = ' '
             if "abs_refcat" in entry:
                 log_substring = entry[entry.rfind("abs_refcat"):]
                 refcat_name = log_substring[:log_substring.find("\n")]
@@ -108,7 +108,7 @@ def test_tweakreg(
         passmsg = "PASS" if "GAIA" in refcat_name else "FAIL"
         dms_logger.info(f"DMS549 MSG: {passmsg}, {refcat_name} used to align data to "
                         f"the Gaia astrometric reference frame.")
-    
+
     # check if the Mean Absolute Error is less that 5 milliarcsec  (DMS549)
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert  mean_abs_error < 5.0

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -91,7 +91,6 @@ def test_tweakreg(
     passmsg = "PASS" if np.max(abs_diff) < 10.0 else "FAIL"
     dms_logger.info(f"DMS406 {passmsg} the Absolute Astrometric Uncertainty of {np.max(abs_diff):5.2f} mas is less that 10 mas.")
 
-    assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
     # Find the reference catalog used by tweakreg
     refcat_name = None
     for entry in tweakreg_out.meta.cal_logs:
@@ -112,9 +111,6 @@ def test_tweakreg(
     passmsg = "PASS" if  mean_abs_error < 5.0 else "FAIL"
     dms_logger.info(f"DMS549 {passmsg} the Mean Absolute Error of {mean_abs_error:5.2f} mas is less that 5 mas.")
     # check that the tweakreg step is marked complete
-    assert tweakreg_out.meta.cal_step.tweakreg == "COMPLETE"
-    passmsg = "PASS" if  tweakreg_out.meta.cal_step.tweakreg == "COMPLETE" else "FAIL"
-    dms_logger.info(f"DMS549 {passmsg} the Tweakreg step is compete.")
     wcs_filename = output_data.rsplit("_", 1)[0] + "_wcs.asdf"
     assert os.path.isfile(wcs_filename)
     passmsg = "PASS" if os.path.isfile(wcs_filename) else "FAIL"

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -84,7 +84,7 @@ def test_tweakreg(
     assert rms < 1.3 / np.sqrt(2)
 
     # check if the Mean Absolute Error is less that 10 milliarcsec  (DMS406)
-    abs_diff = (np.absolute(diff) *0.1)/1.e-3
+    abs_diff = (np.absolute(diff))/1.e-3
     mean_abs_error = (tweakreg_out.meta.wcs_fit_results.mae )/ 1.e-3
     assert mean_abs_error < 10.0
     passmsg = "PASS" if mean_abs_error < 10.0 else "FAIL"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -146,5 +146,20 @@
   ],
   "DMS488": [
     "romancal.regtest.test_tweakreg.test_tweakreg"
+  ],
+     "DMS531": [
+	 "romancal.regtest.test_source_catalog.test_psf_library"
+  ],
+     "DMS532": [
+	 "romancal.regtest.test_source_catalog.test_psf_library"
+     ],
+     "DMS535": [
+	 "romancal.regtest.test_source_catalog.test_psf_library"
+  ],
+     "DMS536": [
+	 "romancal.regtest.test_source_catalog.test_psf_library"
+  ],    
+  "DMS549": [
+    "romancal.regtest.test_tweakreg.test_tweakreg"
   ]
 }

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -151,16 +151,16 @@
     "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
   "DMS531": [
-    "romancal.regtest.test_psf_library"
+    "romancal.regtest.test_psf_library.test_psf_library_reffile"
   ],
   "DMS532": [
-     "romancal.regtest.test_psf_library"
+     "romancal.regtest.test_psf_library.test_psf_library_reffile"
   ],
   "DMS535": [
-    "romancal.regtest.test_psf_library"
+    "romancal.regtest.test_psf_library.test_psf_library_crdsfile"
   ],
   "DMS536": [
-    "romancal.regtest.test_psf_library"
+    "romancal.regtest.test_psf_library.test_psf_library_psfinterp"
   ],    
   "DMS549": [
     "romancal.regtest.test_tweakreg.test_tweakreg"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -151,16 +151,16 @@
     "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
   "DMS531": [
-    "romancal.regtest.test_psf_library.test_psf_library"
+    "romancal.regtest.test_psf_library"
   ],
   "DMS532": [
-     "romancal.regtest.test_psf_library.test_psf_library"
+     "romancal.regtest.test_psf_library"
   ],
   "DMS535": [
-    "romancal.regtest.test_psf_library.test_psf_library"
+    "romancal.regtest.test_psf_library"
   ],
   "DMS536": [
-    "romancal.regtest.test_psf_library.test_psf_library"
+    "romancal.regtest.test_psf_library"
   ],    
   "DMS549": [
     "romancal.regtest.test_tweakreg.test_tweakreg"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -145,21 +145,21 @@
     "romancal.regtest.test_wfi_grism_16resultants.test_output_has_16_resultants"
   ],
   "DMS488": [
-    "romancal.regtest.test_tweakreg"
+      "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
      "DMS531": [
-	 "romancal.regtest.test_psf_library"
+	 "romancal.regtest.test_psf_library.test_psf_library"
   ],
      "DMS532": [
-	 "romancal.regtest.test_psf_library"
+	 "romancal.regtest.etst_psf_library.test_psf_library"
      ],
      "DMS535": [
-	 "romancal.regtest.test_psf_library"
+	 "romancal.regtest.test_psf_library.test_psf_library"
   ],
      "DMS536": [
-	 "romancal.regtest.test_psf_library"
+	 "romancal.regtest.test_psf_library.test_psf_library"
   ],    
   "DMS549": [
-    "romancal.regtest.test_tweakreg"
+    "romancal.regtest.test_tweakreg.test_tweakreg"
   ]
 }

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -161,7 +161,7 @@
   ],
   "DMS536": [
     "romancal.regtest.test_psf_library.test_psf_library_psfinterp"
-  ],    
+  ],
   "DMS549": [
     "romancal.regtest.test_tweakreg.test_tweakreg"
  ]

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -147,11 +147,11 @@
   "DMS488": [
       "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
-     "DMS531": [
-	 "romancal.regtest.test_psf_library.test_psf_library"
+    "DMS531": [
+       "romancal.regtest.test_psf_library.test_psf_library"
   ],
      "DMS532": [
-	 "romancal.regtest.test_psf_library.test_psf_library"
+	"romancal.regtest.test_psf_library.test_psf_library"
      ],
      "DMS535": [
 	 "romancal.regtest.test_psf_library.test_psf_library"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -151,7 +151,7 @@
 	 "romancal.regtest.test_psf_library.test_psf_library"
   ],
      "DMS532": [
-	 "romancal.regtest.etst_psf_library.test_psf_library"
+	 "romancal.regtest.test_psf_library.test_psf_library"
      ],
      "DMS535": [
 	 "romancal.regtest.test_psf_library.test_psf_library"

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -134,6 +134,9 @@
   "DMS405": [
     "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
+  "DMS406": [
+    "romancal.regtest.test_tweakreg.test_tweakreg"
+  ],
   "DMS413": [
     "romancal.regtest.test_wfi_image_16resultants.test_output_is_image_model",
     "romancal.regtest.test_wfi_image_16resultants.test_input_has_16_resultants",
@@ -145,21 +148,21 @@
     "romancal.regtest.test_wfi_grism_16resultants.test_output_has_16_resultants"
   ],
   "DMS488": [
-      "romancal.regtest.test_tweakreg.test_tweakreg"
+    "romancal.regtest.test_tweakreg.test_tweakreg"
   ],
-    "DMS531": [
-       "romancal.regtest.test_psf_library.test_psf_library"
+  "DMS531": [
+    "romancal.regtest.test_psf_library.test_psf_library"
   ],
-     "DMS532": [
-	"romancal.regtest.test_psf_library.test_psf_library"
-     ],
-     "DMS535": [
-	 "romancal.regtest.test_psf_library.test_psf_library"
+  "DMS532": [
+     "romancal.regtest.test_psf_library.test_psf_library"
   ],
-     "DMS536": [
-	 "romancal.regtest.test_psf_library.test_psf_library"
+  "DMS535": [
+    "romancal.regtest.test_psf_library.test_psf_library"
+  ],
+  "DMS536": [
+    "romancal.regtest.test_psf_library.test_psf_library"
   ],    
   "DMS549": [
     "romancal.regtest.test_tweakreg.test_tweakreg"
-  ]
+ ]
 }

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -145,21 +145,21 @@
     "romancal.regtest.test_wfi_grism_16resultants.test_output_has_16_resultants"
   ],
   "DMS488": [
-    "romancal.regtest.test_tweakreg.test_tweakreg"
+    "romancal.regtest.test_tweakreg"
   ],
      "DMS531": [
-	 "romancal.regtest.test_source_catalog.test_psf_library"
+	 "romancal.regtest.test_psf_library"
   ],
      "DMS532": [
-	 "romancal.regtest.test_source_catalog.test_psf_library"
+	 "romancal.regtest.test_psf_library"
      ],
      "DMS535": [
-	 "romancal.regtest.test_source_catalog.test_psf_library"
+	 "romancal.regtest.test_psf_library"
   ],
      "DMS536": [
-	 "romancal.regtest.test_source_catalog.test_psf_library"
+	 "romancal.regtest.test_psf_library"
   ],    
   "DMS549": [
-    "romancal.regtest.test_tweakreg.test_tweakreg"
+    "romancal.regtest.test_tweakreg"
   ]
 }


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1108](https://jira.stsci.edu/browse/RCAL-1108)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1839

<!-- describe the changes comprising this PR here -->
This PR adds the DMS identifier for the astrometry and ePSF tests as well as updating the tests. 

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [N/A] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

Passing regression tests are at https://github.com/spacetelescope/RegressionTests/actions/runs/16496850855

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
