### PR TITLE
Fix `os.chdir` usage in tests

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,22 +1,6 @@
-import os
-from contextlib import contextmanager
+from contextlib import chdir
 
 import pytest
-
-# chdir contextmanager was added with Python 3.11
-try:
-    from contextlib import chdir
-except ImportError:
-
-    @contextmanager
-    def chdir(path):
-        old_path = os.getcwd()
-
-        try:
-            os.chdir(path)
-            yield
-        finally:
-            os.chdir(old_path)
 
 
 @pytest.fixture(autouse=True)

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from re import match
 
@@ -86,9 +85,8 @@ def library_model_all_nan(mosaic_model):
     ),
 )
 def test_multiband_catalog(
-    library_model, fit_psf, snr_threshold, npixels, save_results, tmp_path
+    library_model, fit_psf, snr_threshold, npixels, save_results, function_jail
 ):
-    os.chdir(tmp_path)
     step = MultibandCatalogStep()
 
     result = step.call(
@@ -138,19 +136,18 @@ def test_multiband_catalog(
                 assert f"{colname}_err" in cat.colnames
 
     if save_results:
-        filepath = Path(tmp_path / f"{result.meta.filename}_cat.parquet")
+        filepath = Path(function_jail / f"{result.meta.filename}_cat.parquet")
         assert filepath.exists()
         tbl = pyarrow.parquet.read_table(filepath)
         assert isinstance(tbl, pyarrow.Table)
 
-        filepath = Path(tmp_path / f"{result.meta.filename}_segm.asdf")
+        filepath = Path(function_jail / f"{result.meta.filename}_segm.asdf")
         assert filepath.exists()
         assert isinstance(rdm.open(filepath), MosaicSegmentationMapModel)
 
 
 @pytest.mark.parametrize("save_results", (True, False))
-def test_multiband_catalog_no_detections(library_model, save_results, tmp_path):
-    os.chdir(tmp_path)
+def test_multiband_catalog_no_detections(library_model, save_results, function_jail):
     step = MultibandCatalogStep()
 
     result = step.call(
@@ -169,9 +166,8 @@ def test_multiband_catalog_no_detections(library_model, save_results, tmp_path):
 
 @pytest.mark.parametrize("save_results", (True, False))
 def test_multiband_catalog_invalid_inputs(
-    library_model_all_nan, save_results, tmp_path
+    library_model_all_nan, save_results, function_jail
 ):
-    os.chdir(tmp_path)
     step = MultibandCatalogStep()
 
     result = step.call(
@@ -189,9 +185,9 @@ def test_multiband_catalog_invalid_inputs(
 
 
 @pytest.mark.parametrize("save_results", (True, False))
-def test_multiband_catalog_some_invalid_inputs(library_model, save_results, tmp_path):
-    os.chdir(tmp_path)
-
+def test_multiband_catalog_some_invalid_inputs(
+    library_model, save_results, function_jail
+):
     # Modify the first model in the library to have all NaN values
     with library_model:
         model = library_model.borrow(0)  # f184 model

--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 
@@ -245,13 +243,12 @@ def test_identical_images(tmp_path, base_image, caplog):
 def test_outlier_detection_always_returns_modelcontainer_with_updated_datamodels(
     input_type,
     base_image,
-    tmp_path,
     create_mock_asn_file,
+    function_jail,
 ):
     """Test that the OutlierDetectionStep always returns a ModelLibrary
     with updated data models after processing different input types."""
 
-    os.chdir(tmp_path)
     img_1 = base_image()
     img_1.meta.filename = "img_1.asdf"
     img_1.data *= img_1.meta.photometry.conversion_megajanskys / img_1.data
@@ -260,12 +257,12 @@ def test_outlier_detection_always_returns_modelcontainer_with_updated_datamodels
     img_2.data *= img_2.meta.photometry.conversion_megajanskys / img_2.data
 
     library = ModelLibrary([img_1, img_2])
-    library._save(tmp_path)
+    library._save(function_jail)
 
     step_input_map = {
         "ModelLibrary": library,
         "ASNFile": create_mock_asn_file(
-            tmp_path,
+            function_jail,
             members_mapping=[
                 {"expname": img_1.meta.filename, "exptype": "science"},
                 {"expname": img_2.meta.filename, "exptype": "science"},

--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -58,13 +58,11 @@ def test_input_to_output(function_jail, input_value, expected_output_type):
 
 @pytest.mark.parametrize("save_results", [True, False])
 @pytest.mark.parametrize("skip_tweakreg", [True, False])
-def test_elp_save_results(
-    function_jail, tmp_path, save_results, skip_tweakreg, monkeypatch
-):
+def test_elp_save_results(function_jail, save_results, skip_tweakreg, monkeypatch):
     """
     Test that the elp respects save_results.
     """
-    output_path = tmp_path / "output"
+    output_path = function_jail / "output"
     output_path.mkdir()
 
     model = rdm.ScienceRawModel.create_fake_data()
@@ -86,7 +84,7 @@ def test_elp_save_results(
 
     pipeline.run(model)
     # check that the current directory doesn't contain extra files
-    assert set(p.name for p in tmp_path.iterdir()) == {"output"}
+    assert set(p.name for p in function_jail.iterdir()) == {"output"}
 
     output_files = set(p.name for p in output_path.iterdir())
     # TODO shouldn't this be empty?

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -3,6 +3,7 @@ import os.path as op
 import pprint
 import shutil
 import sys
+from contextlib import chdir
 from difflib import unified_diff
 from glob import glob as _sys_glob
 from pathlib import Path
@@ -215,15 +216,12 @@ class RegtestData:
             self.truth_remote = path
         if docopy is None:
             docopy = self.docopy
-        os.makedirs("truth", exist_ok=True)
-        os.chdir("truth")
-        try:
+
+        truth_dir = Path("truth")
+        truth_dir.mkdir(exist_ok=True)
+        with chdir(truth_dir):
             self.truth = get_bigdata(self._inputs_root, self._env, path, docopy=docopy)
             self.truth_remote = os.path.join(self._inputs_root, self._env, path)
-        except BigdataError:
-            os.chdir("..")
-            raise
-        os.chdir("..")
 
         return self.truth
 

--- a/romancal/skymatch/tests/test_skymatch.py
+++ b/romancal/skymatch/tests/test_skymatch.py
@@ -1,4 +1,3 @@
-import os
 from itertools import product
 
 import astropy.units as u
@@ -404,13 +403,12 @@ def test_skymatch_2x(wfi_rate, skymethod, subtract):
 def test_skymatch_always_returns_modellibrary_with_updated_datamodels(
     input_type,
     mk_sky_match_image_models,
-    tmp_path,
     create_mock_asn_file,
+    function_jail,
 ):
     """Test that the SkyMatchStep always returns a ModelLibrary
     with updated data models after processing different input types."""
 
-    os.chdir(tmp_path)
     [im1a, im1b, im2a, im2b, im3], dq_mask = mk_sky_match_image_models
 
     im1a.meta.filename = "im1a.asdf"
@@ -420,12 +418,12 @@ def test_skymatch_always_returns_modellibrary_with_updated_datamodels(
     im3.meta.filename = "im3.asdf"
 
     library = ModelLibrary([im1a, im1b, im2a, im2b, im3])
-    library._save(tmp_path)
+    library._save(function_jail)
 
     step_input_map = {
         "ModelLibrary": library,
         "ASNFile": create_mock_asn_file(
-            tmp_path,
+            function_jail,
             members_mapping=[
                 {"expname": im1a.meta.filename, "exptype": "science"},
                 {"expname": im1b.meta.filename, "exptype": "science"},

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -982,13 +982,11 @@ def test_parse_catfile_raises_error_on_invalid_content(tmp_path, catfile_line_co
         trs._parse_catfile(catfile)
 
 
-def test_update_source_catalog_coordinates(tmp_path, base_image):
+def test_update_source_catalog_coordinates(function_jail, base_image):
     """Test that TweakReg updates the catalog coordinates with the tweaked WCS."""
 
-    os.chdir(tmp_path)
-
     img = base_image(shift_1=1000, shift_2=1000)
-    add_tweakreg_catalog_attribute(tmp_path, img, catalog_filename="img_1")
+    add_tweakreg_catalog_attribute(function_jail, img, catalog_filename="img_1")
 
     # create ImageSourceCatalogModel
     source_catalog = setup_source_catalog(img)
@@ -1027,13 +1025,11 @@ def test_update_source_catalog_coordinates(tmp_path, base_image):
     np.testing.assert_array_equal(cat_dec_psf, expected_psf[1])
 
 
-def test_source_catalog_coordinates_have_changed(tmp_path, base_image):
+def test_source_catalog_coordinates_have_changed(function_jail, base_image):
     """Test that the original catalog file content is different from the updated file."""
 
-    os.chdir(tmp_path)
-
     img = base_image(shift_1=1000, shift_2=1000)
-    add_tweakreg_catalog_attribute(tmp_path, img, catalog_filename="img_1")
+    add_tweakreg_catalog_attribute(function_jail, img, catalog_filename="img_1")
 
     # create ImageSourceCatalogModel
     source_catalog = setup_source_catalog(img)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
I have been running the RCAL tests a lot lately, and so I started running them locally with `pytest-xdist` to speed things up. In doing this I occasionally saw files that were not cleaned up by the tests as they finished.

After investigating this I noticed this only happened when tests were run in parallel and not serially. Except when a couple of tests were run by themselves. The issue boils down to the use `os.chdir` which changes pythons working directory to whatever is input until its changed again, since this happens outside of `pytest`'s control it can bleed over into other tests. The parallel running of tests with `pytest-xdist` exposed this because each parallel runner is executing in its own spawned python instance, so if the test which switched python to working in some temporary directly happened in a different thread than some of the tests in question they would write their results out to the main directory for me to see.

We already have the `function_jail` fixture, which operates on a temporary directory first switching python to work in that directory and then upon test completion python is returned to the home directory prior to the switch. My solution was to `grep` through RCAL finding usages of `os.chdir` and replacing them with the use of `function_jail` like what they should have used for the start. For future development, lets try to avoid using `os.chdir` in tests and use `function_jail` or the `contextlib.chdir` context manager.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
