### PR TITLE
Enable call to update catalog coordinates upon request.

### DIFF
--- a/changes/2153.tweakreg.rst
+++ b/changes/2153.tweakreg.rst
@@ -1,0 +1,1 @@
+Allow user to update the source catalog coordinates with the WCS corrections determined by TweakRegStep.

--- a/docs/roman/tweakreg/README.rst
+++ b/docs/roman/tweakreg/README.rst
@@ -251,6 +251,12 @@ Parameters used for absolute astrometry to a reference catalog.
 * ``save_abs_catalog``: A boolean specifying whether or not to write out the
   astrometric catalog used for the fit as a separate product (Default=False).
 
+* ``update_source_catalog_coordinates``: A boolean indicating whether to update
+  the source catalog coordinates after applying the WCS corrections (Default=False).
+
+  .. note::
+    If `True`, the source catalog coordinates will be updated to reflect
+    the new positions based on the corrected WCS of the input image.
 
 Further Documentation
 ---------------------

--- a/romancal/associations/multiband_asn.py
+++ b/romancal/associations/multiband_asn.py
@@ -13,6 +13,11 @@ logger.setLevel("INFO")
 __all__ = ["MultibandAssociation"]
 
 
+_COADD_RE = re.compile(
+    r"^(?P<prefix>.*_)(?P<skycell>[0-9p]*x[0-9]*y[0-9]*)_(?P<filter>f[0-9]+)_coadd\.asdf$"
+)
+
+
 class MultibandAssociation:
     """A class to create multiband associations."""
 
@@ -45,51 +50,76 @@ class MultibandAssociation:
     def _get_skycell_groups(self, filelist):
         """
         Create skycell groups based on the unique skycell identifiers from a list of filenames.
+
         Parameters
         ----------
         filelist : list of str
             List of filenames.
+
         Returns
         -------
         dict
             Dictionary mapping skycell identifiers to lists of filenames.
         """
-        pattern = re.compile(
-            r".*_(?P<skycells>[0-9p]*x[0-9]*y[0-9]*)_f[0-9]*_coadd\.asdf$"
-        )
         groups = {}
         for filename in filelist:
-            match = pattern.match(filename)
+            match = _COADD_RE.match(filename)
             if match:
-                key = match.group("skycells")
+                key = match.group("skycell")
                 groups.setdefault(key, []).append(filename)
         return groups
 
     def create_multiband_asn(self):
-        """
-        Create a multiband association from a list of files.
-
-        Parameters:
-        files (list): List of file paths or pattern to include in the association.
-
-        Returns:
-        dict: The created association.
-        """
+        """Create a multiband association from a list of files."""
         for skycell_id, filenames in self.skycell_groups.items():
-            # Get prefixes for all combinations of data_release_id and product_type from filenames
-            # (r00001_{data_release_id}_{product_type}_{skycell_id}_asn.json)
-            prefixes = {x.split(skycell_id)[0] for x in filenames}
+            # Group by the file prefix (everything up to and including the underscore
+            # before the skycell id). This prefix encodes program, data_release_id,
+            # and product type (e.g. visit/full/pass).
+            prefixes = set()
+            for filename in filenames:
+                match = _COADD_RE.match(filename)
+                if match:
+                    prefixes.add(match.group("prefix"))
+
             for prefix in prefixes:
-                # Get all files that match this prefix (data_release_id + product_type) and skycell
+                # Get all files that match this prefix (data_release_id + product_type)
+                # and this skycell.
                 files = [x for x in filenames if x.startswith(f"{prefix}{skycell_id}")]
+
+                # Determine data release id from the prefix: rPPPPP_<data_release_id>_...
+                # If parsing fails, fall back to 'p'.
+                try:
+                    data_release_id = prefix.split("_")[1]
+                except IndexError:
+                    data_release_id = "p"
+
+                # Determine which filters are present in the input list.
+                filter_ids = []
+                for f in files:
+                    match = _COADD_RE.match(f)
+                    if match:
+                        filter_ids.append(match.group("filter"))
+                unique_filters = sorted(set(filter_ids))
+
+                # Roman naming conventions for the archive catalog (Level 4):
+                # - Prompt products include optical element
+                # - Data release products omit optical element
+                # For multiband catalogs, if multiple filters are present, omit
+                # the filter even for prompt-style names.
+                include_filter = data_release_id == "p" and len(unique_filters) == 1
+                filter_part = f"_{unique_filters[0]}" if include_filter else ""
+
+                product_name = f"{prefix}{skycell_id}{filter_part}"
+                output_asn = f"{product_name}_asn.json"
+
                 args = [
                     *files,
                     "-o",
-                    f"{prefix}{skycell_id}_asn.json",
+                    output_asn,
                     "--product-name",
-                    f"{skycell_id}",
+                    product_name,
                     "--data-release-id",
-                    prefix.split("_")[1],
+                    data_release_id,
                 ]
                 asn_from_list._cli(args)
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import os
-import shutil
 
 import numpy as np
 import pytest

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -3,15 +3,14 @@ import json
 import os
 
 import numpy as np
+import pyarrow.parquet as pq
 import pytest
 from astropy import coordinates as coord
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.modeling import models
 from astropy.table import Table
 from numpy.random import default_rng
-import pyarrow.parquet as pq
-from astropy.coordinates import SkyCoord
-
 
 from romancal.datamodels import ModelLibrary
 from romancal.tweakreg.tweakreg_step import TweakRegStep, _validate_catalog_columns

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -235,10 +235,10 @@ def setup_source_catalog(img):
     # read in the mock table
     source_catalog = Table.read("img_1", format="ascii.ecsv")
     # rename columns to match expected column names
-    source_catalog.rename_columns(["x", "y"], ["xcentroid", "ycentroid"])
+    source_catalog.rename_columns(["x", "y"], ["x_centroid", "y_centroid"])
     # add mock PSF coordinates
-    source_catalog["x_psf"] = source_catalog["xcentroid"]
-    source_catalog["y_psf"] = source_catalog["ycentroid"]
+    source_catalog["x_psf"] = source_catalog["x_centroid"]
+    source_catalog["y_psf"] = source_catalog["y_centroid"]
 
     # generate a set of random shifts to be added to the original coordinates
     seed = 13
@@ -246,8 +246,8 @@ def setup_source_catalog(img):
     shift_x = rng.uniform(-0.5, 0.5, size=len(source_catalog))
     shift_y = rng.uniform(-0.5, 0.5, size=len(source_catalog))
     # add random fraction of a pixel shifts to the centroid coordinates
-    source_catalog["xcentroid"] += shift_x
-    source_catalog["ycentroid"] += shift_y
+    source_catalog["x_centroid"] += shift_x
+    source_catalog["y_centroid"] += shift_y
 
     # generate another set of random shifts to be added to the original coordinates
     seed = 5
@@ -260,8 +260,8 @@ def setup_source_catalog(img):
 
     # calculate centroid world coordinates
     centroid = img.meta.wcs(
-        source_catalog["xcentroid"],
-        source_catalog["ycentroid"],
+        source_catalog["x_centroid"],
+        source_catalog["y_centroid"],
     )
     # calculate PSF world coordinates
     psf = img.meta.wcs(
@@ -431,7 +431,7 @@ def test_tweakreg_catalog_coordinate_update_behavior(
         if should_update:
             # verify coordinates were updated with tweaked WCS
             expected_centroid = dm.meta.wcs(
-                cat_after["xcentroid"], cat_after["ycentroid"]
+                cat_after["x_centroid"], cat_after["y_centroid"]
             )
             expected_psf = dm.meta.wcs(cat_after["x_psf"], cat_after["y_psf"])
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -242,7 +242,7 @@ def test_update_source_catalog_coordinates(function_jail, tweakreg_image):
     with res:
         dm = res.borrow(0)
         assert dm.meta.source_catalog.tweakreg_catalog_name == "img_1_cat.parquet"
-        update_catalog_coordinates(
+        TweakRegStep().update_catalog_coordinates(
             dm.meta.source_catalog.tweakreg_catalog_name, dm.meta.wcs
         )
         res.shelve(dm, 0)
@@ -287,7 +287,7 @@ def test_source_catalog_coordinates_have_changed(function_jail, tweakreg_image):
     with res:
         dm = res.borrow(0)
         assert dm.meta.source_catalog.tweakreg_catalog_name == "img_1_cat.parquet"
-        update_catalog_coordinates(
+        TweakRegStep().update_catalog_coordinates(
             dm.meta.source_catalog.tweakreg_catalog_name, dm.meta.wcs
         )
         res.shelve(dm, 0)
@@ -407,43 +407,6 @@ def setup_source_catalog(img):
     source_catalog["dec_psf"].unit = u.deg
 
     return source_catalog
-
-
-def update_catalog_coordinates(tweakreg_catalog_name, tweaked_wcs):
-    """
-    Update the source catalog coordinates using the tweaked WCS.
-
-    Parameters
-    ----------
-    tweakreg_catalog_name : str
-        The name of the TweakReg catalog file produced by `SourceCatalog`.
-    tweaked_wcs : `gwcs.wcs.WCS`
-        The tweaked World Coordinate System (WCS) object.
-
-    Returns
-    -------
-    None
-    """
-    # read in cat file
-    catalog = Table.read(tweakreg_catalog_name)
-
-    # define mapping between pixel and world coordinates
-    colname_mapping = {
-        ("xcentroid", "ycentroid"): ("ra_centroid", "dec_centroid"),
-        ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
-    }
-
-    for k, v in colname_mapping.items():
-        # get column names
-        x_colname, y_colname = k
-        ra_colname, dec_colname = v
-
-        # calculate new coordinates using tweaked WCS and update catalog coordinates
-        catalog[ra_colname], catalog[dec_colname] = tweaked_wcs(
-            catalog[x_colname], catalog[y_colname]
-        )
-
-    catalog.write(tweakreg_catalog_name, overwrite=True)
 
 
 @pytest.mark.parametrize(

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -483,16 +483,7 @@ def test_source_catalog_coordinates_have_changed(function_jail, tweakreg_image):
     # update tweakreg catalog name
     img.meta.source_catalog.tweakreg_catalog_name = "img_1_cat.parquet"
 
-    res = TweakRegStep.call([img])
-
-    # tweak the current WCS using TweakRegStep and save the updated cat file
-    with res:
-        dm = res.borrow(0)
-        assert dm.meta.source_catalog.tweakreg_catalog_name == "img_1_cat.parquet"
-        TweakRegStep().update_catalog_coordinates(
-            dm.meta.source_catalog.tweakreg_catalog_name, dm.meta.wcs
-        )
-        res.shelve(dm, 0)
+    TweakRegStep.call([img], update_source_catalog_coordinates=True)
 
     # Read the updated catalog
     cat_updated = Table.read("img_1_cat.parquet")

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -7,7 +7,6 @@ import pyarrow.parquet as pq
 import pytest
 from astropy import coordinates as coord
 from astropy import units as u
-from astropy.coordinates import SkyCoord
 from astropy.modeling import models
 from astropy.table import Table
 from numpy.random import default_rng

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -520,7 +520,7 @@ def test_parquet_metadata_preserved_after_update(function_jail, tweakreg_image):
     )
 
     # Verify column schemas match (types, names, field metadata)
-    for orig_field, updated_field in zip(original_schema, updated_schema):
+    for orig_field, updated_field in zip(original_schema, updated_schema, strict=False):
         assert orig_field.name == updated_field.name
         # Note: We expect RA/Dec columns to have the same type, just different values
         # So schema types should still match

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -420,7 +420,7 @@ def test_tweakreg_catalog_coordinate_update_behavior_combined(
     cat_original = Table.read("img_1_cat_original.parquet")
 
     # Run TweakRegStep with specified parameter
-    res = TweakRegStep.call([img], update_source_catalog_coordinates=update_coordinates)
+    TweakRegStep.call([img], update_source_catalog_coordinates=update_coordinates)
 
     # Read catalog after tweakreg
     cat_after = Table.read("img_1_cat.parquet")

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -330,7 +330,7 @@ class TweakRegStep(RomanStep):
 
         # Extract columns as numpy arrays for WCS calculation
         colname_mapping = {
-            ("x_centroid", "y_centroid"): ("ra_centroid", "dec_centroid"),
+            ("xcentroid", "ycentroid"): ("ra_centroid", "dec_centroid"),
             ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
         }
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -332,6 +332,7 @@ class TweakRegStep(RomanStep):
         colname_mapping = {
             ("x_centroid", "y_centroid"): ("ra_centroid", "dec_centroid"),
             ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
+            ("x_centroid_win", "y_centroid_win"): ("ra_centroid_win", "dec_centroid_win"),
         }
 
         # Build list of updated columns

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -332,7 +332,10 @@ class TweakRegStep(RomanStep):
         colname_mapping = {
             ("x_centroid", "y_centroid"): ("ra_centroid", "dec_centroid"),
             ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
-            ("x_centroid_win", "y_centroid_win"): ("ra_centroid_win", "dec_centroid_win"),
+            ("x_centroid_win", "y_centroid_win"): (
+                "ra_centroid_win",
+                "dec_centroid_win",
+            ),
         }
 
         # Build list of updated columns

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -320,7 +320,7 @@ class TweakRegStep(RomanStep):
 
         # define mapping between pixel and world coordinates
         colname_mapping = {
-            ("xcentroid", "ycentroid"): ("ra_centroid", "dec_centroid"),
+            ("x_centroid", "y_centroid"): ("ra_centroid", "dec_centroid"),
             ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
         }
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
 from astropy.table import Table
 from roman_datamodels import datamodels as rdm
 from stcal.tweakreg import tweakreg
@@ -18,8 +20,6 @@ from stcal.tweakreg.tweakreg import TweakregError
 from romancal.assign_wcs.utils import add_s_region
 from romancal.datamodels.fileio import open_dataset
 from romancal.lib.save_wcs import save_wfiwcs
-import pyarrow.parquet as pq
-import pyarrow as pa
 
 # LOCAL
 from ..datamodels import ModelLibrary

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -330,7 +330,7 @@ class TweakRegStep(RomanStep):
 
         # Extract columns as numpy arrays for WCS calculation
         colname_mapping = {
-            ("xcentroid", "ycentroid"): ("ra_centroid", "dec_centroid"),
+            ("x_centroid", "y_centroid"): ("ra_centroid", "dec_centroid"),
             ("x_psf", "y_psf"): ("ra_psf", "dec_psf"),
         }
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1138](https://jira.stsci.edu/browse/RCAL-1138)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1790 

<!-- describe the changes comprising this PR here -->
### Description
This PR enables calling a method that will apply the "tweak correction" to the coordinates in the final catalog. By default, the coordinates written to the catalog won't be updated. If desired, the update can be done by passing the `update_source_catalog_coordinates=True` to the call to `TweakRegStep`, as in the example below:

`TweakRegStep.call([img], update_source_catalog_coordinates=True)`

Note that the ELP pipeline will always run with `update_source_catalog_coordinates=True` to produce catalogs with the best astrometric solution.

### Unit tests
Previously, there were two unit tests developed for testing the updating of the coordinates in the catalogs that overlapped (`test_update_source_catalog_coordinates` and `test_source_catalog_coordinates_have_changed`). In this PR, we consolidated those two tests into one using parametrization. 

### Regression tests
- ~https://github.com/spacetelescope/RegressionTests/actions/runs/21495160165 (all passing; 01/30/26).~
- ~https://github.com/spacetelescope/RegressionTests/actions/runs/21830026812 (all passing; 02/09/26).~
- https://github.com/spacetelescope/RegressionTests/actions/runs/21878620245/job/63154798575 (all tests related to this PR are passing; three failing tests due to context issues; 02/10/26).

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
