### PR TITLE
RTB-1027: Add wfi18_transient step

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,7 @@ This PR addresses ...
   - ``changes/<PR#>.dq_init.rst``
   - ``changes/<PR#>.saturation.rst``
   - ``changes/<PR#>.refpix.rst``
+  - ``changes/<PR#>.wfi18_transient.rst``
   - ``changes/<PR#>.linearity.rst``
   - ``changes/<PR#>.dark_current.rst``
   - ``changes/<PR#>.jump_detection.rst``

--- a/changes/2096.wfi18_transient.rst
+++ b/changes/2096.wfi18_transient.rst
@@ -1,0 +1,1 @@
+Add the new ``wfi18_transient`` step to the exposure level pipeline to correct an anomalous first read signal in detector WFI18.

--- a/docs/roman/data_products/product_types.rst
+++ b/docs/roman/data_products/product_types.rst
@@ -33,6 +33,8 @@ the user is running the pipeline. The input for each optional step is the output
 +------------------------------------------------+-----------------+--------------------------+---------------------+------------------+---------------------------------------+
 | :ref:`refpix <refpix>`                         |                 | refpix (opt)             | RampModel           | DN               | 3-D ref pix corrected data            |
 +------------------------------------------------+-----------------+--------------------------+---------------------+------------------+---------------------------------------+
+| :ref:`wfi18_transient <wfi18_transient_step>`  |                 | wfi18_transient (opt)    | RampModel           | DN               | 3-D data corrected for WFI18 transient|
++------------------------------------------------+-----------------+--------------------------+---------------------+------------------+---------------------------------------+
 | :ref:`linearity <linearity_step>`              |                 | linearity (opt)          | RampModel           | DN               | 3-D linearity corrected data          |
 +------------------------------------------------+-----------------+--------------------------+---------------------+------------------+---------------------------------------+
 | :ref:`dark_current <dark_current_step>`        |                 | darkcurrent (opt)        | RampModel           | DN               | 3-D dark current subtracted data      |

--- a/docs/roman/package_index.rst
+++ b/docs/roman/package_index.rst
@@ -21,3 +21,4 @@
    stpipe/index.rst
    tweakreg/index.rst
    set_velocity_aberration.rst
+   wfi18_transient/index.rst

--- a/docs/roman/pipeline/exposure_pipeline.rst
+++ b/docs/roman/pipeline/exposure_pipeline.rst
@@ -26,6 +26,7 @@ table below.
  :ref:`dq_init <dq_init_step>`                      |check|    |check|  |check|
  :ref:`saturation <saturation_step>`                |check|    |check|  |check|
  :ref:`refpix <refpix>`                             |check|    |check|  |check|
+ :ref:`wfi18_transient <wfi18_transient_step>`      |check|    |check|  |check|
  :ref:`linearity <linearity_step>`                  |check|    |check|  |check|
  :ref:`ramp_fitting <ramp_fitting_step>`            |check|    |check|  |check|
  :ref:`dark_current <dark_current_step>`            |check|    |check|  |check|

--- a/docs/roman/pipeline_naming_conventions.rst
+++ b/docs/roman/pipeline_naming_conventions.rst
@@ -75,6 +75,7 @@ Uncalibrated raw input                         `_uncal`
 DQ initialization                              `_dqinit`
 Saturation detection                           `_saturation`
 Reference Pixel Correction                     `_refpix`
+WFI18 Transient Anomaly Correction             `_wfi18_transient`
 Linearity correction                           `_linearity`
 Dark current                                   `_darkcurrent`
 Corrected ramp data                            `_rampfit`

--- a/docs/roman/pipeline_steps.rst
+++ b/docs/roman/pipeline_steps.rst
@@ -6,6 +6,7 @@ Pipeline Steps
    dq_init/index.rst
    saturation/index.rst
    refpix/index.rst
+   wfi18_transient/index.rst
    linearity/index.rst
    dark_current/index.rst
    ramp_fitting/index.rst

--- a/docs/roman/references_general/dq_flags.inc
+++ b/docs/roman/references_general/dq_flags.inc
@@ -1,37 +1,38 @@
 Flags for the DQ, PIXELDQ, and GROUPDQ Arrays.
 
-===  ==========    ================  ===========================================
-Bit  Value         Name              Description
-===  ==========    ================  ===========================================
-0    1             DO_NOT_USE        Bad pixel. Do not use.
-1    2             SATURATED         Pixel saturated during exposure
-2    4             JUMP_DET          Jump detected during exposure
-3    8             DROPOUT           Data lost in transmission
-4    16            GW_AFFECTED_DATA  Data affected by the GW read window
-5    32            PERSISTENCE       High persistence (was RESERVED_2)
-6    64            AD_FLOOR          Below A/D floor (0 DN, was RESERVED_3)
-7    128           OUTLIER           Detected as outlier in coadded image
-8    256           UNRELIABLE_ERROR  Uncertainty exceeds quoted error
-9    512           NON_SCIENCE       Pixel not on science portion of detector
-10   1024          DEAD              Dead pixel
-11   2048          HOT               Hot pixel
-12   4096          WARM              Warm pixel
-13   8192          LOW_QE            Low quantum efficiency
-15   32768         TELEGRAPH         Telegraph pixel
-16   65536         NONLINEAR         Pixel highly nonlinear
-17   131072        BAD_REF_PIXEL     Reference pixel cannot be used
-18   262144        NO_FLAT_FIELD     Flat field cannot be measured
-19   524288        NO_GAIN_VALUE     Gain cannot be measured
-20   1048576       NO_LIN_CORR       Linearity correction not available
-21   2097152       NO_SAT_CHECK      Saturation check not available
-22   4194304       UNRELIABLE_BIAS   Bias variance large
-23   8388608       UNRELIABLE_DARK   Dark variance large
-24   16777216      UNRELIABLE_SLOPE  Slope variance large (i.e., noisy pixel)
-25   33554432      UNRELIABLE_FLAT   Flat variance large
+===  ==========    ================        ===========================================
+Bit  Value         Name                    Description
+===  ==========    ================        ===========================================
+0    1             DO_NOT_USE              Bad pixel. Do not use.
+1    2             SATURATED               Pixel saturated during exposure
+2    4             JUMP_DET                Jump detected during exposure
+3    8             DROPOUT                 Data lost in transmission
+4    16            GW_AFFECTED_DATA        Data affected by the GW read window
+5    32            PERSISTENCE             High persistence (was RESERVED_2)
+6    64            AD_FLOOR                Below A/D floor (0 DN, was RESERVED_3)
+7    128           WFI18_TRANSIENT         Group DQ only: Affected by the WFI18 transient anomaly
+7    128           OUTLIER                 Pixel DQ only: Detected as outlier in coadded image
+8    256           UNRELIABLE_ERROR        Uncertainty exceeds quoted error
+9    512           NON_SCIENCE             Pixel not on science portion of detector
+10   1024          DEAD                    Dead pixel
+11   2048          HOT                     Hot pixel
+12   4096          WARM                    Warm pixel
+13   8192          LOW_QE                  Low quantum efficiency
+15   32768         TELEGRAPH               Telegraph pixel
+16   65536         NONLINEAR               Pixel highly nonlinear
+17   131072        BAD_REF_PIXEL           Reference pixel cannot be used
+18   262144        NO_FLAT_FIELD           Flat field cannot be measured
+19   524288        NO_GAIN_VALUE           Gain cannot be measured
+20   1048576       NO_LIN_CORR             Linearity correction not available
+21   2097152       NO_SAT_CHECK            Saturation check not available
+22   4194304       UNRELIABLE_BIAS         Bias variance large
+23   8388608       UNRELIABLE_DARK         Dark variance large
+24   16777216      UNRELIABLE_SLOPE        Slope variance large (i.e., noisy pixel)
+25   33554432      UNRELIABLE_FLAT         Flat variance large
 26   67108864      RESERVED_5
 27   134217728     RESERVED_6
-28   268435456     UNRELIABLE_RESET  Sensitive to reset anomaly
+28   268435456     UNRELIABLE_RESET        Sensitive to reset anomaly
 29   536870912     RESERVED_7
-30   1073741824    OTHER_BAD_PIXEL   A catch-all flag
-31   2147483648    REFERENCE_PIXEL   Pixel is a reference pixel
-===  ==========    ================  ===========================================
+30   1073741824    OTHER_BAD_PIXEL         A catch-all flag
+31   2147483648    REFERENCE_PIXEL         Pixel is a reference pixel
+===  ==========    ================        ===========================================

--- a/docs/roman/wfi18_transient/arguments.rst
+++ b/docs/roman/wfi18_transient/arguments.rst
@@ -1,0 +1,11 @@
+.. _wfi18_transient_arguments:
+
+Step Arguments
+==============
+The ``wfi18_transient`` step uses the following optional arguments:
+
+``--mask_rows`` (boolean, default=False)
+  If True, the rows in the first resultant that are most affected by
+  the transient anomaly will be set to DO_NOT_USE in the GROUPDQ
+  array.  If False, a fit to the transient anomaly is attempted, and
+  the fit correction is subtracted from the first resultant.

--- a/docs/roman/wfi18_transient/description.rst
+++ b/docs/roman/wfi18_transient/description.rst
@@ -6,7 +6,7 @@ read of exposures taken with detector WFI18.  The transient signal is strongly t
 dependent with significant exposure-to-exposure variations so it must be fit and
 removed separately for each exposure.
 
-To fit the transient signal, the ``wfi_transient`` step implements the following algorithm:
+To fit the transient signal, the ``wfi18_transient`` step implements the following algorithm:
 
 #. Estimate the true counts in the first read from the values in the 2nd and 3rd
    resultants, extrapolating backward from the count rate.
@@ -18,7 +18,7 @@ To fit the transient signal, the ``wfi_transient`` step implements the following
    values to minimize bias from covariances.
 
 #. Estimate the typical residual in each row from a sigma-clipped mean of the
-   weakly illuminated pixels.
+   residuals in weakly illuminated pixels.
 
 #. Fit the row residuals with a double-exponential model with functional form:
 

--- a/docs/roman/wfi18_transient/description.rst
+++ b/docs/roman/wfi18_transient/description.rst
@@ -1,0 +1,54 @@
+Description
+============
+
+The ``wfi18_transient`` step corrects for an anomalous transient signal in the first
+read of exposures taken with detector WFI18.  The transient signal is strongly temperature
+dependent with significant exposure-to-exposure variations so it must be fit and
+removed separately for each exposure.
+
+To fit the transient signal, the ``wfi_transient`` step implements the following algorithm:
+
+#. Estimate the true counts in the first read from the values in the 2nd and 3rd
+   resultants, extrapolating backward from the count rate.
+
+#. Construct the first read residuals by subtracting the estimated counts from the
+   measured counts, recorded in the first resultant.
+
+#. Identify weakly illuminated pixels in each row, using the 4th and 5th resultant
+   values to minimize bias from covariances.
+
+#. Estimate the typical residual in each row from a sigma-clipped mean of the
+   weakly illuminated pixels.
+
+#. Fit the row residuals with a double-exponential model with functional form:
+
+   .. math::
+
+      residual = a\ exp[-t / \tau_a] + b\ exp[-t / \tau_b]
+
+   where :math:`t` is the average readout time for the row and :math:`a`, :math:`b`,
+   :math:`\tau_a` and :math:`\tau_b` are free parameters.
+
+#. Evaluate the fit model at the readout time for each pixel in the first
+   resultant.
+
+#. Subtract the modeled residuals from the first resultant.
+
+This algorithm requires a minimum of 5 resultants to be successful.  If fewer resultants
+are present, or if the fit fails for any reason, the step will fall back on simply
+masking the rows most affected by the transient anomaly.  In this case, the first
+1000 rows of the first resultant will be set to DO_NOT_USE in the GROUPDQ array.
+Optionally, the user may choose to apply the mask instead of attempting a fit as above,
+by setting the ``mask_rows`` parameter for this step to ``True``.
+
+This step is applicable to detector WFI18 only.  On successful completion for WFI18
+data, the ``wfi18_transient`` keyword in the ``cal_step`` metadata is set to "COMPLETE".
+If it is run on an exposure from any other detector it will have no effect, other
+than to set the ``cal_step`` metadata keyword to "N/A".
+
+References
+----------
+
+The WFI18 transient correction algorithm is based on work by T. Brandt,
+"Characterizing and Correcting the Anomalous First Read of Detector 18 on Roman-WFI",
+STScI Technical Document, 2025 (in prep).

--- a/docs/roman/wfi18_transient/index.rst
+++ b/docs/roman/wfi18_transient/index.rst
@@ -1,0 +1,13 @@
+.. _wfi18_transient_step:
+
+==================================
+WFI18 Transient Anomaly Correction
+==================================
+
+.. toctree::
+   :maxdepth: 2
+
+   description.rst
+   arguments.rst
+
+.. automodapi:: romancal.wfi18_transient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,11 @@ name = "``refpix`` (WFI-Image, WFI-Prism, WFI-Grism)"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "wfi18_transient"
+name = "``wfi18_transient`` (WFI-Image, WFI-Prism, WFI-Grism)"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "linearity"
 name = "``linearity`` (WFI-Image, WFI-Prism, WFI-Grism)"
 showcontent = true

--- a/romancal/lib/suffix.py
+++ b/romancal/lib/suffix.py
@@ -61,6 +61,7 @@ SUFFIXES_TO_ADD = [
     "cat",
     "segm",
     "coadd",
+    "wfi18_transient",
 ]
 
 # Suffixes that are discovered but should not be considered.
@@ -93,6 +94,7 @@ _calculated_suffixes = {
     "resamplestep",
     "sourcecatalogstep",
     "multibandcatalogstep",
+    "wfi18transientstep",
 }
 
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -25,6 +25,7 @@ from romancal.refpix import RefPixStep
 from romancal.saturation import SaturationStep
 from romancal.source_catalog import SourceCatalogStep
 from romancal.tweakreg import TweakRegStep
+from romancal.wfi18_transient import WFI18TransientStep
 
 from ..stpipe import RomanPipeline
 
@@ -57,6 +58,7 @@ class ExposurePipeline(RomanPipeline):
         "dq_init": dq_init_step.DQInitStep,
         "saturation": SaturationStep,
         "refpix": RefPixStep,
+        "wfi18_transient": WFI18TransientStep,
         "linearity": LinearityStep,
         "dark_current": DarkCurrentStep,
         "rampfit": ramp_fit_step.RampFitStep,
@@ -116,6 +118,7 @@ class ExposurePipeline(RomanPipeline):
                     )
                 else:
                     result = self.refpix.run(result)
+                    result = self.wfi18_transient.run(result)
                     result = self.linearity.run(result)
                     result = self.rampfit.run(result)
                     result = self.dark_current.run(result)
@@ -183,6 +186,7 @@ class ExposurePipeline(RomanPipeline):
         # Set all subsequent steps to skipped
         for step_str in [
             "refpix",
+            "wfi18_transient",
             "linearity",
             "dark",
             "ramp_fit",

--- a/romancal/regtest/test_wfi18_transient.py
+++ b/romancal/regtest/test_wfi18_transient.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+import roman_datamodels as rdm
+
+from romancal.lib.suffix import replace_suffix
+from romancal.stpipe import RomanStep
+
+from .regtestdata import compare_asdf
+
+# mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
+WFI18_FILENAME = "TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_refpix.asdf"
+WFI01_FILENAME = "r0000101001001001001_0001_wfi01_f158_refpix.asdf"
+
+
+@pytest.fixture(
+    params=[
+        WFI18_FILENAME,
+        WFI01_FILENAME,
+    ],
+    scope="module",
+)
+def run_wfi18_transient(rtdata_module, resource_tracker, request):
+    rtdata = rtdata_module
+    input_fn = request.param
+    output_fn = replace_suffix(Path(input_fn).stem, "wfi18_transient") + ".asdf"
+    rtdata.get_data(f"WFI/image/{input_fn}")
+    rtdata.output = output_fn
+    rtdata.get_truth(f"truth/WFI/image/{output_fn}")
+    with resource_tracker.track():
+        RomanStep.from_cmdline(["romancal.step.WFI18TransientStep", rtdata.input])
+    return rtdata
+
+
+@pytest.fixture(scope="module")
+def output_model(run_wfi18_transient):
+    with rdm.open(run_wfi18_transient.output) as model:
+        yield model
+
+
+def test_log_tracked_resources(log_tracked_resources, run_wfi18_transient):
+    log_tracked_resources()
+
+
+def test_output_matches_truth(run_wfi18_transient, ignore_asdf_paths):
+    rtdata = run_wfi18_transient
+    diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
+    assert diff.identical, diff.report()
+
+
+def test_cal_step_updated(output_model):
+    """Test that cal_step is set as expected."""
+    if output_model.meta.instrument.detector == "WFI18":
+        assert output_model.meta.cal_step.wfi18_transient == "COMPLETE"
+    else:
+        assert output_model.meta.cal_step.wfi18_transient == "N/A"

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -239,3 +239,13 @@ out = test_psf_library.render_psfs_for_filename(
     'r0000101001001001001_0001_wfi01_f158_cal.asdf')
 asdf.dump(out, open('psf_render.asdf', 'wb'))"
 cp psf_render.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+# tests for wfi18_transient step: uses WFI18 TVAC data as well as the default WFI01 data
+jf rt dl roman-pipeline/dev/WFI/image/TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_uncal.asdf --flat
+cp TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
+strun roman_elp TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_uncal.asdf --steps.refpix.save_results=true --steps.wfi18_transient.skip=true --steps.linearity.skip=true --steps.dark_current.skip=True --steps.rampfit.skip=true --steps.assign_wcs.skip=true --steps.flatfield.skip=true --steps.photom.skip=true --steps.source_catalog.skip=true --steps.tweakreg.skip=true
+cp TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_refpix.asdf $outdir/roman-pipeline/dev/WFI/image/
+strun romancal.step.WFI18TransientStep TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_refpix.asdf
+cp TVAC2_NOMOPS_TTNOISE_20240418084515_WFI18_wfi18_transient.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+strun romancal.step.WFI18TransientStep r0000101001001001001_0001_wfi01_f158_refpix.asdf
+cp r0000101001001001001_0001_wfi01_f158_refpix.asdf $outdir/roman-pipeline/dev/truth/WFI/image/

--- a/romancal/step.py
+++ b/romancal/step.py
@@ -19,6 +19,7 @@ from .saturation.saturation_step import SaturationStep
 from .skymatch.skymatch_step import SkyMatchStep
 from .source_catalog.source_catalog_step import SourceCatalogStep
 from .tweakreg.tweakreg_step import TweakRegStep
+from .wfi18_transient.wfi18_transient_step import WFI18TransientStep
 
 __all__ = [
     "AssignWcsStep",
@@ -37,4 +38,5 @@ __all__ = [
     "SkyMatchStep",
     "SourceCatalogStep",
     "TweakRegStep",
+    "WFI18TransientStep",
 ]

--- a/romancal/stpipe/integration.py
+++ b/romancal/stpipe/integration.py
@@ -39,4 +39,5 @@ def get_steps():
         ("romancal.step.ResampleStep", "resample", False),
         ("romancal.step.SourceCatalogStep", "source_catalog", False),
         ("romancal.step.MultibandCatalogStep", "multiband_catalog", False),
+        ("romancal.step.WFI18TransientStep", "wfi18_transient", False),
     ]

--- a/romancal/wfi18_transient/__init__.py
+++ b/romancal/wfi18_transient/__init__.py
@@ -1,0 +1,3 @@
+from .wfi18_transient_step import WFI18TransientStep
+
+__all__ = ["WFI18TransientStep"]

--- a/romancal/wfi18_transient/tests/test_wfi18_transient.py
+++ b/romancal/wfi18_transient/tests/test_wfi18_transient.py
@@ -1,9 +1,11 @@
 import numpy as np
-from roman_datamodels import datamodels
+from roman_datamodels import datamodels, dqflags
 
 from romancal.wfi18_transient.wfi18_transient import _double_exp, _frame_read_times
 from romancal.wfi18_transient.wfi18_transient_step import WFI18TransientStep
 
+
+MASK_FLAG = dqflags.group.DO_NOT_USE | dqflags.group.WFI18_TRANSIENT
 
 def create_ramp_model(nresultants, nrows=4096, ncols=4096):
     # make a ramp model with fake data
@@ -101,7 +103,7 @@ def test_wfi18_transient_too_few_resultants(caplog):
 
     assert "Masking affected rows" in caplog.text
     np.testing.assert_equal(result.data, 0)
-    np.testing.assert_equal(result.groupdq[0, :1000], 1)
+    np.testing.assert_equal(result.groupdq[0, :1000], MASK_FLAG)
     np.testing.assert_equal(result.groupdq[0, 1000:], 0)
     np.testing.assert_equal(result.groupdq[1:], 0)
 
@@ -116,7 +118,7 @@ def test_wfi18_transient_fit_failure(caplog):
 
     assert "Transient fit failed; masking affected rows instead" in caplog.text
     np.testing.assert_equal(result.data, np.nan)
-    np.testing.assert_equal(result.groupdq[0, :1000], 1)
+    np.testing.assert_equal(result.groupdq[0, :1000], MASK_FLAG)
     np.testing.assert_equal(result.groupdq[0, 1000:], 0)
     np.testing.assert_equal(result.groupdq[1:], 0)
 

--- a/romancal/wfi18_transient/tests/test_wfi18_transient.py
+++ b/romancal/wfi18_transient/tests/test_wfi18_transient.py
@@ -4,8 +4,8 @@ from roman_datamodels import datamodels, dqflags
 from romancal.wfi18_transient.wfi18_transient import _double_exp, _frame_read_times
 from romancal.wfi18_transient.wfi18_transient_step import WFI18TransientStep
 
-
 MASK_FLAG = dqflags.group.DO_NOT_USE | dqflags.group.WFI18_TRANSIENT
+
 
 def create_ramp_model(nresultants, nrows=4096, ncols=4096):
     # make a ramp model with fake data

--- a/romancal/wfi18_transient/tests/test_wfi18_transient.py
+++ b/romancal/wfi18_transient/tests/test_wfi18_transient.py
@@ -1,0 +1,141 @@
+import numpy as np
+from roman_datamodels import datamodels
+
+from romancal.wfi18_transient.wfi18_transient import _double_exp, _frame_read_times
+from romancal.wfi18_transient.wfi18_transient_step import WFI18TransientStep
+
+
+def create_ramp_model(nresultants, nrows=4096, ncols=4096):
+    # make a ramp model with fake data
+    ramp_model = datamodels.RampModel.create_fake_data(
+        shape=(nresultants, nrows, ncols)
+    )
+
+    # add necessary metadata
+    ramp_model.meta.instrument.detector = "WFI18"
+    ramp_model.meta.exposure.frame_time = 1.0
+    ramp_model.meta.exposure.sca_number = 18
+
+    # add required cal steps
+    ramp_model.meta.cal_step = {}
+    for step_name in ramp_model.schema_info("required")["roman"]["meta"]["cal_step"][
+        "required"
+    ].info:
+        ramp_model.meta.cal_step[step_name] = "INCOMPLETE"
+
+    # add a read pattern with an increasing number of groups
+    read_pattern = []
+    next_value = 1
+    for n in range(nresultants):
+        read_pattern.append(list(range(next_value, next_value + n + 1)))
+        next_value = read_pattern[-1][-1] + 1
+
+    ramp_model.meta.exposure.read_pattern = read_pattern
+    ramp_model.pixeldq = np.zeros((nrows, ncols), dtype=ramp_model.pixeldq.dtype)
+    ramp_model.groupdq = np.zeros(
+        (nresultants, nrows, ncols), dtype=ramp_model.groupdq.dtype
+    )
+
+    return ramp_model
+
+
+def transient_glow():
+    read_times = _frame_read_times(18, 1.0)
+    glow = _double_exp(read_times, 0.1, 0.01, 0.01, 0.01)
+    return glow
+
+
+def test_wfi18_transient(caplog):
+    model = create_ramp_model(5)
+
+    # Fill the data array with a flat value
+    model.data[:] = 1.0
+
+    # Add a glow to the bottom of the detector in the first read,
+    # not including the reference pixels
+    model.data[0, 4:-4, 4:-4] += transient_glow()[4:-4, 4:-4]
+    assert not np.allclose(model.data, 1.0, atol=1e-5)
+
+    # Correct out the glow
+    result = WFI18TransientStep.call(model)
+    assert result.meta.cal_step.wfi18_transient == "COMPLETE"
+
+    # For this test data, the fit should succeed. The correction
+    # should be pretty good, restoring the value to the expected
+    # value of 1.0
+    np.testing.assert_allclose(result.data, 1.0, atol=1e-5)
+    np.testing.assert_equal(result.groupdq, 0)
+
+
+def test_wfi18_transient_flat_data(caplog):
+    model = create_ramp_model(5)
+
+    # Fill the data array with a flat value
+    model.data[:] = 1.0
+
+    result = WFI18TransientStep.call(model)
+    assert result.meta.cal_step.wfi18_transient == "COMPLETE"
+
+    # For flat data, the fit should succeed and there
+    # should be no change in the output
+    np.testing.assert_equal(result.data, 1)
+    np.testing.assert_equal(result.groupdq, 0)
+
+
+def test_wfi18_transient_wrong_detector():
+    model = create_ramp_model(1)
+    model.meta.instrument.detector = "WFI01"
+
+    # attempting to call on the wrong detector will skip the step
+    # and set the cal step status to N/A
+    result = WFI18TransientStep.call(model)
+    assert result.meta.cal_step.wfi18_transient == "N/A"
+
+
+def test_wfi18_transient_too_few_resultants(caplog):
+    model = create_ramp_model(1)
+
+    # attempting to call with resultants < 5 will fall back on masking
+    result = WFI18TransientStep.call(model)
+    assert result.meta.cal_step.wfi18_transient == "COMPLETE"
+
+    assert "Masking affected rows" in caplog.text
+    np.testing.assert_equal(result.data, 0)
+    np.testing.assert_equal(result.groupdq[0, :1000], 1)
+    np.testing.assert_equal(result.groupdq[0, 1000:], 0)
+    np.testing.assert_equal(result.groupdq[1:], 0)
+
+
+def test_wfi18_transient_fit_failure(caplog):
+    model = create_ramp_model(5)
+    model.data[:] = np.nan
+
+    # attempting to call with invalid data will fall back on masking
+    result = WFI18TransientStep.call(model)
+    assert result.meta.cal_step.wfi18_transient == "COMPLETE"
+
+    assert "Transient fit failed; masking affected rows instead" in caplog.text
+    np.testing.assert_equal(result.data, np.nan)
+    np.testing.assert_equal(result.groupdq[0, :1000], 1)
+    np.testing.assert_equal(result.groupdq[0, 1000:], 0)
+    np.testing.assert_equal(result.groupdq[1:], 0)
+
+
+def test_wfi18_transient_save_results(tmp_path):
+    # Make a small model
+    model = create_ramp_model(1, nrows=10, ncols=10)
+    model.meta.filename = "test_refpix.asdf"
+    input_filename = str(tmp_path / model.meta.filename)
+    model.save(input_filename)
+
+    # Run on the file on disk, save the output
+    WFI18TransientStep.call(input_filename, save_results=True, output_dir=str(tmp_path))
+
+    # Output should have the correct suffix
+    expected_output = tmp_path / "test_wfi18_transient.asdf"
+    assert expected_output.exists()
+
+    # Saved output has the expected type and metadata
+    with datamodels.open(expected_output) as output_model:
+        assert isinstance(output_model, datamodels.RampModel)
+        assert output_model.meta.cal_step.wfi18_transient == "COMPLETE"

--- a/romancal/wfi18_transient/wfi18_transient.py
+++ b/romancal/wfi18_transient/wfi18_transient.py
@@ -1,0 +1,211 @@
+import logging
+import warnings
+
+import numpy as np
+from astropy.stats import sigma_clipped_stats
+from roman_datamodels import dqflags
+from scipy import optimize
+
+__all__ = ["correct_anomaly", "mask_affected_rows"]
+
+log = logging.getLogger(__name__)
+
+
+def mask_affected_rows(groupdq):
+    """
+    Mask the rows most affected by the transient anomaly.
+
+    Rows masked with DO_NOT_USE are 0-1000, at the bottom of the array.
+
+    Parameters
+    ----------
+    groupdq : `~numpy.ndarray`
+        The group DQ image.  Updated in place.
+    """
+    groupdq[0, :1000, :] |= dqflags.group.DO_NOT_USE
+
+
+def _frame_read_times(sca, frame_time):
+    """
+    Compute the read times for a single frame.
+
+    This is a placeholder function that assumes a uniform read
+    across each channel within the frame time.  A more careful
+    treatment will need to account for time spent reading out the
+    guide window.
+
+    Data shape for the frame is assumed to be 4096 x 4096, with
+    32 channels along the columns.
+
+    Parameters
+    ----------
+    sca : int
+        Detector number.
+    frame_time : float
+        The frame time for the exposure, in seconds.
+
+    Returns
+    -------
+    read_times : `~numpy.ndarray`
+        A 4096 x 4096 array containing the read time in seconds for each pixel.
+    """
+    nchannel = 32
+    nrow = 4096
+    ncol = 128
+    channel_read_times = (
+        np.arange(nrow * ncol).reshape(nrow, ncol) / (nrow * ncol) * frame_time
+    )
+    read_times = np.tile(channel_read_times, (1, nchannel))
+
+    # Apply science -> detector flipping for read order
+    if (sca % 3) == 0:
+        read_times = read_times[:, ::-1]
+    else:  # pragma: no cover
+        # This is not expected for WFI18, but included here for completeness.
+        read_times = read_times[::-1, :]
+    return read_times
+
+
+def _resultant_read_times(read_pattern, frame_time):
+    """
+    Compute the mean read time for each resultant in the exposure.
+
+    Parameters
+    ----------
+    read_pattern : list of list of int
+        The read pattern for the exposure, from `meta.exposure.read_pattern`.
+    frame_time : float
+        The frame time for the exposure, in seconds.
+
+    Returns
+    -------
+    `~numpy.ndarray`
+        One float value for each resultant, containing the mean read time
+        in seconds.
+    """
+    t_resultant = []
+    for pattern in read_pattern:
+        group_read = [r * frame_time for r in pattern]
+        t_resultant.append(np.mean(group_read))
+    return np.array(t_resultant)
+
+
+def _double_exp(t, a, b, tau_a, tau_b):
+    """
+    Evaluate a double exponential function.
+
+    Functional form is ``a * exp(-t/tau_a) + b * exp(-t/tau_b)``.
+
+    Parameters
+    ----------
+    t : float
+        Time (independent variable).
+    a : float
+        Amplitude for the first exponential.
+    b : float
+        Amplitude for the second exponential.
+    tau_a : float
+        Time constant for the first exponential.
+    tau_b : float
+        Time constant for the second exponential.
+
+    Returns
+    -------
+    float
+        The double exponential function evaluated at time ``t``.
+    """
+    return a * np.exp(-t / tau_a) + b * np.exp(-t / tau_b)
+
+
+def correct_anomaly(input_model, mask_rows=False):
+    """
+    Correct the transient first read anomaly.
+
+    If the input model has less than 5 resultants or the fitting
+    process fails, the most affected rows in the first read will be
+    masked instead of fitting and removing the anomaly.
+
+    Parameters
+    ----------
+    input_model : `~roman_datamodels.datamodels.RampModel`
+        Input model to correct. Updated in place.
+    mask_rows : bool, optional
+        If True, use the fallback option of just masking the
+        most affected rows instead of fitting and removing
+        the anomaly.
+
+    Returns
+    -------
+    input_model : `~roman_datamodels.datamodels.RampModel`
+        The updated model.
+    """
+    # Fallback option: just mask the affected rows in the first read
+    if mask_rows or input_model.data.shape[0] < 5:
+        log.info("Masking affected rows")
+        mask_affected_rows(input_model.groupdq)
+        return input_model
+
+    # Get the read times for all pixels and resultants
+    sca = input_model.meta.exposure.sca_number
+    frame_time = input_model.meta.exposure.frame_time
+    read_pattern = input_model.meta.exposure.read_pattern
+    t_pixel = _frame_read_times(sca, frame_time)
+    t_resultant = _resultant_read_times(read_pattern, frame_time)
+
+    # Input data without reference pixels
+    data = input_model.data[:, 4:-4, 4:-4]
+    t_pixel = t_pixel[4:-4, 4:-4]
+
+    # Average read time per row
+    t_row = np.mean(t_pixel, axis=1)
+
+    # The anomalous recorded value for the first read
+    first_read = data[0].copy()
+
+    # Use the 2nd and 3rd resultants to estimate the true value for the first read,
+    # extrapolating backward from the count rate.
+    diff_time = np.diff(t_resultant)
+    estimated_rate = (data[2] - data[1]) / diff_time[1]
+    estimated_first_read = data[1] - estimated_rate * diff_time[0]
+
+    # Residual from the estimated value
+    residual = first_read - estimated_first_read
+
+    # Identify rows with weakly illuminated pixels for fitting.
+    # Use a different pair of reads, to minimize bias from covariances.
+    diff_data = data[4] - data[3]
+    high_illum_mask = diff_data > np.median(diff_data, axis=1)
+
+    # Compute the sigma clipped mean of the residual for each row
+    # from the low illumination pixels
+    residual_rows, _, _ = sigma_clipped_stats(
+        residual, mask=high_illum_mask, sigma=3.0, axis=1
+    )
+
+    # Fit the sum of two exponential functions to the residual rows
+    # Starting guess is here is empirical and may need adjustment.
+    p0 = [residual_rows[0] * 1.1, residual_rows[0] * -0.1, t_row[300], t_row[1000]]
+
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "Covariance of the parameters could not be estimated",
+                optimize.OptimizeWarning,
+            )
+            result = optimize.curve_fit(_double_exp, t_row, residual_rows, p0=p0)
+    except (ValueError, RuntimeError):
+        # Fit failed - fall back on masking the data
+        log.warning("Transient fit failed; masking affected rows instead.")
+        mask_affected_rows(input_model.groupdq)
+        return input_model
+
+    # Calculate the correction by evaluating the model at the pixel readout times.
+    a, b, tau_a, tau_b = result[0]
+    log.debug(f"Fit parameters: a={a}, b={b}, tau_a={tau_a}, tau_b={tau_b}")
+    correction = _double_exp(t_pixel, a, b, tau_a, tau_b)
+
+    # Subtract the correction in the array view
+    data[0] -= correction
+
+    return input_model

--- a/romancal/wfi18_transient/wfi18_transient.py
+++ b/romancal/wfi18_transient/wfi18_transient.py
@@ -171,7 +171,7 @@ def correct_anomaly(input_model, mask_rows=False):
     # Residual from the estimated value
     residual = first_read - estimated_first_read
 
-    # Identify rows with weakly illuminated pixels for fitting.
+    # Identify weakly illuminated pixels in each row for fitting.
     # Use a different pair of reads, to minimize bias from covariances.
     diff_data = data[4] - data[3]
     high_illum_mask = diff_data > np.median(diff_data, axis=1)

--- a/romancal/wfi18_transient/wfi18_transient.py
+++ b/romancal/wfi18_transient/wfi18_transient.py
@@ -22,7 +22,7 @@ def mask_affected_rows(groupdq):
     groupdq : `~numpy.ndarray`
         The group DQ image.  Updated in place.
     """
-    groupdq[0, :1000, :] |= dqflags.group.DO_NOT_USE
+    groupdq[0, :1000, :] |= dqflags.group.DO_NOT_USE | dqflags.group.WFI18_TRANSIENT
 
 
 def _frame_read_times(sca, frame_time):

--- a/romancal/wfi18_transient/wfi18_transient_step.py
+++ b/romancal/wfi18_transient/wfi18_transient_step.py
@@ -28,7 +28,7 @@ class WFI18TransientStep(RomanStep):
     reference_file_types: ClassVar = []
 
     spec = """
-        mask_rows = boolean(default = False) # Just mask the affected rows
+        mask_rows = boolean(default = False) # Mask the affected rows instead of fitting
     """
 
     def process(self, input_data):

--- a/romancal/wfi18_transient/wfi18_transient_step.py
+++ b/romancal/wfi18_transient/wfi18_transient_step.py
@@ -1,0 +1,56 @@
+#! /usr/bin/env python
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import roman_datamodels as rdm
+
+from romancal.stpipe import RomanStep
+from romancal.wfi18_transient.wfi18_transient import correct_anomaly
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
+__all__ = ["WFI18TransientStep"]
+
+log = logging.getLogger(__name__)
+
+
+class WFI18TransientStep(RomanStep):
+    """
+    Correct a transient anomaly in the first read.
+
+    This correction applies to detector WFI18 only.
+    """
+
+    class_alias = "wfi18_transient"
+    reference_file_types: ClassVar = []
+
+    spec = """
+        mask_rows = boolean(default = False) # Just mask the affected rows
+    """
+
+    def process(self, input_data):
+        if isinstance(input_data, rdm.DataModel):
+            input_model = input_data
+        else:
+            # Open the input data model
+            input_model = rdm.open(input_data)
+
+        # Ignore any data that is not WFI18
+        if input_model.meta.instrument.detector != "WFI18":
+            input_model.meta.cal_step.wfi18_transient = "N/A"
+            return input_model
+
+        log.info("Correcting the first read transient anomaly for WFI18")
+        output_model = correct_anomaly(input_model, mask_rows=self.mask_rows)
+        output_model.meta.cal_step.wfi18_transient = "COMPLETE"
+
+        if self.save_results:
+            try:
+                self.suffix = "wfi18_transient"
+            except AttributeError:
+                self["suffix"] = "wfi18_transient"
+
+        return output_model

--- a/romancal/wfi18_transient/wfi18_transient_step.py
+++ b/romancal/wfi18_transient/wfi18_transient_step.py
@@ -38,6 +38,12 @@ class WFI18TransientStep(RomanStep):
             # Open the input data model
             input_model = rdm.open(input_data)
 
+        if self.save_results:
+            try:
+                self.suffix = "wfi18_transient"
+            except AttributeError:
+                self["suffix"] = "wfi18_transient"
+
         # Ignore any data that is not WFI18
         if input_model.meta.instrument.detector != "WFI18":
             input_model.meta.cal_step.wfi18_transient = "N/A"
@@ -46,11 +52,5 @@ class WFI18TransientStep(RomanStep):
         log.info("Correcting the first read transient anomaly for WFI18")
         output_model = correct_anomaly(input_model, mask_rows=self.mask_rows)
         output_model.meta.cal_step.wfi18_transient = "COMPLETE"
-
-        if self.save_results:
-            try:
-                self.suffix = "wfi18_transient"
-            except AttributeError:
-                self["suffix"] = "wfi18_transient"
 
         return output_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RTB-1027](https://jira.stsci.edu/browse/RTB-1027)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Add a new step to the exposure level pipeline to address the WFI18 transient anomaly in the first read.

Note:
- Requires a change to the cal_step schema to add the new step status keyword: https://github.com/spacetelescope/rad/pull/780 (merged)
- Also requires a change to roman_datamodels to add a new group DQ flag: https://github.com/spacetelescope/roman_datamodels/pull/615 (merged)
- This draft includes a placeholder function for calculating the readout timing, assuming a uniform read across each channel within the frame time.  It will need to be updated when a more rigorous timing calculation is possible.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
