### PR TITLE
[skycell] explicitly cast `orientat_projection_center` as `np.float64`

### DIFF
--- a/romancal/skycell/skymap.py
+++ b/romancal/skycell/skymap.py
@@ -273,7 +273,9 @@ class SkyCells:
                 ),
                 "orientat_projection_center": self._skymap.model.projection_regions[
                     "orientat"
-                ][projregion_index].astype(np.float64),
+                ][projregion_index].astype(
+                    np.float64
+                ),  # hotfix for `TypeError: Object of type float32 is not JSON serializable`
             }
             for skycell_index, projregion_index in zip(
                 self.indices, self.projection_regions, strict=True

--- a/romancal/skycell/skymap.py
+++ b/romancal/skycell/skymap.py
@@ -273,7 +273,7 @@ class SkyCells:
                 ),
                 "orientat_projection_center": self._skymap.model.projection_regions[
                     "orientat"
-                ][projregion_index],
+                ][projregion_index].astype(np.float64),
             }
             for skycell_index, projregion_index in zip(
                 self.indices, self.projection_regions, strict=True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
hot fix for regression test failure introduced by #2089; changes type of `np.float32` coming from the reference file to `np.float64` to play nice with the JSON association

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
