### PR TITLE
RCAL-1118 Record aperture corrections in catalog headers 

### DIFF
--- a/changes/1911.source_catalog.rst
+++ b/changes/1911.source_catalog.rst
@@ -1,0 +1,3 @@
+Update source catalog tables to use the `ee_fraction`` values from the ``apcorr_ref``
+reference file, using it for the ``is_extended`` flag decision. Also, the ``ee_fraction``
+values for each of the aperture radii are now stored in the table metadata.

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from re import match
 
 import astropy.units as u
 import numpy as np
@@ -102,6 +103,22 @@ def test_multiband_catalog(
     cat = result.source_catalog
     assert isinstance(cat, Table)
     assert len(cat) == 7
+
+    assert len(cat.meta["aperture_radii"]["circle_pix"]) > 0
+    print(cat.colnames)
+    assert sum(
+        1 for name in cat.colnames if match(r"^aper\d+_f158_flux$", name)
+    ) == len(cat.meta["aperture_radii"]["circle_pix"])
+    assert sum(
+        1 for name in cat.colnames if match(r"^aper\d+_f184_flux$", name)
+    ) == len(cat.meta["aperture_radii"]["circle_pix"])
+    assert "ee_fractions" in cat.meta
+    assert isinstance(cat.meta["ee_fractions"], dict)
+    assert len(cat.meta["ee_fractions"]) == 2
+    assert "f158" in cat.meta["ee_fractions"]
+    assert "f184" in cat.meta["ee_fractions"]
+    for value in cat.meta["ee_fractions"].values():
+        assert len(value) == len(cat.meta["aperture_radii"]["circle_pix"])
 
     if len(cat) > 0:
         assert np.min(cat["x_centroid"]) > 0.0

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from re import match
 
 import astropy.units as u
 import numpy as np
@@ -174,6 +175,20 @@ def test_l2_source_catalog(
     assert isinstance(cat, Table)
     assert len(cat) == nsources
 
+    # Check that the ee_fraction_xx entries are in the metadata
+    if "aperture_radii" in cat.meta:
+        assert len(cat.meta["aperture_radii"]["circle_pix"]) > 0
+        assert sum(1 for name in cat.colnames if match(r"^aper\d+_flux$", name)) == len(
+            cat.meta["aperture_radii"]["circle_pix"]
+        )
+
+        assert "ee_fractions" in cat.meta
+        assert len(cat.meta["ee_fractions"]) == len(
+            cat.meta["aperture_radii"]["circle_pix"]
+        )
+    else:
+        assert nsources == 0
+
     if nsources > 0:
         for colname in cat.colnames:
             if (
@@ -222,6 +237,20 @@ def test_l3_source_catalog(
     cat = result.source_catalog
     assert isinstance(cat, Table)
     assert len(cat) == nsources
+
+    # Check that the ee_fraction_xx entries are in the metadata
+    if "aperture_radii" in cat.meta:
+        assert len(cat.meta["aperture_radii"]["circle_pix"]) > 0
+        assert sum(1 for name in cat.colnames if match(r"^aper\d+_flux$", name)) == len(
+            cat.meta["aperture_radii"]["circle_pix"]
+        )
+
+        assert "ee_fractions" in cat.meta
+        assert len(cat.meta["ee_fractions"]) == len(
+            cat.meta["aperture_radii"]["circle_pix"]
+        )
+    else:
+        assert nsources == 0
 
     if nsources > 0:
         for colname in cat.colnames:


### PR DESCRIPTION
…ile, save  those fractions in the table metadata, and update the is_extended property to use the ee_fraction values

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1118](https://jira.stsci.edu/browse/RCAL-118)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR reads the `ee_fractions` from the `apcorr` reference file and then computes the `ee_fractions` used by the pipeline. These values are then stored in the header of the `source_catalog` table.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
