### PR TITLE
rcal-1331 Update so that WFI_SPECTRAL data are not flat corrected

### DIFF
--- a/changes/2202.flatfield.rst
+++ b/changes/2202.flatfield.rst
@@ -1,0 +1,1 @@
+Update exposure type so exclude WFI_SPECTRAL from the flat field correction

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -58,7 +58,7 @@ def do_flat_field(output_model, flat_model, include_var_flat=False):
         log.warning("Flat data array is not the same shape as the science data")
         log.warning("Step will be skipped")
         output_model.meta.cal_step.flat_field = "SKIPPED"
-    elif output_model.meta.exposure.type != "WFI_IMAGE":
+    elif output_model.meta.exposure.type == "WFI_SPECTRAL":
         # Check to see if attempt to flatten non-Image data
         log.info("Skipping flat field for spectral exposure.")
         output_model.meta.cal_step.flat_field = "SKIPPED"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1331](https://jira.stsci.edu/browse/RCAL-1331)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1996

<!-- describe the changes comprising this PR here -->
This PR updates the flat field step to skip the flat field correction for spectral data (WFI_SPECTRAL)

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [N/A] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

The passing regression tests are at https://github.com/spacetelescope/RegressionTests/actions/runs/22197776823