### PR TITLE
Multiband ASN filenames compliant with Roman naming conventions.

### DIFF
--- a/docs/roman/associations/multiband_asn.rst
+++ b/docs/roman/associations/multiband_asn.rst
@@ -18,6 +18,16 @@ multiband data products to be generated per skycell. This enables efficient
 organization and processing of data across multiple filters for the same region
 of the sky.
 
+Multiband catalog products always omit the optical element (filter) from their
+output filenames, regardless of whether they contain one or multiple filters.
+This naming convention distinguishes multiband products from single-band products.
+
+Usage
+^^^^^
+
+Command Line Interface
+""""""""""""""""""""""
+
 To create a multiband association, use the following command:
 
 .. code-block:: bash
@@ -33,17 +43,52 @@ you can run the command with the ``-h`` option:
 
     multiband_asn -h
 
+Python API
+""""""""""
+
+You can also use the Python API:
+
+.. code-block:: python
+
+    from romancal.associations.multiband_asn import MultibandAssociation
+
+    # Example with multiple filters for the same skycell
+    files = [
+        "r00001_p_full_270p65x48y69_f184_coadd.asdf",
+        "r00001_p_full_270p65x48y69_f213_coadd.asdf"
+    ]
+    multiband = MultibandAssociation(files)
+
+    # Or use a wildcard pattern
+    # multiband = MultibandAssociation(["r00001_p_full_270p65x48y69_f*_coadd.asdf"])
+    
+    multiband.create_multiband_asn()
+    # This will create: r00001_p_full_270p65x48y69_asn.json
+
+The data release ID and product type are extracted from the filenames.
+Association files are generated for each skycell group.
+
+File Naming Conventions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Input Filenames
+"""""""""""""""
+
 The input filenames should follow the convention:
 
 .. code-block:: text
 
-    rPPPPP_<data_release_id>_<product_type>_<skycell_id>_coadd.asdf
+    rPPPPP_<data_release_id>_<product_type>_<skycell_id>_<filter>_coadd.asdf
 
 Where:
-    PPPPP = Program number
-    data_release_id = Data release identifier (e.g., 'p' for prompt)
-    product_type = Product type (e.g., 'full')
-    skycell_id = Skycell identifier (e.g., '270p65x48y69')
+    - PPPPP = Program number (5 digits, zero-padded)
+    - data_release_id = Data release identifier (e.g., 'p' for prompt, 'dr01' for data release 1)
+    - product_type = Product type (e.g., 'full', 'visit', 'pass')
+    - skycell_id = Skycell identifier (e.g., '270p65x48y69')
+    - filter = Filter identifier (e.g., 'f184', 'f213')
+
+Output Filenames
+""""""""""""""""
 
 The association files will be JSON files named:
 
@@ -51,20 +96,107 @@ The association files will be JSON files named:
 
     rPPPPP_<data_release_id>_<product_type>_<skycell_id>_asn.json
 
-For example, to generate associations for all skycells in a program:
+Note that the filter is **always omitted** from multiband association filenames,
+regardless of the number of filters included in the association.
+
+Examples
+^^^^^^^^
+
+Example 1: Prompt Multi-Filter Product
+"""""""""""""""""""""""""""""""""""""""
+
+**Input files:**
+
+.. code-block:: text
+
+    r00001_p_visit_x001y001_f184_coadd.asdf
+    r00001_p_visit_x001y001_f213_coadd.asdf
+
+**Command:**
 
 .. code-block:: bash
 
-    multiband_asn r00001_*full*_coadd.asdf
+    multiband_asn r00001_p_visit_x001y001_f*_coadd.asdf
 
-You can also use the Python API:
+**Output association:**
 
-.. code-block:: python
+.. code-block:: text
 
-    from romancal.associations.multiband_asn import MultibandAssociation
-    files = ["r00001_p_full_270p65x48y69_coadd.asdf", ...]
-    multiband = MultibandAssociation(files)
-    multiband.create_multiband_asn()
+    r00001_p_visit_x001y001_asn.json
 
-The data release ID and product type are extracted from the filenames.
-Association files are generated for each skycell group.
+Example 2: Prompt Single-Filter Product
+""""""""""""""""""""""""""""""""""""""""
+
+**Input files:**
+
+.. code-block:: text
+
+    r00001_p_full_x002y003_f184_coadd.asdf
+
+**Command:**
+
+.. code-block:: bash
+
+    multiband_asn r00001_p_full_x002y003_f184_coadd.asdf
+
+**Output association:**
+
+.. code-block:: text
+
+    r00001_p_full_x002y003_asn.json
+
+Note: Even with a single filter, the filter identifier is omitted from the
+multiband association filename to distinguish it from single-band products.
+
+Example 3: Data Release Product
+""""""""""""""""""""""""""""""""
+
+**Input files:**
+
+.. code-block:: text
+
+    r00001_dr01_full_270p65x48y69_f184_coadd.asdf
+    r00001_dr01_full_270p65x48y69_f213_coadd.asdf
+    r00001_dr01_full_270p65x48y69_f158_coadd.asdf
+
+**Command:**
+
+.. code-block:: bash
+
+    multiband_asn r00001_dr01_full_270p65x48y69_f*_coadd.asdf
+
+**Output association:**
+
+.. code-block:: text
+
+    r00001_dr01_full_270p65x48y69_asn.json
+
+Example 4: Multiple Skycells and Product Types
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+**Input files:**
+
+.. code-block:: text
+
+    r00001_p_visit_x001y001_f184_coadd.asdf
+    r00001_p_visit_x001y001_f213_coadd.asdf
+    r00001_p_visit_x002y003_f184_coadd.asdf
+    r00001_p_full_x001y001_f184_coadd.asdf
+    r00001_p_full_x001y001_f213_coadd.asdf
+
+**Command:**
+
+.. code-block:: bash
+
+    multiband_asn r00001_p_*_x*_f*_coadd.asdf
+
+**Output associations:**
+
+.. code-block:: text
+
+    r00001_p_visit_x001y001_asn.json
+    r00001_p_visit_x002y003_asn.json
+    r00001_p_full_x001y001_asn.json
+
+The tool automatically groups files by skycell and product type, creating
+separate associations for each unique combination.

--- a/docs/roman/associations/multiband_asn.rst
+++ b/docs/roman/associations/multiband_asn.rst
@@ -124,31 +124,8 @@ Example 1: Prompt Multi-Filter Product
 
     r00001_p_visit_x001y001_asn.json
 
-Example 2: Prompt Single-Filter Product
-""""""""""""""""""""""""""""""""""""""""
 
-**Input files:**
-
-.. code-block:: text
-
-    r00001_p_full_x002y003_f184_coadd.asdf
-
-**Command:**
-
-.. code-block:: bash
-
-    multiband_asn r00001_p_full_x002y003_f184_coadd.asdf
-
-**Output association:**
-
-.. code-block:: text
-
-    r00001_p_full_x002y003_asn.json
-
-Note: Even with a single filter, the filter identifier is omitted from the
-multiband association filename to distinguish it from single-band products.
-
-Example 3: Data Release Product
+Example 2: Data Release Product
 """"""""""""""""""""""""""""""""
 
 **Input files:**

--- a/docs/roman/associations/multiband_asn.rst
+++ b/docs/roman/associations/multiband_asn.rst
@@ -61,7 +61,7 @@ You can also use the Python API:
 
     # Or use a wildcard pattern
     # multiband = MultibandAssociation(["r00001_p_full_270p65x48y69_f*_coadd.asdf"])
-    
+
     multiband.create_multiband_asn()
     # This will create: r00001_p_full_270p65x48y69_asn.json
 

--- a/romancal/associations/multiband_asn.py
+++ b/romancal/associations/multiband_asn.py
@@ -13,6 +13,11 @@ logger.setLevel("INFO")
 __all__ = ["MultibandAssociation"]
 
 
+_COADD_RE = re.compile(
+    r"^(?P<prefix>.*_)(?P<skycell>[0-9p]*x[0-9]*y[0-9]*)_(?P<filter>f[0-9]+)_coadd\.asdf$"
+)
+
+
 class MultibandAssociation:
     """A class to create multiband associations."""
 
@@ -45,51 +50,76 @@ class MultibandAssociation:
     def _get_skycell_groups(self, filelist):
         """
         Create skycell groups based on the unique skycell identifiers from a list of filenames.
+
         Parameters
         ----------
         filelist : list of str
             List of filenames.
+
         Returns
         -------
         dict
             Dictionary mapping skycell identifiers to lists of filenames.
         """
-        pattern = re.compile(
-            r".*_(?P<skycells>[0-9p]*x[0-9]*y[0-9]*)_f[0-9]*_coadd\.asdf$"
-        )
         groups = {}
         for filename in filelist:
-            match = pattern.match(filename)
+            match = _COADD_RE.match(filename)
             if match:
-                key = match.group("skycells")
+                key = match.group("skycell")
                 groups.setdefault(key, []).append(filename)
         return groups
 
     def create_multiband_asn(self):
-        """
-        Create a multiband association from a list of files.
-
-        Parameters:
-        files (list): List of file paths or pattern to include in the association.
-
-        Returns:
-        dict: The created association.
-        """
+        """Create a multiband association from a list of files."""
         for skycell_id, filenames in self.skycell_groups.items():
-            # Get prefixes for all combinations of data_release_id and product_type from filenames
-            # (r00001_{data_release_id}_{product_type}_{skycell_id}_asn.json)
-            prefixes = {x.split(skycell_id)[0] for x in filenames}
+            # Group by the file prefix (everything up to and including the underscore
+            # before the skycell id). This prefix encodes program, data_release_id,
+            # and product type (e.g. visit/full/pass).
+            prefixes = set()
+            for filename in filenames:
+                match = _COADD_RE.match(filename)
+                if match:
+                    prefixes.add(match.group("prefix"))
+
             for prefix in prefixes:
-                # Get all files that match this prefix (data_release_id + product_type) and skycell
+                # Get all files that match this prefix (data_release_id + product_type)
+                # and this skycell.
                 files = [x for x in filenames if x.startswith(f"{prefix}{skycell_id}")]
+
+                # Determine data release id from the prefix: rPPPPP_<data_release_id>_...
+                # If parsing fails, fall back to 'p'.
+                try:
+                    data_release_id = prefix.split("_")[1]
+                except IndexError:
+                    data_release_id = "p"
+
+                # Determine which filters are present in the input list.
+                filter_ids = []
+                for f in files:
+                    match = _COADD_RE.match(f)
+                    if match:
+                        filter_ids.append(match.group("filter"))
+                unique_filters = sorted(set(filter_ids))
+
+                # Roman naming conventions for the archive catalog (Level 4):
+                # - Prompt products include optical element
+                # - Data release products omit optical element
+                # For multiband catalogs, if multiple filters are present, omit
+                # the filter even for prompt-style names.
+                include_filter = data_release_id == "p" and len(unique_filters) == 1
+                filter_part = f"_{unique_filters[0]}" if include_filter else ""
+
+                product_name = f"{prefix}{skycell_id}{filter_part}"
+                output_asn = f"{product_name}_asn.json"
+
                 args = [
                     *files,
                     "-o",
-                    f"{prefix}{skycell_id}_asn.json",
+                    output_asn,
                     "--product-name",
-                    f"{skycell_id}",
+                    product_name,
                     "--data-release-id",
-                    prefix.split("_")[1],
+                    data_release_id,
                 ]
                 asn_from_list._cli(args)
 

--- a/romancal/associations/multiband_asn.py
+++ b/romancal/associations/multiband_asn.py
@@ -93,23 +93,11 @@ class MultibandAssociation:
                 except IndexError:
                     data_release_id = "p"
 
-                # Determine which filters are present in the input list.
-                filter_ids = []
-                for f in files:
-                    match = _COADD_RE.match(f)
-                    if match:
-                        filter_ids.append(match.group("filter"))
-                unique_filters = sorted(set(filter_ids))
-
                 # Roman naming conventions for the archive catalog (Level 4):
-                # - Prompt products include optical element
-                # - Data release products omit optical element
-                # For multiband catalogs, if multiple filters are present, omit
-                # the filter even for prompt-style names.
-                include_filter = data_release_id == "p" and len(unique_filters) == 1
-                filter_part = f"_{unique_filters[0]}" if include_filter else ""
-
-                product_name = f"{prefix}{skycell_id}{filter_part}"
+                # - Multiband catalogs always omit the optical element (filter)
+                #   regardless of whether they contain single or multiple filters.
+                # - This distinguishes multiband products from single-band products.
+                product_name = f"{prefix}{skycell_id}"
                 output_asn = f"{product_name}_asn.json"
 
                 args = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR improves multiband association naming and filter handling. The output filenames are now following the requirements of the Roman naming conventions found in [this document](https://innerspace.stsci.edu/pages/viewpage.action?spaceKey=RDMSDOC&title=Roman+Science+File+Naming+Conventions+for+Files+in+the+Archive+Catalog).

The main changes are:

- Refactor regex pattern to module-level constant `_COADD_RE`;
- Improve filter handling for Roman naming conventions;
- Better error handling for data release ID parsing;
- Add filter to product names only for prompt products with single filter;
- Fix skycell group regex to properly capture prefix and filter components.

## Regression tests
- https://github.com/spacetelescope/RegressionTests/actions/runs/21868317478 (all passing; 02/10/26)

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
