### PR TITLE
RCAL-1317: Don't pass pix_ratio to gwcs_blot

### DIFF
--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -196,7 +196,7 @@ def _flag_resampled_model_crs(
     else:
         fillval = float(fillval)
     blot = gwcs_blot(
-        median_data, median_wcs, image.data.shape, image.meta.wcs, 1.0, fillval
+        median_data, median_wcs, image.data.shape, image.meta.wcs, fillval
     )
 
     # Get background level of science data if it has not been subtracted, so it

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -195,7 +195,14 @@ def _flag_resampled_model_crs(
         fillval = 0
     else:
         fillval = float(fillval)
-    blot = gwcs_blot(median_data, median_wcs, image.data.shape, image.meta.wcs, fillval)
+
+    blot = gwcs_blot(
+        median_data=median_data,
+        median_wcs=median_wcs,
+        blot_shape=image.data.shape,
+        blot_wcs=image.meta.wcs,
+        fillval=fillval,
+    )
 
     # Get background level of science data if it has not been subtracted, so it
     # can be added into the level of the blotted data, which has been

--- a/romancal/outlier_detection/utils.py
+++ b/romancal/outlier_detection/utils.py
@@ -195,9 +195,7 @@ def _flag_resampled_model_crs(
         fillval = 0
     else:
         fillval = float(fillval)
-    blot = gwcs_blot(
-        median_data, median_wcs, image.data.shape, image.meta.wcs, fillval
-    )
+    blot = gwcs_blot(median_data, median_wcs, image.data.shape, image.meta.wcs, fillval)
 
     # Get background level of science data if it has not been subtracted, so it
     # can be added into the level of the blotted data, which has been


### PR DESCRIPTION
Resolves [RCAL-1317](https://jira.stsci.edu/browse/RCAL-1317)
Closes #2162

https://github.com/spacetelescope/stcal/pull/509 deprecated parameter `pix_ratio` in `stcal.outlier_detection.utils.gwcs_blot()`. This PR removes that argument.

Merge this after https://github.com/spacetelescope/stcal/pull/509 is merged.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/21559489727
v2: https://github.com/spacetelescope/RegressionTests/actions/runs/21738398287

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
