### PR TITLE
skip failing engdb tests

### DIFF
--- a/romancal/lib/engdb/tests/test_engdb_mast.py
+++ b/romancal/lib/engdb/tests/test_engdb_mast.py
@@ -70,6 +70,7 @@ def test_aliveness(is_alive):
     engdb_mast.EngdbMast(base_url=engdb_mast.MAST_BASE_URL, token="dummytoken")  # noqa: S106
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_get_records(engdb):
     """Test getting records"""
     records = engdb._get_records(*QUERY)
@@ -77,6 +78,7 @@ def test_get_records(engdb):
     assert report_diff_values(records, EXPECTED_RECORDS)
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 @pytest.mark.parametrize(
     "pars, expected",
     [

--- a/romancal/lib/engdb/tests/test_engdb_tools.py
+++ b/romancal/lib/engdb/tests/test_engdb_tools.py
@@ -35,6 +35,7 @@ def test_environmental_bad(monkeypatch):
     assert did_except, f"DB connection falsely created for {engdb.base_url}"
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_basic(engdb):
     assert engdb._get_records(GOOD_MNEMONIC, GOOD_STARTTIME, GOOD_ENDTIME)
 
@@ -44,6 +45,7 @@ def test_bad_service():
         engdb_tools.engdb_service("junk_service")
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_values(engdb):
     records = engdb._get_records(GOOD_MNEMONIC, SHORT_STARTTIME, SHORT_STARTTIME)
     assert len(records) == 2
@@ -52,6 +54,7 @@ def test_values(engdb):
     assert values[0] == "SCFA"
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_values_with_bracket(engdb):
     records = engdb._get_records(GOOD_MNEMONIC, SHORT_STARTTIME, SHORT_STARTTIME)
     assert len(records) == 2
@@ -62,6 +65,7 @@ def test_values_with_bracket(engdb):
     assert values[1] == "SCFA"
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_values_with_time(engdb):
     values = engdb.get_values(
         GOOD_MNEMONIC, GOOD_STARTTIME, SHORT_STARTTIME, include_obstime=True
@@ -71,11 +75,13 @@ def test_values_with_time(engdb):
     assert isinstance(values[0].obstime, Time)
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_novalues(engdb):
     values = engdb.get_values(GOOD_MNEMONIC, NODATA_STARTIME, NODATA_ENDTIME)
     assert len(values) == 0
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_unzip(engdb):
     """Test forunzipped versions of content"""
     values = engdb.get_values(

--- a/romancal/orientation/tests/test_set_telescope_pointing.py
+++ b/romancal/orientation/tests/test_set_telescope_pointing.py
@@ -89,6 +89,7 @@ def test_change_base_url_fail():
         )
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_get_pointing():
     """Ensure that the averaging works."""
     q_expected = np.array([-0.52558752, 0.3719724, -0.52016581, 0.38150882])

--- a/romancal/orientation/tests/test_v1_calculate.py
+++ b/romancal/orientation/tests/test_v1_calculate.py
@@ -17,6 +17,7 @@ MAST_GOOD_STARTTIME = Time("2027-03-23T19:20:40", format="isot")
 MAST_GOOD_ENDTIME = Time("2027-03-23T19:21:36", format="isot")
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_from_models_mast(tmp_path):
     """Test v1_calculate_from_models for basic running"""
     model = ScienceRawModel.create_fake_data(
@@ -48,6 +49,7 @@ def test_from_models_mast(tmp_path):
     assert len(errors) == 0, f"V1 tables are different: {errors_str}"
 
 
+@pytest.mark.skip(reason="needs update for new database response")
 def test_over_time_mast(tmp_path):
     """Test v1_calculate_over_time for basic running"""
     try:


### PR DESCRIPTION
Several tests are failing due to a change in the response from the engineering database.

This is a stop-gap PR skipping those tests until they can be fixed. By skipping these tests other PRs can be tests and other projects can continue to use the romancal regtests for testing code changes.

Regression tests show no failures: https://github.com/spacetelescope/RegressionTests/actions/runs/17245133624

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
