### PR TITLE
remove unused RampModel.err

### DIFF
--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -111,33 +111,6 @@ def test_groupdq():
     )
 
 
-def test_err():
-    """Check that a 3-D ERR array is initialized and all values are zero."""
-
-    # size of integration
-    instrument = "WFI"
-    nresultants = 5
-    xsize = 1032
-    ysize = 1024
-    csize = (nresultants, ysize, xsize)
-
-    # create raw input data for step
-    dm_ramp = make_ramp(csize, instrument)
-
-    # create a MaskModel elements for the dq input mask
-    ref_data = MaskRefModel.create_fake_data(shape=csize[1:])
-    ref_data["meta"]["instrument"]["name"] = instrument
-
-    # run correction step
-    outfile = do_dqinit(dm_ramp, ref_data)
-
-    # check that ERR array was created and initialized to zero
-    errarr = outfile.err
-
-    assert errarr.ndim == 3  # check that output err array is 3-D
-    assert np.all(errarr == 0)  # check that values are 0
-
-
 def test_dq_add1_groupdq():
     """
     Test if the dq_init code set the groupdq flag on the first
@@ -236,7 +209,6 @@ def test_dqinit_step_interface(instrument, exptype):
     assert result.pixeldq.shape == shape[1:]
     assert result.meta.cal_step.dq_init == "COMPLETE"
     assert result.data.dtype == np.float32
-    assert result.err.dtype == np.float32
     assert result.pixeldq.dtype == np.uint32
     assert result.groupdq.dtype == np.uint8
     # check that extra value came through

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -171,7 +171,7 @@ class ExposurePipeline(RomanPipeline):
         # Create a dictionary for fully saturated data
         slopes = np.zeros(input_model.data.shape[1:], dtype=fake_model.data.dtype)
         dq = input_model.pixeldq | input_model.groupdq[0] | group.SATURATED
-        err = np.zeros(input_model.err.shape[1:], dtype=fake_model.err.dtype)
+        err = np.zeros(input_model.data.shape[1:], dtype=fake_model.err.dtype)
         image_info_allsat = {
             "slope": slopes,
             "dq": dq,

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -165,10 +165,13 @@ class ExposurePipeline(RomanPipeline):
         """
         Create zeroed-out image file
         """
+        # Make a throw-away model to get the expected datatypes
+        fake_model = rdm.ImageModel.create_fake_data()
+
         # Create a dictionary for fully saturated data
-        slopes = np.zeros(input_model.data.shape[1:], dtype=input_model.data.dtype)
+        slopes = np.zeros(input_model.data.shape[1:], dtype=fake_model.data.dtype)
         dq = input_model.pixeldq | input_model.groupdq[0] | group.SATURATED
-        err = np.zeros(input_model.err.shape[1:], dtype=input_model.err.dtype)
+        err = np.zeros(input_model.err.shape[1:], dtype=fake_model.err.dtype)
         image_info_allsat = {
             "slope": slopes,
             "dq": dq,


### PR DESCRIPTION
A few tests check the unused `RampModel.err` array. Updating these tests is needed to allow removal of the (mostly) unused array.

This also fixes a minor bug where the `create_fully_saturated_zeroed_image` method of the exposure pipeline is on main pulling the datatype from `RampModel.err` and using it to construct the `ImageModel.err`, `var_rnoise`, etc datatypes. With this PR that method now uses the datatypes for those arrays defined in the schemas.

Regtests with only this PR: https://github.com/spacetelescope/RegressionTests/actions/runs/21043288793 all pass

Regtests with https://github.com/spacetelescope/rad/pull/803 and https://github.com/spacetelescope/roman_datamodels/pull/620
https://github.com/spacetelescope/RegressionTests/actions/runs/21043329378 shows expected differences where the `dq_init` step no longer adds the `err` array

I propose that we:
- merge this PR
- then merge the rad PR
- then merge the roman_datamodels PR
- then okify the regtest differences

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
