### PR TITLE
update romanisim requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # roman_datamodels release.
     # "roman_datamodels>=0.29.1,<0.30",
     "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels.git",
-    "romanisim>=0.12.0,<0.13",
+    "romanisim>=0.13.0,<0.14",
     # "romanisim@git+https://github.com/spacetelescope/romanisim.git",
     "asdf>=4.1.0,<6",
     "crds>=13.0.2",


### PR DESCRIPTION
This PR bumps the version of romanisim used with romancal.  We want this to let us use python 3.14 in romancal for the most part.

Regression tests started here: https://github.com/spacetelescope/RegressionTests/actions/runs/21965228056

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
