### PR TITLE
convert info and search doctests to directives

### DIFF
--- a/docs/roman/datamodels/models.rst
+++ b/docs/roman/datamodels/models.rst
@@ -139,26 +139,8 @@ Looking at the contents of a model
 
 You can examine the contents of your model from within python using
 
-.. code-block:: python
-
-    >>> image_model.info()  # doctest: +ELLIPSIS
-    root (AsdfObject)
-    └─roman (WfiImage) # Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
-      ├─meta (dict)
-      │ ├─calibration_software_name (str): RomanCAL # Calibration Software Name
-      │ ├─calibration_software_version (str): 9.9.0 # Calibration Software Version Number
-      │ ├─filename (str): r0019106003005004023_0034_wfi01_cal.asdf # File Name
-      │ ├─file_date (Time): 2020-01-01T00:00:00.000 # File Creation Date
-      │ ├─model_type (str): ImageModel # Data Model Type
-    ...
+.. image_model_info::
 
 or you can print specifics
 
-.. code-block:: python
-
-    >>> image_model.search("detector")
-    root (AsdfObject)
-    └─roman (WfiImage) # Level 2 (L2) Calibrated Roman Wide Field Instrument (WFI) Rate Image.
-      └─meta (dict)
-        └─instrument (dict) # Wide Field Instrument (WFI) Configuration Information
-          └─detector (str): WFI01
+.. image_model_search::


### PR DESCRIPTION
Follow up to https://github.com/spacetelescope/romancal/pull/2003 (and other previous PRs that required updating the mentioned doctest).

This converts the hard-coded doctests on the models doc page that expect a specific info and search output:
https://roman-pipeline.readthedocs.io/en/latest/roman/datamodels/models.html#looking-at-the-contents-of-a-model

to sphinx directives that generate the docs output based on the current (whatever it may be) info and search output:
https://roman-pipeline--2005.org.readthedocs.build/en/2005/roman/datamodels/models.html#looking-at-the-contents-of-a-model

See discussion over at https://github.com/spacetelescope/romancal/pull/2004

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
