### PR TITLE
Add ignore_asdf_paths to compare_asdf.

### DIFF
--- a/romancal/regtest/test_psf_library.py
+++ b/romancal/regtest/test_psf_library.py
@@ -164,7 +164,7 @@ def test_psf_library_jitter(render_psfs):
     assert rms(stamps["center"], yy) < rms(stamps["jitter"], yy)
 
 
-def test_psf_match(render_psfs):
+def test_psf_match(render_psfs, ignore_asdf_paths):
     rtdata, _ = render_psfs
-    diff = compare_asdf(rtdata.output, rtdata.truth)
+    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
     assert diff.identical, diff.report()


### PR DESCRIPTION
#2023 introduced failures in devdeps regression tests because it failed to ignore certain asdf keywords that vary among different development versions of files.  This adds the usual ignore_asdf_paths behavior to avoid testing for exact matches on those keywords.

Passes regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/19106470882