### PR TITLE
only save l1 wcs if save_results is enabled

### DIFF
--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -1308,3 +1308,17 @@ def test_tweakreg_updates_s_region(tmp_path, base_image):
         for i, model in enumerate(res):
             assert model.meta.wcsinfo.s_region != old_fake_s_region
             res.shelve(model, i, modify=False)
+
+
+@pytest.mark.parametrize("save_results", [True, False])
+def test_tweakreg_produces_output(tmp_path, base_image, save_results):
+    """With save_results and output_dir set confirm expected files are in the output directory"""
+    img = base_image()
+    add_tweakreg_catalog_attribute(tmp_path, img, catalog_filename="img")
+    base_filename = img.meta.filename
+    trs.TweakRegStep.call([img], save_results=save_results, output_dir=str(tmp_path))
+
+    fns = [p.name for p in tmp_path.iterdir()]
+    # the files should exist only if save_results was True
+    assert (f"{base_filename}_tweakregstep.asdf" in fns) == save_results
+    assert (f"{base_filename}_wcs.asdf" in fns) == save_results

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -288,7 +288,7 @@ class TweakRegStep(RomanStep):
                     images.shelve(image_model, imcat.meta["model_index"])
 
         # Write out the WfiWcs products
-        if self.save_l1_wcs:
+        if self.save_l1_wcs and self.save_results:
             save_wfiwcs(self, images, force=True)
 
         return images


### PR DESCRIPTION

Closes https://github.com/spacetelescope/romancal/issues/1758

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
