### PR TITLE
Follow on for the removal of tagged scalars from RAD

### DIFF
--- a/docs/roman/datamodels/models.rst
+++ b/docs/roman/datamodels/models.rst
@@ -145,11 +145,11 @@ You can examine the contents of your model from within python using
     root (AsdfObject)
     └─roman (WfiImage) # Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
       ├─meta (dict)
-      │ ├─calibration_software_name (CalibrationSoftwareName): RomanCAL # Calibration Software Name
-      │ ├─calibration_software_version (CalibrationSoftwareVersion): 9.9.0 # Calibration Software Version Number
-      │ ├─filename (Filename): r0019106003005004023_0034_wfi01_cal.asdf # File Name
-      │ ├─file_date (FileDate): 2020-01-01T00:00:00.000
-      │ ├─model_type (ModelType): ImageModel # Data Model Type
+      │ ├─calibration_software_name (str): RomanCAL # Calibration Software Name
+      │ ├─calibration_software_version (str): 9.9.0 # Calibration Software Version Number
+      │ ├─filename (str): r0019106003005004023_0034_wfi01_cal.asdf # File Name
+      │ ├─file_date (Time): 2020-01-01T00:00:00.000 # File Creation Date
+      │ ├─model_type (str): ImageModel # Data Model Type
     ...
 
 or you can print specifics


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR includes the changes for `romancal` that are necessary to support spacetelescope/rad#688 and spacetelescope/roman_datamodels#555. The only change of note for `romancal` is that the `model.info()` output is very slightly different.

See https://github.com/spacetelescope/rad/pull/688#issue-3368635125 for an explanation of the failing regression tests.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
