### PR TITLE
Update source injection tests to reflect romanisim abandoning astropy units

### DIFF
--- a/romancal/source_catalog/tests/test_injection.py
+++ b/romancal/source_catalog/tests/test_injection.py
@@ -199,7 +199,7 @@ def test_inject_sources(image_model, mosaic_model):
         cps_conv = bandpass.get_abflux(test_filter, 2)
         # electrons to mjysr (roughly order unity in scale)
         if isinstance(si_model, ImageModel):
-            unit_factor = 1 / parameters.reference_data["gain"].value
+            unit_factor = 1 / parameters.reference_data["gain"]
         else:
             unit_factor = bandpass.etomjysr(test_filter, 2)
         total_rec_flux = np.sum(si_model.data - data_orig.data)  # MJy / sr


### PR DESCRIPTION
The source injection test relied on romanisim's gain parameter having units.  This was removed in romanisim main, so that now the gain parameter has no units.  This PR removes the '.value' attribute access that relies on gain being a unit.

This only updates a test and doesn't have implications on regtests or need a changelog entry.

This makes regtests pass.  https://github.com/spacetelescope/RegressionTests/actions/runs/20997706259