### PR TITLE
RCAL-1324: remove skip of snowball test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "crds>=13.0.2",
     "drizzle>=2.2.0,<2.3.0",
     "gwcs>=1.0.1,<2",
-    "stcal>=1.17.0,<1.18",
+    # "stcal>=1.17.0,<1.18",
+    "stcal@git+https://github.com/spacetelescope/stcal.git",
     "stpipe>=0.11.0,<0.12.0",
     "spherical-geometry>=1.3.3,<1.4",
 ]

--- a/romancal/ramp_fitting/tests/test_ramp_fit_likelihood.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_likelihood.py
@@ -78,7 +78,6 @@ def test_bad_readpattern():
         )
 
 
-@pytest.mark.skip(reason="See rcal-1324")
 def test_flag_large_events_withsnowball():
     """Test that large events are flagged"""
     resultants = create_linear_ramp(n_resultants=20, nrows=100, ncols=100)


### PR DESCRIPTION
Resolves [RCAL-1324](https://jira.stsci.edu/browse/RCAL-1324)

This PR addresses an architecturally sensitive issue with the `test_flag_large_events_withsnowball` which is resolved by [stcal pr#520](https://github.com/spacetelescope/stcal/pull/520). The step had been marked SKIP but with the resolution, the test is re-enabled.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
