### PR TITLE
Update GWCS pin

### DIFF
--- a/changes/2139.general.rst
+++ b/changes/2139.general.rst
@@ -1,0 +1,1 @@
+Update GWCS pin to ``>=1.0.0``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "asdf >=4.1.0,<6",
     "crds >=13.0.2",
     "drizzle >= 2.1.1,<2.2",
-    "gwcs >=0.25.2,<0.27.0",
+    "gwcs >=1.0.0",
     "stcal @ git+https://github.com/spacetelescope/stcal.git",
     "stpipe >=0.11.0,<0.12.0",
     "spherical-geometry >=1.3.3,<1.4",


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
GWCS just made a 1.0.0 release and regression testing has already found that RCAL supports it.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
