### PR TITLE
Update skymatch usage to accommodate stcal changes

### DIFF
--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -115,7 +115,7 @@ class SkyMatchStep(RomanStep):
             dqmask = np.isfinite(image_model.data)
         else:
             dqmask = bitfield_to_boolean_mask(
-                image_model.dq, self._dqbits, good_mask_value=True, dtype=np.bool
+                image_model.dq, self._dqbits, good_mask_value=True, dtype="bool"
             ) & np.isfinite(image_model.data)
 
         # see if 'skymatch' was previously run and raise an exception

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -155,7 +155,6 @@ class SkyMatchStep(RomanStep):
             sky_id=image_model.meta.filename,  # file name?
             skystat=self._skystat,
             stepsize=self.stepsize,
-            reduce_memory_usage=False,
             meta={"image_model": input_image_model},
         )
 

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -149,8 +149,6 @@ class SkyMatchStep(RomanStep):
             image=image_model.data,
             wcs_fwd=wcs.forward_transform,
             wcs_inv=wcs.backward_transform,
-            pix_area=1.0,  # TODO: pixel area
-            convf=1.0,  # TODO: conv. factor to brightness
             mask=dqmask,
             sky_id=image_model.meta.filename,  # file name?
             skystat=self._skystat,

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -112,11 +112,11 @@ class SkyMatchStep(RomanStep):
             }
 
         if self._dqbits is None:
-            dqmask = np.isfinite(image_model.data).astype(dtype=np.uint8)
+            dqmask = np.isfinite(image_model.data)
         else:
             dqmask = bitfield_to_boolean_mask(
-                image_model.dq, self._dqbits, good_mask_value=1, dtype=np.uint8
-            ) * np.isfinite(image_model.data)
+                image_model.dq, self._dqbits, good_mask_value=True, dtype=np.bool
+            ) & np.isfinite(image_model.data)
 
         # see if 'skymatch' was previously run and raise an exception
         # if 'subtract' mode has changed compared to the previous pass:


### PR DESCRIPTION
https://github.com/spacetelescope/stcal/pull/504 makes a number of skymatch updates including removing `SkyImage.__init__` arguments:
- convf: hard-coded to 1
- pixel_area: hard-coded to 1
- reduce_memory_usage: hard-coded to False (and this mode removed since it resulted in overwriting input data)

This updates the internal skymatch usage to accommodate those changes.

regtests (with the stcal PR): https://github.com/spacetelescope/RegressionTests/actions/runs/21488254530
all pass

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
