### PR TITLE
Fix warning filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ filterwarnings = [
     "ignore:invalid escape:DeprecationWarning",
     # dev numpy deprecated shape assignment which astropy still uses
     "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:astropy.*",
+    # astropy triggers an unhandled warning in dev numpy: https://github.com/astropy/astropy/issues/19216
+    "ignore:The chararray class is deprecated:DeprecationWarning",
 ]
 junit_family = "xunit2"
 inputs_root = ["roman-pipeline"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,6 @@ norecursedirs = [
 filterwarnings = [
     "error::ResourceWarning",
     "error::DeprecationWarning",
-    "ignore:invalid escape:DeprecationWarning",
-    # dev numpy deprecated shape assignment which astropy still uses
-    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:astropy.*",
     # astropy triggers an unhandled warning in dev numpy: https://github.com/astropy/astropy/issues/19216
     "ignore:The chararray class is deprecated:DeprecationWarning",
 ]


### PR DESCRIPTION
Add a warning ignore for an unhandled warning triggered by astropy: https://github.com/astropy/astropy/issues/19216
Also removing a few warning ignores that are no longer needed.

Running devdeps regtests here (since the newly ignored warning only appears there):
https://github.com/spacetelescope/RegressionTests/actions/runs/21993763157

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
