### PR TITLE
include B21 files in compatibility tests

### DIFF
--- a/romancal/regtest/compatibility/conftest.py
+++ b/romancal/regtest/compatibility/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture(scope="module")
-def old_rtdata_module(rtdata_module):
-    rtdata_module._env = "build/26Q1_B20"
+@pytest.fixture(scope="module", params=["build/26Q1_B20", "build/26Q2_B21"])
+def old_rtdata_module(rtdata_module, request):
+    rtdata_module._env = request.param
     yield rtdata_module


### PR DESCRIPTION
Closes https://jira.stsci.edu/browse/RCAL-1356
See https://github.com/spacetelescope/romancal/issues/2223

Expand migration/compatibility tests to include B21 files.

regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/22919450836

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
