### PR TITLE
RCAL-1365: Capitalize psf_match_reference_filter metadata

### DIFF
--- a/changes/2247.multiband_catalog.rst
+++ b/changes/2247.multiband_catalog.rst
@@ -1,0 +1,1 @@
+Updated psf_match_reference_filter metadata assignment to be uppercase and added a default value.

--- a/romancal/multiband_catalog/multiband_catalog.py
+++ b/romancal/multiband_catalog/multiband_catalog.py
@@ -383,7 +383,7 @@ def multiband_catalog(self, library, example_model, catalog_model, ee_spline):
     ref_psf_model = ref_info["ref_psf_model"]
 
     # Record the PSF match reference filter in metadata
-    detection_catalog.meta["psf_match_reference_filter"] = ref_filter.lower()
+    detection_catalog.meta["psf_match_reference_filter"] = ref_filter.upper()
 
     # Store reference filter's catalog for computing correction factors
     ref_filter_catalog = None  # defined in processing loop
@@ -475,6 +475,9 @@ def initialize_catalog_model(library, example_model):
     catalog_model = datamodels.MultibandSourceCatalogModel.create_minimal(
         {"meta": example_model.meta}
     )
+
+    catalog_model.meta.setdefault("psf_match_reference_filter", "NOT_CONFIGURED")
+
     catalog_model.meta["image"] = {
         # try to record association name else fall back to example model
         # filename

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -101,7 +101,7 @@ def check_psf_matched_catalog(cat, all_filters, ref_filter):
     n_aper = len(cat.meta["aperture_radii"]["circle_pix"])
     matched_bands = [f"{f}m" for f in all_filters if f != ref_filter]
 
-    assert cat.meta.get("psf_match_reference_filter") == ref_filter
+    assert cat.meta.get("psf_match_reference_filter") == ref_filter.upper()
 
     # All original filter bands should have aperture columns
     for f in all_filters:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1365](https://jira.stsci.edu/browse/RCAL-1365)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2241 

<!-- describe the changes comprising this PR here -->
This PR updates psf_match_reference_filter metadata assignment to be uppercase. It also adds a default value for psf_match_reference_filter.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
