### PR TITLE
switch to rdm released version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,15 @@ dependencies = [
     "numpy >=1.25",
     "photutils >=2.1.0",
     "requests >=2.26",
-    "roman_datamodels >=0.28.0",
+    # Between the intermediate and build releases we want to keep
+    # the roman_datamodels pin to the released version. If there
+    # is a need to change this to main then we need a new
+    # roman_datamodels release.
+    "roman_datamodels >=0.28.0,<0.29.0",
     # "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
     "scipy >=1.14.1",
     "stcal>=1.15.1,<1.16.0",
-    # "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe >=0.11.0,<0.12.0",
-    # "stpipe @ git+https://github.com/spacetelescope/stpipe.git@main",
     "tweakwcs >=0.8.11",
     "spherical-geometry >= 1.3.3",
     "stsci.imagestats >= 1.8.3",


### PR DESCRIPTION
Changes roman_datamodels dependency to released version and fixes the stcal min version.

The thought process here is:
- we expect the next romancal release to use the released version of roman_datamodels
- we'd like to continue making roman_datamodels/rad changes on roman_datamodels/rad main

By changing the roman_datamodels pin to the released version this will mean that:
- scheduled regtest runs will use the released version of rdm
- regtests run for rcal PRs will use the released version of rdm

This will allow us to make rcal changes and by default they will be tested against the released rdm. If we see failures that require rdm changes we know we need a new rdm release.

Since we're hoping to continue making rdm/rad changes we will end up wanting to run rcal tests with these changes. This is possible even with the pin here via:
- rcal downstream testing that is part of the rdm CI
- regtests can still be run with rdm/rad main

This does mean that there are some rdm/rad changes that impact regtests that we'll want to defer until after the rcal release but we can proceed with changes like dropping the maker_utils, adding PITs schemas, etc.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/18572070002/job/52948292600

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
