### PR TITLE
RCAL-1121: Fix missing/mistaken meta assignments

### DIFF
--- a/changes/1874.orientation.rst
+++ b/changes/1874.orientation.rst
@@ -1,0 +1,1 @@
+Fix missing/mistaken meta assignments

--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -472,7 +472,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
     vinfo = wcsinfo
 
     # Get the pointing information
-    quality = 'PLANNED'
+    quality = "PLANNED"
     try:
         t_pars.update_pointing()
     except ValueError as exception:
@@ -1411,7 +1411,7 @@ def update_meta(model, wcsinfo, vinfo, quality):
 
     # Update SIAF-related meta
     wm = model.meta.wcsinfo
-    siaf = Siaf('roman')
+    siaf = Siaf("roman")
     aper = siaf[wm.aperture_name.upper()]
     wm.v2_ref = aper.V2Ref
     wm.v3_ref = aper.V3Ref

--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -484,7 +484,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
                 " Default pointing parameters will be used."
             )
             logger.warning("Exception is %s", exception)
-            logger.info("Setting ENGQLPTG keyword to PLANNED")
+            logger.info("Setting pointing quality to PLANNED")
             quality = "PLANNED"
     else:
         logger.info("Successful read of engineering quaternions:")
@@ -495,7 +495,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
         try:
             wcsinfo, vinfo, transforms = calc_wcs(t_pars)
             quality = "CALCULATED"
-            logger.info("Setting ENGQLPTG keyword to %s", quality)
+            logger.info("Setting pointing quality to %s", quality)
         except EXPECTED_ERRORS as e:
             logger.warning(
                 "WCS calculation has failed and will be skipped."
@@ -505,7 +505,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
             if not t_pars.allow_default:
                 raise
             else:
-                logger.info("Setting ENGQLPTG keyword to PLANNED")
+                logger.info("Setting pointing quality to PLANNED")
                 quality = "PLANNED"
     logger.info("Aperture WCS info: %s", wcsinfo)
     logger.info("V1 WCS info: %s", vinfo)

--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -42,6 +42,20 @@ All the transformation matrices, as defined by
 (DCM). A DCM contains the Euler rotation angles that represent the sky
 coordinates for a particular frame-of-reference. The initial DCM is provided
 through the engineering telemetry and represents how the observatory is orientated.
+
+** META Affected**
+The following meta values are populated:
+
+- meta.pointing.dec_v1
+- meta.pointing.pa_aperture
+- meta.pointing.pa_v3
+- meta.pointing.pointing_engineering_source
+- meta.pointing.ra_v1
+- meta.wcsinfo.dec_ref
+- meta.wcsinfo.ra_ref
+- meta.wcsinfo.roll_ref
+- meta.wcsinfo.s_region
+
 """
 
 import dataclasses

--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -1422,7 +1422,7 @@ def update_meta(model, wcsinfo, vinfo, quality):
     wm.ra_ref = wcsinfo.ra
     wm.dec_ref = wcsinfo.dec
     wm.s_region = wcsinfo.s_region
-    # wm.roll_ref = ???
+    wm.roll_ref = wcsinfo.pa - wm.v3yangle
 
     # Update V1 pointing
     model.meta.pointing.pa_aperture = wcsinfo.pa

--- a/romancal/orientation/tests/test_set_telescope_pointing.py
+++ b/romancal/orientation/tests/test_set_telescope_pointing.py
@@ -39,14 +39,14 @@ OBSTIME_EXPECTED = Time(1805829668.0276294, format="unix")
 
 # Meta attributes for test comparisons
 METAS_EQUALITY = [
-    "meta.exposure.engineering_quality",
+    "meta.pointing.pointing_engineering_source",
 ]
 METAS_ISCLOSE = [
+    "meta.wcsinfo.dec_ref",
+    "meta.wcsinfo.ra_ref",
     "meta.wcsinfo.roll_ref",
     "meta.wcsinfo.v2_ref",
     "meta.wcsinfo.v3_ref",
-    "meta.wcsinfo.ra_ref",
-    "meta.wcsinfo.dec_ref",
     "meta.pointing.ra_v1",
     "meta.pointing.dec_v1",
     "meta.pointing.pa_v3",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1121](https://jira.stsci.edu/browse/RCAL-1121)

<!-- describe the changes comprising this PR here -->
This PR addresses issues found during initial implementation of the orientation scripts in the ground system environment

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
