### PR TITLE
offload copying `array_shape` to `wcsinfo_to_wcs` function

### DIFF
--- a/changes/2070.general.rst
+++ b/changes/2070.general.rst
@@ -1,0 +1,1 @@
+ensure `wcsobj.array_shape` is populated by inverse of `wcsobj.pixel_shape`

--- a/romancal/lib/wcsinfo_to_wcs.py
+++ b/romancal/lib/wcsinfo_to_wcs.py
@@ -68,4 +68,8 @@ def wcsinfo_to_wcs(
     if bounding_box:
         wcsobj.bounding_box = bounding_box
 
+    # ensure array_shape is populated
+    if not hasattr(wcsobj, "array_shape"):
+        wcsobj.array_shape = wcsobj.pixel_shape[::-1]
+
     return wcsobj

--- a/romancal/skycell/skymap.py
+++ b/romancal/skycell/skymap.py
@@ -244,15 +244,13 @@ class SkyCell:
     @cached_property
     def wcs(self) -> WCS:
         """WCS representing this sky cell"""
-        wcsobj = wcsinfo_to_wcs(
+        return wcsinfo_to_wcs(
             self.wcs_info,
             bounding_box=(
                 (-0.5, self.pixel_shape[0] - 0.5),
                 (-0.5, self.pixel_shape[1] - 0.5),
             ),
         )
-        wcsobj.array_shape = self.pixel_shape
-        return wcsobj
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, SkyCell):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
split from #1964 

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
