### PR TITLE
Add default ra/dec.

### DIFF
--- a/romancal/source_catalog/source_catalog.py
+++ b/romancal/source_catalog/source_catalog.py
@@ -341,14 +341,16 @@ class RomanSourceCatalog:
         """
         The best estimate of the right ascension (ICRS).
         """
-        return np.zeros(self.n_sources, dtype=np.float64) * u.deg
+        # FIXME: just return ra_centroid as a placeholder
+        return self.ra_centroid.copy()
 
     @lazyproperty
     def dec(self):
         """
         The best estimate of the declination (ICRS).
         """
-        return np.zeros(self.n_sources, dtype=np.float64) * u.deg
+        # FIXME: just return dec_centroid as a placeholder
+        return self.dec_centroid.copy()
 
     @lazyproperty
     def is_extended(self):

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -186,6 +186,8 @@ def test_l2_source_catalog(
         assert np.min(cat["y_centroid"]) > 0.0
         assert np.max(cat["x_centroid"]) < 100.0
         assert np.max(cat["y_centroid"]) < 100.0
+        assert np.any(cat["ra"])
+        assert np.any(cat["dec"])
 
 
 @pytest.mark.parametrize(
@@ -233,6 +235,8 @@ def test_l3_source_catalog(
         assert np.min(cat["y_centroid"]) > 0.0
         assert np.max(cat["x_centroid"]) < 100.0
         assert np.max(cat["y_centroid"]) < 100.0
+        assert np.any(cat["ra"])
+        assert np.any(cat["dec"])
 
 
 def test_background(mosaic_model, tmp_path):


### PR DESCRIPTION
We added new placeholder 'ra' and 'dec' columns to the catalogs.  These catalogs are the first things people will look at when trying to figure out what the ra/dec of a source is, and are intended to combine the various ras and decs that we provide into a single 'best' quantity.  We have not yet selected an approach for populating this 'best' quantity from the other ras and decs available, but I think it's good to at least populate this quantity with something so that most people's first plots do not have all of the sources colocated at (0, 0).

Regression test passing: https://github.com/spacetelescope/RegressionTests/actions/runs/16882974160 .

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [X] update or add relevant tests
  - [X] update relevant docstrings and / or `docs/` page
  - [X] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [X] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
