### PR TITLE
RCAL-1314: Add WFI_parallel Keyword Migration

### DIFF
--- a/changes/2143.general.rst
+++ b/changes/2143.general.rst
@@ -1,0 +1,1 @@
+Added WFI parallel keyword value assignment to the old file migration block.

--- a/romancal/datamodels/migration.py
+++ b/romancal/datamodels/migration.py
@@ -32,8 +32,9 @@ def update_model_version(model, *, close_on_update=False):
 
     # old files (<B21) lacks WFI_parallel
     if "wfi_parallel" not in model.meta.observation:
-        updated_model.meta.observation.wfi_parallel = (model.meta.observation.visit_file_sequence > 1)
-
+        updated_model.meta.observation.wfi_parallel = (
+            model.meta.observation.visit_file_sequence > 1
+        )
 
     if close_on_update:
         model.close()

--- a/romancal/datamodels/migration.py
+++ b/romancal/datamodels/migration.py
@@ -31,9 +31,10 @@ def update_model_version(model, *, close_on_update=False):
         updated_model.meta.file_date = Time(updated_model.meta.file_date)
 
     # old files (<B21) lacks WFI_parallel
-    if "wfi_parallel" not in model.meta.observation:
+    if (("wfi_parallel" not in model.meta.get("observation", {})) and
+        (visit_file_sequence := model.meta.get("observation", {}).get("visit_file_sequence", None))):
         updated_model.meta.observation.wfi_parallel = (
-            model.meta.observation.visit_file_sequence > 1
+            visit_file_sequence > 1
         )
 
     if close_on_update:

--- a/romancal/datamodels/migration.py
+++ b/romancal/datamodels/migration.py
@@ -30,6 +30,11 @@ def update_model_version(model, *, close_on_update=False):
     if type(updated_model.meta.file_date) is not Time:
         updated_model.meta.file_date = Time(updated_model.meta.file_date)
 
+    # old files (<B21) lacks WFI_parallel
+    if "wfi_parallel" not in model.meta.observation:
+        updated_model.meta.observation.wfi_parallel = (model.meta.observation.visit_file_sequence > 1)
+
+
     if close_on_update:
         model.close()
 

--- a/romancal/datamodels/migration.py
+++ b/romancal/datamodels/migration.py
@@ -31,11 +31,12 @@ def update_model_version(model, *, close_on_update=False):
         updated_model.meta.file_date = Time(updated_model.meta.file_date)
 
     # old files (<B21) lacks WFI_parallel
-    if (("wfi_parallel" not in model.meta.get("observation", {})) and
-        (visit_file_sequence := model.meta.get("observation", {}).get("visit_file_sequence", None))):
-        updated_model.meta.observation.wfi_parallel = (
-            visit_file_sequence > 1
+    if ("wfi_parallel" not in model.meta.get("observation", {})) and (
+        visit_file_sequence := model.meta.get("observation", {}).get(
+            "visit_file_sequence", None
         )
+    ):
+        updated_model.meta.observation.wfi_parallel = visit_file_sequence > 1
 
     if close_on_update:
         model.close()

--- a/romancal/datamodels/tests/test_migration.py
+++ b/romancal/datamodels/tests/test_migration.py
@@ -30,12 +30,17 @@ def test_old_open_model(old_model, close_on_update, monkeypatch):
     update_model_version(old_model, close_on_update=close_on_update)
     assert close_on_update == close_called
 
-
-def test_update(old_model, latest_model):
+@pytest.mark.parametrize("vfs_value, wp_bool", [
+    (1, False),
+    (2, True),]
+)
+def test_update(old_model, latest_model, vfs_value, wp_bool):
+    old_model.meta.observation.visit_file_sequence = vfs_value
     new_model = update_model_version(old_model)
     assert new_model is not old_model
     assert new_model.tag != old_model.tag
     assert new_model.tag == latest_model.tag
+    assert new_model.meta.observation.wfi_parallel == wp_bool
 
 
 def test_no_update(latest_model):

--- a/romancal/datamodels/tests/test_migration.py
+++ b/romancal/datamodels/tests/test_migration.py
@@ -30,9 +30,13 @@ def test_old_open_model(old_model, close_on_update, monkeypatch):
     update_model_version(old_model, close_on_update=close_on_update)
     assert close_on_update == close_called
 
-@pytest.mark.parametrize("vfs_value, wp_bool", [
-    (1, False),
-    (2, True),]
+
+@pytest.mark.parametrize(
+    "vfs_value, wp_bool",
+    [
+        (1, False),
+        (2, True),
+    ],
 )
 def test_update(old_model, latest_model, vfs_value, wp_bool):
     old_model.meta.observation.visit_file_sequence = vfs_value


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1314](https://jira.stsci.edu/browse/RCAL-1314)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2140

<!-- describe the changes comprising this PR here -->
This PR adds WFI parallel keyword value assignment to the old file migration block and a test.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
