### PR TITLE
swtich back to released versions of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,14 @@ dependencies = [
     # the roman_datamodels pin to the released version. If there
     # is a need to change this to main then we need a new
     # roman_datamodels release.
-    # "roman_datamodels>=0.30.0,<0.31",
-    "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels.git",
-    # "romanisim>=0.13.0,<0.14",
-    "romanisim@git+https://github.com/spacetelescope/romanisim.git",
+    "roman_datamodels>=0.30.0,<0.31",
+    # "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels.git",
+    "romanisim>=0.13.0,<0.14",
     "asdf>=4.1.0,<6",
     "crds>=13.0.2",
     "drizzle>=2.2.0,<2.3.0",
     "gwcs>=1.0.1,<2",
-    "stcal@git+https://github.com/spacetelescope/stcal.git",
-    # "stcal>=1.17.0,<1.18",
+    "stcal>=1.17.0,<1.18",
     "stpipe>=0.11.0,<0.12.0",
     "spherical-geometry>=1.3.3,<1.4",
 ]


### PR DESCRIPTION
Regtests are failing to resolve a valid environment:
https://github.com/spacetelescope/RegressionTests/actions/runs/22005305620/job/63587579934

This switches the roman_datamodels, romanisim, and stcal versions back to released versions to allow the environment to resolve.
regtests:
https://github.com/spacetelescope/RegressionTests/actions/runs/22005484959/job/63588146608

The issue looks to be a combination of:
- romanisim pointing to released rdm (which with this PR now matches what romancal wants)
- regtests resolving an environment as part of sonarscan without using dependency overrides (which makes testing pin fixes impossible): https://github.com/spacetelescope/RegressionTests/actions/runs/22005305620/job/63587579934#step:13:1
- regtests installing unnecessary dependencies (without overrides) when running unrelated scripts: https://github.com/spacetelescope/RegressionTests/actions/runs/22005372117/job/63587795579#step:12:1
- regtests (perhaps uv, perhaps me) failing to understand that the current rdm version `0.31.0.dev1+g94d2f8d3b` is `<0.31.0`

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
