### PR TITLE
bump spherical_geometry to allow 1.4 add to devdeps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # "stcal>=1.17.0,<1.18",
     "stcal@git+https://github.com/spacetelescope/stcal.git",
     "stpipe>=0.11.0,<0.12.0",
-    "spherical-geometry>=1.3.3,<1.4",
+    "spherical-geometry>=1.3.3,<1.5",
 ]
 license-files = ["LICENSE"]
 dynamic = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ git+https://github.com/spacetelescope/stpipe.git
 git+https://github.com/spacetelescope/crds.git
 git+https://github.com/spacetelescope/gwcs.git
 git+https://github.com/spacetelescope/tweakwcs.git
+git+https://github.com/spacetelescope/spherical_geometry.git
 
 # ASDF upstream packages
 git+https://github.com/asdf-format/asdf-standard.git


### PR DESCRIPTION
Increase the spherical geometry upper pin to allow 1.4 and add it to devdeps.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/23004761401

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
