### PR TITLE
Add `compare_parquet` to regtestdata and use it to compare output to truth for parquet files

### DIFF
--- a/romancal/regtest/conftest.py
+++ b/romancal/regtest/conftest.py
@@ -209,3 +209,8 @@ def rtdata_module(artifactory_repos, envopt, request, module_jail):
 @pytest.fixture
 def ignore_asdf_paths(ignore_metadata_paths):
     return {"ignore": ignore_metadata_paths}
+
+
+@pytest.fixture
+def ignore_parquet_paths(ignore_parquet_metadata_paths):
+    return {"ignore": ignore_parquet_metadata_paths}

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -533,10 +533,12 @@ class DiffResult:
         return f"{title}\n{report}"
 
 
-def _compare_trees(
-    result, truth, exclude_paths=None, rtol=1e-05, atol=1e-08, equal_nan=True
-):
-    exclude_paths = exclude_paths or []
+def _compare_trees(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
+    exclude_paths = []
+    if ignore:
+        for path in ignore:
+            key_path = "".join([f"['{k}']" for k in path.split(".")])
+            exclude_paths.append(f"root{key_path}")
     operators = [
         NDArrayTypeOperator(
             rtol,
@@ -595,11 +597,6 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
     diff_result : DiffResult
         result of the comparison
     """
-    exclude_paths = []
-    if ignore:
-        for path in ignore:
-            key_path = "".join([f"['{k}']" for k in path.split(".")])
-            exclude_paths.append(f"root{key_path}")
     with asdf.open(result) as af0:
         with asdf.config_context() as cfg:
             # Disable validation of the truth file to allow for more
@@ -611,7 +608,7 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
                 diff = _compare_trees(
                     af0.tree,
                     af1.tree,
-                    exclude_paths=exclude_paths,
+                    ignore=ignore,
                     rtol=rtol,
                     atol=atol,
                     equal_nan=equal_nan,
@@ -621,27 +618,25 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
 
 def _parquet_to_tree(parquet_file):
     table = pyarrow.parquet.read_table(parquet_file)
-    return {
-        "table": astropy.table.Table.from_pandas(table.to_pandas()),
-        "meta": {
-            k.decode("ascii"): v.decode("ascii")
-            for k, v in table.schema.metadata.items()
-        },
-    }
+    # convert meta back into a tree
+    result = {}
+    for k, v in table.schema.metadata.items():
+        path = k.decode("ascii")
+        value = v.decode("ascii")
+        *subpaths, key = path.split(".")
+        obj = result
+        for subpath in subpaths:
+            obj = obj.setdefault(subpath, {})
+        obj[key] = value
+    result["table"] = astropy.table.Table.from_pandas(table.to_pandas())
+    return result
 
 
 def compare_parquet(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
-    exclude_paths = []
-    if ignore:
-        # prepend meta since _parquet_to_tree puts all metadata under the "meta" key
-        for path in ignore:
-            exclude_paths.append(f"root['meta']['{path}']")
-    if ignore:
-        ignore = [f"meta.{key}" for key in ignore]
     diff = _compare_trees(
         _parquet_to_tree(result),
         _parquet_to_tree(truth),
-        exclude_paths=exclude_paths,
+        ignore=ignore,
         rtol=rtol,
         atol=atol,
         equal_nan=equal_nan,

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -13,7 +13,7 @@ import astropy.time
 import deepdiff
 import gwcs
 import numpy as np
-import pyarrow
+import pyarrow.parquet
 import requests
 import roman_datamodels as rdm
 from astropy.units import Quantity

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -13,6 +13,7 @@ import astropy.time
 import deepdiff
 import gwcs
 import numpy as np
+import pyarrow
 import requests
 import roman_datamodels as rdm
 from astropy.units import Quantity
@@ -532,6 +533,36 @@ class DiffResult:
         return f"{title}\n{report}"
 
 
+def _compare_trees(
+    result, truth, exclude_paths=None, rtol=1e-05, atol=1e-08, equal_nan=True
+):
+    exclude_paths = exclude_paths or []
+    operators = [
+        NDArrayTypeOperator(
+            rtol,
+            atol,
+            equal_nan,
+            types=[asdf.tags.core.NDArrayType, np.ndarray],
+        ),
+        TimeOperator(types=[astropy.time.Time]),
+        TableOperator(rtol, atol, equal_nan, types=[astropy.table.Table]),
+        WCSOperator(rtol, atol, equal_nan, types=[gwcs.WCS]),
+    ]
+    # swap the inputs here so DeepDiff(truth, result)
+    # this will create output with 'new_value' referring to
+    # the value in the result and 'old_value' referring to the truth
+    diff = deepdiff.DeepDiff(
+        truth,
+        result,
+        ignore_nan_inequality=equal_nan,
+        custom_operators=operators,
+        exclude_paths=exclude_paths,
+        math_epsilon=atol,
+        ignore_type_in_groups=[asdf.tags.core.NDArrayType, np.ndarray],
+    )
+    return DiffResult(diff, result, truth)
+
+
 def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
     """
     Compare 2 asdf files: result and truth. Note that this comparison is
@@ -566,21 +597,10 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
         result of the comparison
     """
     exclude_paths = []
-    ignore = ignore or []
-    for path in ignore:
-        key_path = "".join([f"['{k}']" for k in path.split(".")])
-        exclude_paths.append(f"root{key_path}")
-    operators = [
-        NDArrayTypeOperator(
-            rtol,
-            atol,
-            equal_nan,
-            types=[asdf.tags.core.NDArrayType, np.ndarray],
-        ),
-        TimeOperator(types=[astropy.time.Time]),
-        TableOperator(rtol, atol, equal_nan, types=[astropy.table.Table]),
-        WCSOperator(rtol, atol, equal_nan, types=[gwcs.WCS]),
-    ]
+    if ignore:
+        for path in ignore:
+            key_path = "".join([f"['{k}']" for k in path.split(".")])
+            exclude_paths.append(f"root{key_path}")
     with asdf.open(result) as af0:
         with asdf.config_context() as cfg:
             # Disable validation of the truth file to allow for more
@@ -589,16 +609,40 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
             # versioned for every change between releases).
             cfg.validate_on_read = False
             with asdf.open(truth) as af1:
-                # swap the inputs here so DeepDiff(truth, result)
-                # this will create output with 'new_value' referring to
-                # the value in the result and 'old_value' referring to the truth
-                diff = deepdiff.DeepDiff(
-                    af1.tree,
+                return _compare_trees(
                     af0.tree,
-                    ignore_nan_inequality=equal_nan,
-                    custom_operators=operators,
+                    af1.tree,
                     exclude_paths=exclude_paths,
-                    math_epsilon=atol,
-                    ignore_type_in_groups=[asdf.tags.core.NDArrayType, np.ndarray],
+                    rtol=rtol,
+                    atol=atol,
+                    equal_nan=equal_nan,
                 )
-                return DiffResult(diff, result, truth)
+
+
+def _parquet_to_tree(parquet_file):
+    table = pyarrow.parquet.read_table(parquet_file)
+    return {
+        "table": astropy.table.Table.from_pandas(table.to_pandas()),
+        "meta": {
+            k.decode("ascii"): v.decode("ascii")
+            for k, v in table.schema.metadata.items()
+        },
+    }
+
+
+def compare_parquet(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
+    exclude_paths = []
+    if ignore:
+        # prepend meta since _parquet_to_tree puts all metadata under the "meta" key
+        for path in ignore:
+            exclude_paths.append(f"root['meta']['{path}']")
+    if ignore:
+        ignore = [f"meta.{key}" for key in ignore]
+    return _compare_trees(
+        _parquet_to_tree(result),
+        _parquet_to_tree(truth),
+        exclude_paths=exclude_paths,
+        rtol=rtol,
+        atol=atol,
+        equal_nan=equal_nan,
+    )

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -551,7 +551,7 @@ def _compare_trees(
     # swap the inputs here so DeepDiff(truth, result)
     # this will create output with 'new_value' referring to
     # the value in the result and 'old_value' referring to the truth
-    diff = deepdiff.DeepDiff(
+    return deepdiff.DeepDiff(
         truth,
         result,
         ignore_nan_inequality=equal_nan,
@@ -560,7 +560,6 @@ def _compare_trees(
         math_epsilon=atol,
         ignore_type_in_groups=[asdf.tags.core.NDArrayType, np.ndarray],
     )
-    return DiffResult(diff, result, truth)
 
 
 def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=True):
@@ -609,7 +608,7 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
             # versioned for every change between releases).
             cfg.validate_on_read = False
             with asdf.open(truth) as af1:
-                return _compare_trees(
+                diff = _compare_trees(
                     af0.tree,
                     af1.tree,
                     exclude_paths=exclude_paths,
@@ -617,6 +616,7 @@ def compare_asdf(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_nan=T
                     atol=atol,
                     equal_nan=equal_nan,
                 )
+                return DiffResult(diff, result, truth)
 
 
 def _parquet_to_tree(parquet_file):
@@ -638,7 +638,7 @@ def compare_parquet(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_na
             exclude_paths.append(f"root['meta']['{path}']")
     if ignore:
         ignore = [f"meta.{key}" for key in ignore]
-    return _compare_trees(
+    diff = _compare_trees(
         _parquet_to_tree(result),
         _parquet_to_tree(truth),
         exclude_paths=exclude_paths,
@@ -646,3 +646,4 @@ def compare_parquet(result, truth, ignore=None, rtol=1e-05, atol=1e-08, equal_na
         atol=atol,
         equal_nan=equal_nan,
     )
+    return DiffResult(diff, result, truth)

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -84,7 +84,7 @@ def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
     # copy RegtestData instance before modifying output and truth
     rtdata = copy.copy(run_mos)
     rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
     diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -1,5 +1,6 @@
 """Roman tests for the High Level Pipeline"""
 
+import copy
 import os
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from romancal.resample._l3_wcs import l3wcsinfo_to_wcs
 
 from . import util
-from .regtestdata import compare_asdf
+from .regtestdata import compare_asdf, compare_parquet
 
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
@@ -76,6 +77,15 @@ def test_log_tracked_resources(log_tracked_resources, run_mos):
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     # DMS356
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
+    assert diff.identical, diff.report()
+
+
+def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
+    # copy RegtestData instance before modifying output and truth
+    rtdata = copy.copy(run_mos)
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 
 

--- a/romancal/regtest/test_mos_pipeline.py
+++ b/romancal/regtest/test_mos_pipeline.py
@@ -1,6 +1,5 @@
 """Roman tests for the High Level Pipeline"""
 
-import copy
 import os
 from pathlib import Path
 
@@ -81,8 +80,8 @@ def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths
 
 
 def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
-    # copy RegtestData instance before modifying output and truth
-    rtdata = copy.copy(run_mos)
+    # must be after the above uses of run_mos as this modifies the fixture
+    rtdata = run_mos
     rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
     rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
     diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -1,4 +1,5 @@
 import copy
+import os
 
 import pytest
 import roman_datamodels as rdm
@@ -60,7 +61,7 @@ def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
     # copy RegtestData instance before modifying output and truth
     rtdata = copy.copy(run_mos)
     rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
     diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -1,4 +1,3 @@
-import copy
 import os
 
 import pytest
@@ -57,15 +56,6 @@ def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths
     assert diff.identical, diff.report()
 
 
-def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
-    # copy RegtestData instance before modifying output and truth
-    rtdata = copy.copy(run_mos)
-    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
-    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
-    assert diff.identical, diff.report()
-
-
 def test_resample_ran(output_model):
     # DMS373 test output is resampled to a skycell
     # FIXME this doesn't test if the output is a skycell
@@ -83,3 +73,12 @@ def test_wcsinfo_wcs_roundtrip(output_model):
 
     ra_mad, dec_mad = util.comp_wcs_grids_arcs(output_model.meta.wcs, gwcs_from_wcsinfo)
     assert (ra_mad + dec_mad) / 2.0 < 1.0e-4
+
+
+def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
+    # must be after the other uses of run_mos as this modifies the fixture
+    rtdata = run_mos
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
+    assert diff.identical, diff.report()

--- a/romancal/regtest/test_mos_skycell_pipeline.py
+++ b/romancal/regtest/test_mos_skycell_pipeline.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 import roman_datamodels as rdm
 
@@ -5,7 +7,7 @@ from romancal.pipeline.mosaic_pipeline import MosaicPipeline
 from romancal.resample._l3_wcs import l3wcsinfo_to_wcs
 
 from . import util
-from .regtestdata import compare_asdf
+from .regtestdata import compare_asdf, compare_parquet
 
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
@@ -51,6 +53,15 @@ def test_log_tracked_resources(log_tracked_resources, run_mos):
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
+    assert diff.identical, diff.report()
+
+
+def test_catalog_matches_truth(run_mos, ignore_parquet_paths):
+    # copy RegtestData instance before modifying output and truth
+    rtdata = copy.copy(run_mos)
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 
 

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -101,13 +101,13 @@ def test_log_tracked_resources(log_tracked_resources, run_multiband_catalog):
     log_tracked_resources()
 
 
-def test_output_matches_truth(output_filename, truth_filename):
-    diff = compare_parquet(output_filename, truth_filename)
+def test_output_matches_truth(output_filename, truth_filename, ignore_parquet_paths):
+    diff = compare_parquet(output_filename, truth_filename, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 
 
 def test_field_list(output_catalog, dms_logger):
-    missing_fields = set(output_catalog.dtype.names) - set(fieldlist)
+    missing_fields = set(fieldlist) - set(output_catalog.dtype.names)
     assert not missing_fields, f"Missing fields in catalog: {missing_fields}"
     dms_logger.info(
         "DMS374, 399, 375, 386, 387, 392, 394, 395: source catalog includes fields: "

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -7,6 +7,8 @@ from roman_datamodels.datamodels import MultibandSegmentationMapModel
 
 from romancal.stpipe import RomanStep
 
+from .regtestdata import compare_parquet
+
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -39,18 +41,18 @@ fieldlist = [
 ]
 
 
-def test_multiband_catalog(rtdata_module, resource_tracker, request, dms_logger):
+@pytest.fixture(scope="module")
+def run_multiband_catalog(rtdata_module, resource_tracker):
     rtdata = rtdata_module
-    inputasnfn = "r00001_p_v01001001001001_270p65x70y49_asn.json"
-    outputfn = "r00001_p_v01001001001001_270p65x70y49_cat.parquet"
-    rtdata.get_asn(f"WFI/image/{inputasnfn}")
-    rtdata.output = outputfn
-    rtdata.input = inputasnfn
-    rtdata.get_truth(f"truth/WFI/image/{outputfn}")
-    cattruth = Table.read(f"truth/{outputfn}")
+
+    rtdata.get_asn("WFI/image/r00001_p_v01001001001001_270p65x70y49_asn.json")
+
+    output = "r00001_p_v01001001001001_270p65x70y49_cat.parquet"
+    rtdata.output = output
+
     args = [
         "romancal.step.MultibandCatalogStep",
-        inputasnfn,
+        rtdata.input,
         "--deblend",
         "True",  # use deblending, DMS 393
         "--kernel_fwhms",
@@ -58,20 +60,66 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request, dms_logger)
         "--inject_sources",  # turn on source injection, DMS 396
         "True",
     ]
-    with resource_tracker.track(log=request):
+    with resource_tracker.track():
         RomanStep.from_cmdline(args)
-    cat = Table.read(outputfn)
-    for field in fieldlist:
-        assert field in cat.dtype.names
 
+    rtdata.get_truth(f"truth/WFI/image/{output}")
+    return rtdata
+
+
+@pytest.fixture(scope="module")
+def output_filename(run_multiband_catalog):
+    return run_multiband_catalog.output
+
+
+@pytest.fixture(scope="module")
+def truth_filename(run_multiband_catalog):
+    return run_multiband_catalog.truth
+
+
+@pytest.fixture(scope="module")
+def segmentation_filename(run_multiband_catalog):
+    return run_multiband_catalog.output.replace("_cat.parquet", "_segm.asdf")
+
+
+@pytest.fixture(scope="module")
+def output_catalog(output_filename):
+    return Table.read(output_filename)
+
+
+@pytest.fixture(scope="module")
+def truth_catalog(truth_filename):
+    return Table.read(truth_filename)
+
+
+@pytest.fixture(scope="module")
+def segmentation_model(segmentation_filename):
+    return MultibandSegmentationMapModel(segmentation_filename)
+
+
+def test_log_tracked_resources(log_tracked_resources, run_multiband_catalog):
+    log_tracked_resources()
+
+
+def test_output_matches_truth(output_filename, truth_filename):
+    diff = compare_parquet(output_filename, truth_filename)
+    assert diff.identical, diff.report()
+
+
+def test_field_list(output_catalog, dms_logger):
+    missing_fields = set(output_catalog.dtype.names) - set(fieldlist)
+    assert not missing_fields, f"Missing fields in catalog: {missing_fields}"
     dms_logger.info(
         "DMS374, 399, 375, 386, 387, 392, 394, 395: source catalog includes fields: "
         + ", ".join(fieldlist)
     )
 
+
+def test_catalog_fields_matches_truth(output_catalog, truth_catalog, dms_logger):
     # DMS 393: multiband catalog uses both PSF-like and extend-source-like
     # kernels
-    assert set(cat.dtype.names) == set(cattruth.dtype.names)
+    assert set(output_catalog.dtype.names) == set(truth_catalog.dtype.names)
+
     # weak assertion that our truth file must at least have the same
     # catalog fields as the file produced here.  Exactly matching rows
     # would require a lot of okifying things that aren't obviously
@@ -85,42 +133,51 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request, dms_logger)
         "fluxes and uncertainties."
     )
 
+
+def test_segmentation_contains_injected_and_recovered_sources(
+    segmentation_model, dms_logger
+):
     # DMS 396: Ensure the segmentation image contains
     # both injected_sources and recovered_sources
-    segm_mod = MultibandSegmentationMapModel(
-        outputfn.replace("_cat.parquet", "_segm.asdf")
-    )
-    assert "injected_sources" in segm_mod
-    assert "recovered_sources" in segm_mod
+    assert "injected_sources" in segmentation_model
+    assert "recovered_sources" in segmentation_model
 
     dms_logger.info(
         "DMS396: segmentation image contains both "
         "injected_sources and recovered_sources."
     )
 
+
+def test_recovery_rate(segmentation_model, dms_logger):
     # DMS 396: Ensure at least 50% of injected sourced are recovered.
-    assert np.count_nonzero(segm_mod.recovered_sources["best_injected_index"] != -1) > (
-        len(segm_mod.injected_sources) / 2
-    )
+    assert np.count_nonzero(
+        segmentation_model.recovered_sources["best_injected_index"] != -1
+    ) > (len(segmentation_model.injected_sources) / 2)
 
     dms_logger.info("DMS396: successfully recovered over half of the injected sources.")
 
+
+def test_psf_matching_quality(output_catalog, dms_logger):
     # DMS 539/540: PSF matching quality check.
     # The aper02/aper08 flux ratio is a proxy for encircled energy and
     # should be similar across all matched bands (since they share an
     # effective PSF after matching).  Assert that matched ratios are much
     # closer to the F158 reference than the original unmatched ratios.
-    bright = cat["segment_f158_flux"] > np.median(cat["segment_f158_flux"])
+    bright = output_catalog["segment_f158_flux"] > np.median(
+        output_catalog["segment_f158_flux"]
+    )
     ref_ratio = np.nanmedian(
-        cat["aper02_f158_flux"][bright] / cat["aper08_f158_flux"][bright]
+        output_catalog["aper02_f158_flux"][bright]
+        / output_catalog["aper08_f158_flux"][bright]
     )
     for band, matched_band in [("f129", "f129m"), ("f213", "f213m")]:
         unmatched_ratio = np.nanmedian(
-            cat[f"aper02_{band}_flux"][bright] / cat[f"aper08_{band}_flux"][bright]
+            output_catalog[f"aper02_{band}_flux"][bright]
+            / output_catalog[f"aper08_{band}_flux"][bright]
         )
         matched_ratio = np.nanmedian(
-            cat[f"aper02_{matched_band}_flux"][bright]
-            / cat[f"aper08_{matched_band}_flux"][bright]
+            output_catalog[f"aper02_{matched_band}_flux"][bright]
+            / output_catalog[f"aper08_{matched_band}_flux"][bright]
         )
         dms_logger.info(
             f"aperture ratios: "

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from roman_datamodels import datamodels as rdm
 
-from romancal.regtest.regtestdata import compare_asdf
+from romancal.regtest.regtestdata import compare_asdf, compare_parquet
 
 
 @pytest.mark.parametrize("modification", [None, "small", "large"])
@@ -145,3 +145,15 @@ def test_n_diffs(tmp_path, n_diffs):
     assert "arrays_differ" in diff.diff
     assert "root['v']" in diff.diff["arrays_differ"]
     assert n_diffs == diff.diff["arrays_differ"]["root['v']"]["n_diffs"]
+
+
+def test_compare_parquet(tmp_path, ignore_asdf_paths):
+    fn0 = tmp_path / "test0.parquet"
+    fn1 = tmp_path / "test1.parquet"
+    m0 = rdm.ImageSourceCatalogModel.create_fake_data()
+    m1 = rdm.ImageSourceCatalogModel.create_fake_data()
+    m0.save(fn0)
+    m1.save(fn1)
+    ignore = ignore_asdf_paths["ignore"] + ["roman.meta.filename"]
+    diff = compare_parquet(fn0, fn1, ignore=ignore)
+    assert diff.identical, diff.report()

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -86,15 +86,8 @@ def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
     log_tracked_resources()
 
 
-def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
-    ignore = ignore_asdf_paths["ignore"] + [
-        "source_catalog.date",
-        "source_catalog.versions",
-        "table_meta_yaml",
-        "roman.meta.image.file_date",
-        "roman.meta.image.filename",
-    ]
-    diff = compare_parquet(output_filename, truth_filename, ignore=ignore)
+def test_output_matches_truth(output_filename, truth_filename, ignore_parquet_paths):
+    diff = compare_parquet(output_filename, truth_filename, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 
 

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -87,7 +87,14 @@ def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
 
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
-    diff = compare_parquet(output_filename, truth_filename, **ignore_asdf_paths)
+    ignore = ignore_asdf_paths["ignore"] + [
+        "source_catalog.date",
+        "source_catalog.versions",
+        "table_meta_yaml",
+        "roman.meta.image.file_date",
+        "roman.meta.image.filename",
+    ]
+    diff = compare_parquet(output_filename, truth_filename, ignore=ignore)
     assert diff.identical, diff.report()
 
 

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -30,7 +30,7 @@ def run_source_catalog(rtdata_module, request, resource_tracker):
 
     rtdata.get_data(f"WFI/image/{inputfn}")
     rtdata.input = inputfn
-    rtdata.get_truth(f"truth/WFI/image/{outputfn}")
+    rtdata.get_truth(f"truth/test_source_catalog/{outputfn}")
 
     args = [
         "romancal.step.SourceCatalogStep",

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -88,9 +88,9 @@ def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     ignore = ignore_asdf_paths["ignore"] + [
-        "roman.source_catalog.date",
-        "roman.source_catalog.versions",
-        "roman.table_meta_yaml",
+        "source_catalog.date",
+        "source_catalog.versions",
+        "table_meta_yaml",
         "roman.meta.image.file_date",
         "roman.meta.image.filename",
     ]

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -88,9 +88,9 @@ def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     ignore = ignore_asdf_paths["ignore"] + [
-        "source_catalog.date",
-        "source_catalog.versions",
-        "table_meta_yaml",
+        "roman.source_catalog.date",
+        "roman.source_catalog.versions",
+        "roman.table_meta_yaml",
         "roman.meta.image.file_date",
         "roman.meta.image.filename",
     ]

--- a/romancal/regtest/test_source_catalog.py
+++ b/romancal/regtest/test_source_catalog.py
@@ -5,6 +5,8 @@ from astropy.table import Table
 
 from romancal.stpipe import RomanStep
 
+from .regtestdata import compare_parquet
+
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 
@@ -40,6 +42,16 @@ def run_source_catalog(rtdata_module, request, resource_tracker):
 
 
 @pytest.fixture(scope="module")
+def output_filename(run_source_catalog):
+    return run_source_catalog.output
+
+
+@pytest.fixture(scope="module")
+def truth_filename(run_source_catalog):
+    return run_source_catalog.truth
+
+
+@pytest.fixture(scope="module")
 def catalog(run_source_catalog):
     yield Table.read(run_source_catalog.output)
 
@@ -72,6 +84,11 @@ def test_has_field(fields, field):
 
 def test_log_tracked_resources(log_tracked_resources, run_source_catalog):
     log_tracked_resources()
+
+
+def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
+    diff = compare_parquet(output_filename, truth_filename, **ignore_asdf_paths)
+    assert diff.identical, diff.report()
 
 
 def test_forced_catalog(rtdata_module, dms_logger):

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -233,6 +233,16 @@ def test_repointed_wcs_differs(repointed_filename_and_delta, output_model):
         )
 
 
+@pytest.mark.soctests
+def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
+    # must be after other uses of run_elp as this modifies the fixture
+    rtdata = run_elp
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
+    assert diff.identical, diff.report()
+
+
 def test_elp_input_dm(rtdata, ignore_asdf_paths):
     """Test for input roman Datamodel to exposure level pipeline"""
     input_data = "r0000101001001001001_0001_wfi01_f158_uncal.asdf"
@@ -396,13 +406,3 @@ def test_elp_save_results(rtdata, function_jail):
     assert isinstance(coadd, rdm.datamodels.ImageModel)
     assert isinstance(catalog, rdm.datamodels.ImageSourceCatalogModel)
     assert isinstance(segmentation, rdm.datamodels.SegmentationMapModel)
-
-
-@pytest.mark.soctests
-def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
-    # must be after other uses of run_elp as this modifies the fixture
-    rtdata = run_elp
-    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
-    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
-    assert diff.identical, diff.report()

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -1,4 +1,3 @@
-import copy
 import os
 from pathlib import Path
 
@@ -106,16 +105,6 @@ def test_catalog_produced(output_filename):
 def test_segmentation_map_produced(output_filename):
     segmentation_map_filename = output_filename.replace("_cal.asdf", "_segm.asdf")
     assert Path(segmentation_map_filename).exists()
-
-
-@pytest.mark.soctests
-def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
-    # copy RegtestData instance before modifying output and truth
-    rtdata = copy.copy(run_elp)
-    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
-    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
-    assert diff.identical, diff.report()
 
 
 @pytest.mark.soctests
@@ -407,3 +396,13 @@ def test_elp_save_results(rtdata, function_jail):
     assert isinstance(coadd, rdm.datamodels.ImageModel)
     assert isinstance(catalog, rdm.datamodels.ImageSourceCatalogModel)
     assert isinstance(segmentation, rdm.datamodels.SegmentationMapModel)
+
+
+@pytest.mark.soctests
+def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
+    # must be after other uses of run_elp as this modifies the fixture
+    rtdata = run_elp
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
+    assert diff.identical, diff.report()

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 import numpy as np
@@ -12,7 +13,7 @@ from romancal.assign_wcs.assign_wcs_step import AssignWcsStep
 from romancal.lib.suffix import replace_suffix
 from romancal.pipeline.exposure_pipeline import ExposurePipeline
 
-from .regtestdata import compare_asdf
+from .regtestdata import compare_asdf, compare_parquet
 
 # mark all tests in this module
 pytestmark = pytest.mark.bigdata
@@ -104,6 +105,16 @@ def test_catalog_produced(output_filename):
 def test_segmentation_map_produced(output_filename):
     segmentation_map_filename = output_filename.replace("_cal.asdf", "_segm.asdf")
     assert Path(segmentation_map_filename).exists()
+
+
+@pytest.mark.soctests
+def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
+    # copy RegtestData instance before modifying output and truth
+    rtdata = copy.copy(run_elp)
+    rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
+    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
+    assert diff.identical, diff.report()
 
 
 @pytest.mark.soctests

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from pathlib import Path
 
 import numpy as np
@@ -112,7 +113,7 @@ def test_catalog_matches_truth(run_elp, ignore_parquet_paths):
     # copy RegtestData instance before modifying output and truth
     rtdata = copy.copy(run_elp)
     rtdata.output = rtdata.output.rsplit("_", 1)[0] + "_cat.parquet"
-    rtdata.get_truth(f"truth/WFI/image/{rtdata.output}")
+    rtdata.get_truth(f"truth/WFI/image/{os.path.basename(rtdata.output)}")
     diff = compare_parquet(rtdata.output, rtdata.truth, **ignore_parquet_paths)
     assert diff.identical, diff.report()
 

--- a/romancal/tests/dms_requirement_tests.json
+++ b/romancal/tests/dms_requirement_tests.json
@@ -109,25 +109,26 @@
     "romancal.regtest.test_source_catalog.test_has_field"
   ],
   "DMS391": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_catalog_fields_matches_truth"
   ],
   "DMS392": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_field_list"
   ],
   "DMS393": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_catalog_fields_matches_truth"
   ],
   "DMS394": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_field_list"
   ],
   "DMS395": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_field_list"
   ],
   "DMS396": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_segmentation_contains_injected_and_recovered_sources",
+    "romancal.regtest.test_multiband_catalog.test_recovery_rate"
   ],
   "DMS399": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_field_list"
   ],
   "DMS400": [
     "romancal.regtest.test_mos_pipeline.test_steps_ran",
@@ -172,10 +173,10 @@
     "romancal.regtest.test_psf_library.test_psf_library_psfinterp"
   ],
   "DMS539": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_psf_matching_quality"
   ],
   "DMS540": [
-    "romancal.regtest.test_multiband_catalog.test_multiband_catalog"
+    "romancal.regtest.test_multiband_catalog.test_psf_matching_quality"
   ],
   "DMS534": [
      "romancal.regtest.test_psf_library.test_psf_library_jitter"


### PR DESCRIPTION
Resolves https://jira.stsci.edu/browse/RCAL-1241
See: https://github.com/spacetelescope/romancal/issues/1994

Add `compare_parquet` (similar to `compare_asdf`) for comparing parquet files generated by regression tests with "truth" parquet files.

At the moment this compares both the table and metadata (but as discussed in the ticket we might want to disable the table comparison). I left it in since:
- it's essentially "free" since we already have [table comparison code](https://github.com/spacetelescope/romancal/blob/0bec7d524678a60641e24872e68d5fb8e987d5ae/romancal/regtest/regtestdata.py#L427)
- it helps to illustrate some differences (which we currently could okify)

`compare_asdf` works by:
- reading the parquet files with pyarrow
- converting the metadata back into a tree structure (to allow us to use the standard "ignores") but with all values as strings (a limitation of the parquet format)
- generating trees to compare containing the metadata and the table stored under a "table" key
- reuse the existing tree comparison code used by `compare_asdf` (refactored a bit to make reuse easier)

EDIT: the previous run is old enough the logs are now missing.
New regtest run here: https://github.com/spacetelescope/RegressionTests/actions/runs/29272068407
shows several errors where the new output contains dust_ebv and the truth files do not. This is something that should be okified.


<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
