### PR TITLE
Temporarily don't treat drizzle deprecation warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,10 @@ norecursedirs = [
 filterwarnings = [
     "error::ResourceWarning",
     "error::DeprecationWarning",
+    "ignore:Argument 'scale' has been deprecated since version 3.0.*Use 'iscale' and 'pixel_scale_ratio' instead.*:DeprecationWarning",
+    "ignore:Argument 'output_pixel_shape' has been deprecated since version 3.0.*can be inferred from 'pixmap'.*:DeprecationWarning",
+    "ignore:Argument 'exptime' has been deprecated since version 3.0.*Use 'iscale' instead and set iscale=exptime.*:DeprecationWarning",
+    "ignore:Argument 'pix_ratio' has been deprecated since version 3.0.*Use 'iscale' instead and set iscale.*:DeprecationWarning",
 ]
 junit_family = "xunit2"
 inputs_root = "roman-pipeline"


### PR DESCRIPTION
In preparation for release 3.0 of `drizzle` package, this PR disables treatment of deprecation warnings to be introduced in the upcoming release of the `drizzle` as errors during testing.

This PR can be reverted after `drizzle v3.0.0` is released and https://github.com/spacetelescope/romancal/pull/2009 is merged.

CC: @pllim 

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
