### PR TITLE
Consistently use arcsec / pix for pixel_scale

### DIFF
--- a/changes/2211.resample.rst
+++ b/changes/2211.resample.rst
@@ -1,0 +1,2 @@
+Fix ``pixel_scale`` and ``pixel_scale_ref`` in the Level 3 wcsinfo block to be
+in arcseconds rather than degrees.

--- a/romancal/resample/l3_wcs.py
+++ b/romancal/resample/l3_wcs.py
@@ -69,12 +69,12 @@ def assign_l3_wcs(model, wcs):
     l3_wcsinfo.dec_ref = world_ref[1]
 
     try:
-        l3_wcsinfo.pixel_scale_ref = transform.cdelt[0]
+        l3_wcsinfo.pixel_scale_ref = transform.cdelt[0] * 3600
     except AttributeError:
-        l3_wcsinfo.pixel_scale_ref = compute_scale(wcs, world_ref)
+        l3_wcsinfo.pixel_scale_ref = compute_scale(wcs, world_ref) * 3600
 
     # pixel scale at center of image
-    l3_wcsinfo.pixel_scale = compute_scale(wcs, world_center)
+    l3_wcsinfo.pixel_scale = compute_scale(wcs, world_center) * 3600
 
     l3_wcsinfo.orientation_ref = calc_pa(wcs, *world_ref)
 
@@ -119,7 +119,7 @@ def calc_pa(wcs, ra, dec):
 
 def l3wcsinfo_to_wcs(wcsinfo, bounding_box=None):
     crpix = [wcsinfo["x_ref"], wcsinfo["y_ref"]]
-    cdelt = [wcsinfo["pixel_scale_ref"], wcsinfo["pixel_scale_ref"]]
+    cdelt = [wcsinfo["pixel_scale_ref"] / 3600, wcsinfo["pixel_scale_ref"] / 3600]
     tangent_projection = models.Pix2Sky_TAN()
     crval = [
         wcsinfo["ra_ref"],

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -61,7 +61,7 @@ def make_output_wcs(
         WCS object, with defined domain, covering entire set of input frames
 
     pscale : float
-        The computed (or provided) input pixel scale (in degrees).
+        The computed (or provided) input pixel scale (in arcseconds).
 
     pscale_ratio : float, optional
         The computed (or provided) input pixel scale ratio.
@@ -85,26 +85,27 @@ def make_output_wcs(
                 ref_wcs,
                 fiducial=np.array([ref_wcsinfo["ra_ref"], ref_wcsinfo["dec_ref"]]),
             )
-            * pscale_ratio
+            * pscale_ratio * 3600
         )
     else:
         pscale_ratio = pscale / np.rad2deg(
             math.sqrt(compute_mean_pixel_area(ref_wcs, shape=ref_shape))
         )
+        pscale *= 3600  # convert to arcsec / pix
 
     wcs = wcs_from_sregions(
         sregions,
         ref_wcs=ref_wcs,
         ref_wcsinfo=ref_wcsinfo,
         pscale_ratio=pscale_ratio,
-        pscale=pscale,
+        pscale=pscale / 3600,
         shape=shape,
         rotation=rotation,
         crpix=crpix,
         crval=crval,
     )
 
-    return wcs, pscale * 3600.0, pscale_ratio
+    return wcs, pscale, pscale_ratio
 
 
 def compute_var_sky(model) -> None:

--- a/romancal/resample/resample_utils.py
+++ b/romancal/resample/resample_utils.py
@@ -85,7 +85,8 @@ def make_output_wcs(
                 ref_wcs,
                 fiducial=np.array([ref_wcsinfo["ra_ref"], ref_wcsinfo["dec_ref"]]),
             )
-            * pscale_ratio * 3600
+            * pscale_ratio
+            * 3600
         )
     else:
         pscale_ratio = pscale / np.rad2deg(

--- a/romancal/resample/tests/test_resample.py
+++ b/romancal/resample/tests/test_resample.py
@@ -591,8 +591,8 @@ def test_l3_wcsinfo(multiple_exposures):
         "dec_ref": 0.001534500000533253,
         "x_ref": 106.4579605214774,
         "y_ref": 80.66617532540977,
-        "pixel_scale_ref": 3.100000000097307e-05,
-        "pixel_scale": 3.099999999719185e-05,
+        "pixel_scale_ref": 3.100000000097307e-05 * 3600,
+        "pixel_scale": 3.099999999719185e-05 * 3600,
         "image_shape": (161, 213),
         "ra": 10.002930353020417,
         "dec": 0.0015101325554100666,
@@ -628,3 +628,14 @@ def test_resample_pixel_scale_units(wfi_sca1):
     coords = output_model.meta.wcs.pixel_to_world((100, 100), (100, 101))
     pscale = coords[0].separation(coords[1]).to(u.arcsec).value
     np.testing.assert_allclose(pscale, pixel_scale)
+
+
+def test_make_output_wcs_pscale_units(wfi_sca1):
+    """
+    Test that make_output_wcs returns pixel scale in arcseconds, not degrees.
+    """
+    input_models = ModelLibrary([wfi_sca1])
+    # fixture uses pscale=(0.000031, 0.000031) degrees/pixel
+    expected_pscale_arcsec = 0.000031 * 3600
+    _, pscale, _ = resample_utils.make_output_wcs(input_models)
+    np.testing.assert_allclose(pscale, expected_pscale_arcsec, rtol=1e-3)


### PR DESCRIPTION
We specify the pixel scale in arcsec / pixel in rad.
https://github.com/spacetelescope/rad/blob/main/latest/meta/l3_wcsinfo.yaml#L70-L71
Prior to this PR, we inconsistently used arcsec / pixel for skycells and degree / pixel for 'default' coadds.  This is confusing and, for example, broke the MultibandCatalogStep when used on 'default' coadds, which was interpreting the pixel scale as arcsec / pixel.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
