### PR TITLE
ignore reverted warning issued in python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ norecursedirs = [
 filterwarnings = [
     "error::ResourceWarning",
     "error::DeprecationWarning",
+    "ignore:invalid escape:DeprecationWarning",
 ]
 junit_family = "xunit2"
 inputs_root = "roman-pipeline"


### PR DESCRIPTION
In python 3.11 an invalid escape like [this one in coord](https://github.com/LSSTDESC/Coord/blob/f812084154af7cc44b6d63eca49b2fa515e87fe2/coord/angle.py#L492C37-L492C58) results in a `DeprecationWarning`. Now that galsim and all it's dependencies are part of the romancal dependencies this warning is causing regtest failures:
https://github.com/spacetelescope/RegressionTests/actions/runs/19316090038
but only in 3.11 since in 3.12 the warning was changed to a `SynataxWarning`:
https://github.com/python/cpython/pull/99011
Since we don't convert `SynataxWarning`s to errors the failures are only in 3.11.

This PR adds a warning filter to ignore the `DeprecationWarning` to allow the tests to pass in 3.11.

Run with python 3.11 showing no failures:
https://github.com/spacetelescope/RegressionTests/actions/runs/19335058418/job/55310495642

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
