### PR TITLE
[SCSB-234] remove sphinx from RTD Conda environment

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -4,5 +4,4 @@ dependencies:
  - python=3.13
  - pip
  - graphviz
- - sphinx_rtd_theme>1.2.0
  - towncrier


### PR DESCRIPTION
so that `pip install .[docs]` can pick up Sphinx 9 from PyPI