### PR TITLE
Update stcal dependency to point to GitHub main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "crds >=13.0.2",
     "drizzle >= 2.1.1,<2.2",
     "gwcs >=0.25.2,<0.27.0",
-    "stcal>=1.15.2,<1.16.0",
+    "stcal @ git+https://github.com/spacetelescope/stcal.git",
     "stpipe >=0.11.0,<0.12.0",
     "spherical-geometry >=1.3.3,<1.4",
     "stsci.imagestats >=1.8.3,<1.9",  # remove when stcal fixes this missing dep


### PR DESCRIPTION
Changed from pinned version range to git main to track latest development.

We've been failing regtests recently due to the saturation flag handling change (allowing distinguishing between partially and fully saturated ramps).  The different behavior under stcal/main and released stcal means that we can't simultaneously satisfy the main & devdeps regtests.  By moving to stcal/main this will no longer be the case.

## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/20552469169

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.skycell.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>
