### PR TITLE
Improve elp association support

### DIFF
--- a/changes/2243.exposure_pipeline.rst
+++ b/changes/2243.exposure_pipeline.rst
@@ -1,0 +1,1 @@
+Improve support for associations and add ``on_disk`` option.

--- a/docs/roman/pipeline/exposure_pipeline.rst
+++ b/docs/roman/pipeline/exposure_pipeline.rst
@@ -46,6 +46,20 @@ The ``exposure`` pipeline has no arguments
 Inputs
 ------
 
+For more details about step arguments (including datatypes, possible values
+and defaults) see :py:obj:`romancal.pipeline.exposure_pipeline.ExposurePipeline.spec`.
+
+``--on_disk``
+  When `True` the input association will be opened in a way that uses
+  temporary files to avoid keeping all input models in memory.
+
+You can see the options for strun using:
+
+strun --help roman_elp
+
+and this will list all the strun options as well as the step options for the roman_elp.
+
+
 3D raw data
 +++++++++++
 
@@ -78,6 +92,7 @@ The corresponding output image will:
 
 A single fully saturated input will also cause :ref:`tweakreg <tweakreg_step>` to be skipped
 for all input images.
+
 
 Outputs
 -------

--- a/romancal/datamodels/fileio.py
+++ b/romancal/datamodels/fileio.py
@@ -78,6 +78,11 @@ def open_dataset(
             result = ModelLibrary(dataset, update_version=update_version, **open_kwargs)
 
         case "asdf":
+            if open_kwargs.pop("on_disk", None) is not None:
+                warnings.warn(
+                    "on_disk is only supported for associations, ignoring on_disk",
+                    stacklevel=2,
+                )
             model = rdm.open(dataset, **open_kwargs)
             if update_version:
                 result = update_model_version(model, close_on_update=True)

--- a/romancal/datamodels/tests/test_fileio.py
+++ b/romancal/datamodels/tests/test_fileio.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import pytest
 import roman_datamodels.datamodels as rdm
 
@@ -80,28 +82,34 @@ def test_open_dataset(
 
 
 @pytest.mark.parametrize(
-    "dataset_fixture_name",
+    "dataset_fixture_name, expect_on_disk",
     [
-        "model_filename",
-        "library_filename",
-        "list_of_models",
-        "list_of_filenames",
+        ("model_filename", False),
+        ("library_filename", True),
+        ("list_of_models", False),
+        ("list_of_filenames", False),
     ],
 )
-def test_open_kwargs(dataset_fixture_name, monkeypatch, request):
+def test_open_kwargs(dataset_fixture_name, expect_on_disk, monkeypatch, request):
     class TestException(Exception):
         pass
 
     def patched_open(self, *args, **kwargs):
         assert "test" in kwargs
+        assert "on_disk" in kwargs if expect_on_disk else "on_disk" not in kwargs
         raise TestException()
 
     dataset = request.getfixturevalue(dataset_fixture_name)
+
     monkeypatch.setattr(rdm, "open", patched_open)
     monkeypatch.setattr(ModelLibrary, "__init__", patched_open)
+    if expect_on_disk:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(UserWarning, match="on_disk")
 
-    with pytest.raises(TestException):
-        open_dataset(dataset, open_kwargs={"test": 1})
+    with pytest.raises(TestException), ctx:
+        open_dataset(dataset, open_kwargs={"test": 1, "on_disk": True})
 
 
 @pytest.mark.parametrize("update_version", [True, False])

--- a/romancal/datamodels/tests/test_fileio.py
+++ b/romancal/datamodels/tests/test_fileio.py
@@ -43,18 +43,6 @@ def list_of_filenames(model_filename):
     return [model_filename]
 
 
-# @pytest.fixture(params=[
-#     "model",
-#     "library",
-#     "model_filename",
-#     "library_filename",
-#     "list_of_models",
-#     "list_of_filenames",
-# ])
-# def valid_dataset(request):
-#     return request.getfixturevalue(request.param)
-
-
 @pytest.mark.parametrize("return_type", [True, False])
 @pytest.mark.parametrize("as_library", [True, False])
 @pytest.mark.parametrize(
@@ -92,7 +80,7 @@ def test_open_dataset(
 
 
 @pytest.mark.parametrize(
-    "dataset",
+    "dataset_fixture_name",
     [
         "model_filename",
         "library_filename",
@@ -100,7 +88,7 @@ def test_open_dataset(
         "list_of_filenames",
     ],
 )
-def test_open_kwargs(dataset, monkeypatch):
+def test_open_kwargs(dataset_fixture_name, monkeypatch, request):
     class TestException(Exception):
         pass
 
@@ -108,6 +96,7 @@ def test_open_kwargs(dataset, monkeypatch):
         assert "test" in kwargs
         raise TestException()
 
+    dataset = request.getfixturevalue(dataset_fixture_name)
     monkeypatch.setattr(rdm, "open", patched_open)
     monkeypatch.setattr(ModelLibrary, "__init__", patched_open)
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -49,6 +49,7 @@ class ExposurePipeline(RomanPipeline):
 
     spec = """
         save_results = boolean(default=False)
+        on_disk = boolean(default=False)
         suffix = string(default="cal")
     """
 
@@ -88,6 +89,7 @@ class ExposurePipeline(RomanPipeline):
             update_version=self.update_version,
             return_type=True,
             as_library=True,
+            open_kwargs={"on_disk": self.on_disk},
         )
         return_lib = input_type in ("ModelLibrary", "asn")
 

--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -8,6 +8,25 @@ from romancal.datamodels.library import ModelLibrary
 from romancal.pipeline import ExposurePipeline
 
 
+@pytest.fixture
+def fake_science_raw():
+    model = rdm.ScienceRawModel.create_fake_data()
+    model.meta.filename = "test_uncal.asdf"
+    model.meta.exposure.read_pattern = [
+        [1],
+        [2],
+        [3],
+        [4],
+    ]  # truncated for 4 groups below
+    model.meta.exposure.ma_table_number = 5
+    model.meta.exposure.start_time = Time(
+        "2024-01-03T00:00:00.0", format="isot", scale="utc"
+    )
+    model.data = np.zeros((4, 4096, 4096), dtype=model.data.dtype)
+    model.amp33 = np.zeros((4, 4096, 128), dtype=model.amp33.dtype)
+    return model
+
+
 @pytest.fixture(scope="function")
 def input_value(request, tmp_path):
     model = rdm.RampModel.create_fake_data(shape=(2, 20, 20))
@@ -61,27 +80,12 @@ def test_input_to_output(function_jail, input_value, expected_output_type):
 
 
 @pytest.mark.parametrize("save_results", [True, False])
-def test_elp_save_results(function_jail, save_results, monkeypatch):
+def test_elp_save_results(function_jail, fake_science_raw, save_results, monkeypatch):
     """
     Test that the elp respects save_results.
     """
     output_path = function_jail / "output"
     output_path.mkdir()
-
-    model = rdm.ScienceRawModel.create_fake_data()
-    model.meta.filename = "test_uncal.asdf"
-    model.meta.exposure.read_pattern = [
-        [1],
-        [2],
-        [3],
-        [4],
-    ]  # truncated for 4 groups below
-    model.meta.exposure.ma_table_number = 5
-    model.meta.exposure.start_time = Time(
-        "2024-01-03T00:00:00.0", format="isot", scale="utc"
-    )
-    model.data = np.zeros((4, 4096, 4096), dtype=model.data.dtype)
-    model.amp33 = np.zeros((4, 4096, 128), dtype=model.amp33.dtype)
 
     pipeline = ExposurePipeline()
     pipeline.output_dir = str(output_path)
@@ -90,7 +94,7 @@ def test_elp_save_results(function_jail, save_results, monkeypatch):
     # don't try to actually run tweakreg as it will fail for an empty model
     monkeypatch.setattr(pipeline.tweakreg, "run", lambda init: init)
 
-    pipeline.run(model)
+    pipeline.run(fake_science_raw)
     # check that the current directory doesn't contain extra files
     assert set(p.name for p in function_jail.iterdir()) == {"output"}
 
@@ -101,3 +105,24 @@ def test_elp_save_results(function_jail, save_results, monkeypatch):
         expected.add("test_cal.asdf")
         expected.add("test_wcs.asdf")
     assert output_files == expected
+
+
+@pytest.mark.parametrize("on_disk", [True, False])
+def test_on_disk(function_jail, fake_science_raw, on_disk):
+    fake_science_raw.meta.filename = "foo.asdf"
+    fake_science_raw.save(fake_science_raw.meta.filename)
+    asn = asn_from_list([fake_science_raw.meta.filename], product_name="foo_out")
+    base_fn, contents = asn.dump(format="json")
+    asn_filename = base_fn
+    with open(asn_filename, "w") as f:
+        f.write(contents)
+
+    pipeline = ExposurePipeline()
+    pipeline.on_disk = on_disk
+    # don't fetch references
+    pipeline.prefetch_references = False
+    # skip all steps
+    [setattr(getattr(pipeline, k), "skip", True) for k in pipeline.step_defs]
+    pipeline.dq_init.skip = False  # unskip dqinit
+    output_value = pipeline.run(asn_filename)
+    assert output_value._on_disk == on_disk


### PR DESCRIPTION
Improve support for passing an association to the elp and add on_disk as a pipeline parameter option.

regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/23643371862

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
