### PR TITLE
RCAL-999: Implement method to populate meta.statistics attribute for datamodels.

### DIFF
--- a/romancal/lib/statistics.py
+++ b/romancal/lib/statistics.py
@@ -50,11 +50,13 @@ def populate_statistics(model):
         and model.data is not None
         and not np.all(np.isnan(model.data))
     ):
-        stats["image_median"] = float(np.nanmedian(model.data))
-        stats["image_rms"] = mad_std(model.data, ignore_nan=True)
+        good = np.ones_like(model.data, dtype="bool")
         if hasattr(model, "dq") and model.dq is not None:
-            num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
-            stats["good_pixel_fraction"] = num_good / model.data.size
+            good &= (model.dq & pixel.DO_NOT_USE) == 0
+        good &= (model.err > 0) & np.isfinite(model.data)
+        stats["image_median"] = float(np.median(model.data[good]))
+        stats["image_rms"] = float(mad_std(model.data[good]))
+        stats["good_pixel_fraction"] = np.sum(good) / model.data.size
 
     for key, value in stats.items():
         model.meta.statistics[key] = value

--- a/romancal/lib/statistics.py
+++ b/romancal/lib/statistics.py
@@ -26,30 +26,35 @@ def populate_statistics(model):
     Parameters
     ----------
     model : ImageModel or MosaicModel
-        The data model object to populate statistics for (must have a 'model.meta.data' attribute).
+        The data model object to populate statistics for (must have a 'model.data' attribute).
 
     Returns
     -------
     None
     """
-    if not hasattr(model, "data") or model.data is None:
-        logger.debug("Model has no data array; skipping statistics population.")
-        return
 
-    if getattr(model.meta, "statistics", None) is None:
+    if not getattr(model.meta, "statistics", False):
         logger.debug("Creating meta.statistics node...")
         model.meta.statistics = {}
 
-    img_median = float(np.nanmedian(model.data))
+    # initialize statistics with default values
+    stats = {
+        "zodiacal_light": -1.0,
+        "image_median": np.nan,
+        "image_rms": np.nan,
+        "good_pixel_fraction": np.nan,
+    }
 
-    img_rms = mad_std(model.data, ignore_nan=True)
+    if (
+        hasattr(model, "data")
+        and model.data is not None
+        and not np.all(np.isnan(model.data))
+    ):
+        stats["image_median"] = float(np.nanmedian(model.data))
+        stats["image_rms"] = mad_std(model.data, ignore_nan=True)
+        if hasattr(model, "dq") and model.dq is not None:
+            num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
+            stats["good_pixel_fraction"] = num_good / model.data.size
 
-    good_pix_frac = 0.0
-    if hasattr(model, "dq") and model.dq is not None:
-        num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
-        good_pix_frac = num_good / model.data.size
-
-        model.meta.statistics.zodiacal_light = -1.0  # placeholder
-        model.meta.statistics.image_median = img_median
-        model.meta.statistics.image_rms = img_rms
-        model.meta.statistics.good_pixel_fraction = good_pix_frac
+    for key, value in stats.items():
+        model.meta.statistics[key] = value

--- a/romancal/lib/statistics.py
+++ b/romancal/lib/statistics.py
@@ -1,0 +1,55 @@
+import logging
+
+import numpy as np
+from astropy.stats import mad_std
+from roman_datamodels.dqflags import pixel
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def populate_statistics(model):
+    """
+    Populate the meta.statistics attribute of the given model with image statistics.
+
+    This method computes and assigns the following statistics to model.meta.statistics:
+      - zodiacal_light (placeholder value)
+      - image_median (median of the data array, ignoring NaNs)
+      - image_rms (MAD standard deviation, ignoring NaNs)
+      - good_pixel_fraction (fraction of pixels not flagged as DO_NOT_USE)
+
+    Notes:
+      - If the model lacks a data array, the method will skip statistics population;
+      - If model.meta.statistics does not exist, it is created as an empty dictionary.
+
+    Parameters
+    ----------
+    model : ImageModel or MosaicModel
+        The data model object to populate statistics for (must have a 'model.meta.data' attribute).
+
+    Returns
+    -------
+    None
+    """
+    if not hasattr(model, "data") or model.data is None:
+        logger.debug("Model has no data array; skipping statistics population.")
+        return
+
+    if getattr(model.meta, "statistics", None) is None:
+        logger.debug("Creating meta.statistics node...")
+        model.meta.statistics = {}
+
+    img_median = float(np.nanmedian(model.data))
+
+    img_rms = mad_std(model.data, ignore_nan=True)
+
+    good_pix_frac = 0.0
+    if hasattr(model, "dq") and model.dq is not None:
+        num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
+        good_pix_frac = num_good / model.data.size
+
+        model.meta.statistics.zodiacal_light = -1.0  # placeholder
+        model.meta.statistics.image_median = img_median
+        model.meta.statistics.image_rms = img_rms
+        model.meta.statistics.good_pixel_fraction = good_pix_frac

--- a/romancal/lib/statistics.py
+++ b/romancal/lib/statistics.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 from astropy.stats import mad_std
+from roman_datamodels.datamodels import MosaicModel
 from roman_datamodels.dqflags import pixel
 
 # Configure logging
@@ -33,7 +34,7 @@ def populate_statistics(model):
     None
     """
 
-    if not getattr(model.meta, "statistics", False):
+    if not hasattr(model.meta, "statistics") or model.meta.statistics is None:
         logger.debug("Creating meta.statistics node...")
         model.meta.statistics = {}
 
@@ -42,21 +43,23 @@ def populate_statistics(model):
         "zodiacal_light": -1.0,
         "image_median": np.nan,
         "image_rms": np.nan,
-        "good_pixel_fraction": np.nan,
+        "good_pixel_fraction": 0.0,
     }
+    if isinstance(model, MosaicModel):
+        stats.pop("zodiacal_light", None)
 
-    if (
-        hasattr(model, "data")
-        and model.data is not None
-        and not np.all(np.isnan(model.data))
-    ):
-        good = np.ones_like(model.data, dtype="bool")
+    if hasattr(model, "data") and model.data is not None:
+        good = np.isfinite(model.data)
         if hasattr(model, "dq") and model.dq is not None:
             good &= (model.dq & pixel.DO_NOT_USE) == 0
-        good &= (model.err > 0) & np.isfinite(model.data)
-        stats["image_median"] = float(np.median(model.data[good]))
-        stats["image_rms"] = float(mad_std(model.data[good]))
-        stats["good_pixel_fraction"] = np.sum(good) / model.data.size
+        if hasattr(model, "err") and model.err is not None:
+            good &= model.err > 0
+        if not np.any(good):
+            logger.warning("No good pixels found for statistics calculation.")
+        else:
+            stats["image_median"] = float(np.median(model.data[good]))
+            stats["image_rms"] = float(mad_std(model.data[good]))
+            stats["good_pixel_fraction"] = np.sum(good) / model.data.size
 
     for key, value in stats.items():
         model.meta.statistics[key] = value

--- a/romancal/lib/tests/test_statistics.py
+++ b/romancal/lib/tests/test_statistics.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from roman_datamodels.datamodels import ImageModel, MosaicModel
+from roman_datamodels.dqflags import pixel
+
+from romancal.lib.statistics import populate_statistics
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [ImageModel, MosaicModel],
+)
+@pytest.mark.parametrize(
+    "data_val, dq_val, expected_frac",
+    [
+        # all pixels good (dq=0)
+        (10.0, 0, 1.0),
+        # all pixels flagged do_not_use (fraction should be 0.0)
+        (10.0, pixel.DO_NOT_USE, 0.0),
+        # half pixels flagged do_not_use (0.5)
+        (5.0, "half_bad", 0.5),
+        # other flags set (saturated), but not do_not_use (fraction should be 1.0)
+        (10.0, pixel.SATURATED | pixel.HOT, 1.0),
+    ],
+)
+def test_populate_statistics(model_class, data_val, dq_val, expected_frac):
+    """Test statistics population."""
+    shape = (10, 10)
+
+    model = model_class.create_minimal()
+
+    model.data = np.full(shape, data_val, dtype=np.float32)
+
+    if dq_val == "half_bad":
+        dq = np.zeros(shape, dtype=np.uint32)
+        dq.view().flat[0:50] = pixel.DO_NOT_USE
+        model.dq = dq
+    else:
+        model.dq = np.full(shape, dq_val, dtype=np.uint32)
+
+    # inject a nan to verify nan-resistance (nanmedian and mad_std)
+    model.data[0, 0] = np.nan
+
+    populate_statistics(model)
+
+    assert model.meta.statistics.image_median == data_val
+    assert model.meta.statistics.image_rms == 0.0
+    assert model.meta.statistics.good_pixel_fraction == pytest.approx(
+        expected_frac, abs=1e-6
+    )
+    # check the placeholder logic (-1.0)
+    assert model.meta.statistics.zodiacal_light == -1.0
+
+
+def test_statistics_graceful_exit_no_data():
+    """Ensure we don't crash if data is None."""
+
+    model = ImageModel.create_minimal()
+
+    model.data = None
+
+    populate_statistics(model)
+
+    # check that meta.statistics wasn't created
+    assert not hasattr(model.meta, "statistics")

--- a/romancal/lib/tests/test_statistics.py
+++ b/romancal/lib/tests/test_statistics.py
@@ -5,67 +5,150 @@ from roman_datamodels.dqflags import pixel
 
 from romancal.lib.statistics import populate_statistics
 
+SHAPE = (10, 10)
+
+
+def _create_model(model_class, *, data, dq=None, err=None):
+    model = model_class.create_minimal()
+    model.data = np.asarray(data, dtype=np.float32)
+
+    if dq is not None:
+        model.dq = np.asarray(dq, dtype=np.uint32)
+
+    model.err = None if err is None else np.asarray(err, dtype=np.float32)
+
+    return model
+
+
+def _assert_float_or_nan(actual, expected):
+    if np.isnan(expected):
+        assert np.isnan(actual)
+    else:
+        assert actual == pytest.approx(expected, abs=1e-6)
+
+
+def _assert_model_specific_placeholders(model):
+    if isinstance(model, MosaicModel):
+        assert not hasattr(model.meta.statistics, "zodiacal_light")
+    else:
+        assert model.meta.statistics.zodiacal_light == -1.0
+
+
+def _case_all_pixels_good():
+    data = np.full(SHAPE, 10.0, dtype=np.float32)
+    dq = np.zeros(SHAPE, dtype=np.uint32)
+    return data, dq, None, 10.0, 0.0, 1.0
+
+
+def _case_all_pixels_do_not_use():
+    data = np.full(SHAPE, 10.0, dtype=np.float32)
+    dq = np.full(SHAPE, pixel.DO_NOT_USE, dtype=np.uint32)
+    return data, dq, None, np.nan, np.nan, 0.0
+
+
+def _case_half_pixels_do_not_use():
+    data = np.full(SHAPE, 5.0, dtype=np.float32)
+    dq = np.zeros(SHAPE, dtype=np.uint32)
+    dq.flat[:50] = pixel.DO_NOT_USE
+    return data, dq, None, 5.0, 0.0, 0.5
+
+
+def _case_non_do_not_use_flags_only():
+    data = np.full(SHAPE, 10.0, dtype=np.float32)
+    dq = np.full(SHAPE, pixel.SATURATED | pixel.HOT, dtype=np.uint32)
+    return data, dq, None, 10.0, 0.0, 1.0
+
+
+def _case_nan_pixels_excluded_from_statistics():
+    data = np.full(SHAPE, 8.0, dtype=np.float32)
+    data[0, 0] = np.nan
+    dq = np.zeros(SHAPE, dtype=np.uint32)
+    expected_fraction = (data.size - 1) / data.size
+    return data, dq, None, 8.0, 0.0, expected_fraction
+
+
+def _case_nonpositive_err_pixels_excluded_from_statistics():
+    data = np.full(SHAPE, 7.0, dtype=np.float32)
+    dq = np.zeros(SHAPE, dtype=np.uint32)
+    err = np.ones(SHAPE, dtype=np.float32)
+    err.flat[:40] = 0.0
+    expected_fraction = (data.size - 40) / data.size
+    return data, dq, err, 7.0, 0.0, expected_fraction
+
 
 @pytest.mark.parametrize(
     "model_class",
     [ImageModel, MosaicModel],
+    ids=["image_model", "mosaic_model"],
 )
 @pytest.mark.parametrize(
-    "data_val, dq_val, expected_frac",
+    "case_factory",
     [
-        # all pixels good (dq=0)
-        (10.0, 0, 1.0),
-        # all pixels flagged do_not_use (fraction should be 0.0)
-        (10.0, pixel.DO_NOT_USE, 0.0),
-        # half pixels flagged do_not_use (0.5)
-        (5.0, "half_bad", 0.5),
-        # other flags set (saturated), but not do_not_use (fraction should be 1.0)
-        (10.0, pixel.SATURATED | pixel.HOT, 1.0),
+        pytest.param(_case_all_pixels_good, id="all_pixels_good"),
+        pytest.param(_case_all_pixels_do_not_use, id="all_pixels_do_not_use"),
+        pytest.param(_case_half_pixels_do_not_use, id="half_pixels_do_not_use"),
+        pytest.param(_case_non_do_not_use_flags_only, id="non_do_not_use_flags_only"),
+        pytest.param(
+            _case_nan_pixels_excluded_from_statistics,
+            id="nan_pixels_excluded_from_statistics",
+        ),
+        pytest.param(
+            _case_nonpositive_err_pixels_excluded_from_statistics,
+            id="nonpositive_err_pixels_excluded_from_statistics",
+        ),
     ],
 )
-def test_populate_statistics(model_class, data_val, dq_val, expected_frac):
-    """Test statistics population."""
-    shape = (10, 10)
-
-    model = model_class.create_minimal()
-
-    model.data = np.full(shape, data_val, dtype=np.float32)
-
-    if dq_val == "half_bad":
-        dq = np.zeros(shape, dtype=np.uint32)
-        dq.view().flat[0:50] = pixel.DO_NOT_USE
-        model.dq = dq
-    else:
-        model.dq = np.full(shape, dq_val, dtype=np.uint32)
-
-    # inject a nan to verify nan-resistance (nanmedian and mad_std)
-    model.data[0, 0] = np.nan
+def test_populate_statistics(model_class, case_factory):
+    """Populate statistics with different pixel-validity conditions."""
+    data, dq, err, expected_median, expected_rms, expected_frac = case_factory()
+    model = _create_model(model_class, data=data, dq=dq, err=err)
 
     populate_statistics(model)
 
-    assert model.meta.statistics.image_median == data_val
-    assert model.meta.statistics.image_rms == 0.0
+    _assert_float_or_nan(model.meta.statistics.image_median, expected_median)
+    _assert_float_or_nan(model.meta.statistics.image_rms, expected_rms)
     assert model.meta.statistics.good_pixel_fraction == pytest.approx(
         expected_frac, abs=1e-6
     )
-    # check the placeholder logic (-1.0)
-    assert model.meta.statistics.zodiacal_light == -1.0
+    _assert_model_specific_placeholders(model)
 
 
-def test_statistics_graceful_exit_no_data():
+@pytest.mark.parametrize(
+    "model_class",
+    [ImageModel, MosaicModel],
+    ids=["image_model", "mosaic_model"],
+)
+def test_populate_statistics_warns_when_no_good_pixels(model_class, caplog):
+    """No-good-pixel path logs a warning and leaves stats at defaults."""
+    data = np.full(SHAPE, 12.0, dtype=np.float32)
+    dq = np.zeros(SHAPE, dtype=np.uint32)
+    err = np.zeros(SHAPE, dtype=np.float32)
+    model = _create_model(model_class, data=data, dq=dq, err=err)
+
+    with caplog.at_level("WARNING", logger="romancal.lib.statistics"):
+        populate_statistics(model)
+
+    assert "No good pixels found for statistics calculation." in caplog.text
+    assert np.isnan(model.meta.statistics.image_median)
+    assert np.isnan(model.meta.statistics.image_rms)
+    assert model.meta.statistics.good_pixel_fraction == 0.0
+    _assert_model_specific_placeholders(model)
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [ImageModel, MosaicModel],
+    ids=["image_model", "mosaic_model"],
+)
+def test_statistics_graceful_exit_no_data(model_class):
     """Ensure meta.statistics is created with defaults if data is None."""
-
-    model = ImageModel.create_minimal()
+    model = model_class.create_minimal()
     model.data = None
 
     populate_statistics(model)
 
-    # 1. Check that meta.statistics WAS created (as per the first 'if' block)
     assert hasattr(model.meta, "statistics")
-
-    # 2. Verify that default values were still assigned
-    # Since model.data was None, the stats remain at their initialized defaults
-    assert model.meta.statistics.zodiacal_light == -1.0
     assert np.isnan(model.meta.statistics.image_median)
     assert np.isnan(model.meta.statistics.image_rms)
-    assert np.isnan(model.meta.statistics.good_pixel_fraction)
+    assert model.meta.statistics.good_pixel_fraction == 0.0
+    _assert_model_specific_placeholders(model)

--- a/romancal/lib/tests/test_statistics.py
+++ b/romancal/lib/tests/test_statistics.py
@@ -53,13 +53,19 @@ def test_populate_statistics(model_class, data_val, dq_val, expected_frac):
 
 
 def test_statistics_graceful_exit_no_data():
-    """Ensure we don't crash if data is None."""
+    """Ensure meta.statistics is created with defaults if data is None."""
 
     model = ImageModel.create_minimal()
-
     model.data = None
 
     populate_statistics(model)
 
-    # check that meta.statistics wasn't created
-    assert not hasattr(model.meta, "statistics")
+    # 1. Check that meta.statistics WAS created (as per the first 'if' block)
+    assert hasattr(model.meta, "statistics")
+
+    # 2. Verify that default values were still assigned
+    # Since model.data was None, the stats remain at their initialized defaults
+    assert model.meta.statistics.zodiacal_light == -1.0
+    assert np.isnan(model.meta.statistics.image_median)
+    assert np.isnan(model.meta.statistics.image_rms)
+    assert np.isnan(model.meta.statistics.good_pixel_fraction)

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -177,11 +177,6 @@ class ResampleStep(RomanStep):
     def _final_updates(self, model):
         model.meta.cal_step["resample"] = "COMPLETE"
 
-        # TODO statistics are unknown
-        model.meta.statistics.image_median = np.nan
-        model.meta.statistics.image_rms = np.nan
-        model.meta.statistics.good_pixel_fraction = np.nan
-
     @staticmethod
     def _load_custom_wcs(asdf_wcs_file, output_shape):
         if not asdf_wcs_file:

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import asdf
-import numpy as np
 from roman_datamodels import datamodels
 
 from romancal.datamodels.fileio import open_dataset

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -14,6 +14,7 @@ from stpipe import Pipeline, Step, crds_client
 
 from romancal.datamodels.fileio import open_dataset
 
+from ..lib.statistics import populate_statistics
 from ..lib.suffix import remove_suffix
 
 _LOG_FORMATTER = logging.Formatter(
@@ -104,7 +105,7 @@ class RomanStep(Step):
 
         if isinstance(model, ImageModel | MosaicModel):
             model.meta.cal_logs = self.log_records
-            self.populate_statistics(model)
+            populate_statistics(model)
 
         if len(reference_files_used) > 0:
             if not hasattr(model.meta, "ref_file"):
@@ -165,35 +166,6 @@ class RomanStep(Step):
         # by tests to be up-to-date.  Roman will likely need to do
         # something similar.
         return remove_suffix(name)
-
-    def populate_statistics(self, model):
-        """
-        Populate meta.statistics.
-        """
-        if not hasattr(model, "data") or model.data is None:
-            log.debug("Model has no data array; skipping statistics population.")
-            return
-
-        if getattr(model.meta, "statistics", None) is None:
-            log.debug("Creating meta.statistics node...")
-            model.meta.statistics = {}
-
-        img_median = float(np.nanmedian(model.data))
-
-        img_rms = mad_std(model.data, ignore_nan=True)
-
-        good_pix_frac = 0.0
-        if hasattr(model, "dq") and model.dq is not None:
-            num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
-            good_pix_frac = num_good / model.data.size
-
-        try:
-            model.meta.statistics.zodiacal_light = -1.0  # placeholder
-            model.meta.statistics.image_median = img_median
-            model.meta.statistics.image_rms = img_rms
-            model.meta.statistics.good_pixel_fraction = good_pix_frac
-        except AttributeError as e:
-            log.warning(f"Could not populate statistics stanza: {e}")
 
 
 # RomanPipeline needs to inherit from Pipeline, but also

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -6,7 +6,10 @@ import importlib.metadata
 import logging
 import time
 
+import numpy as np
+from astropy.stats import mad_std
 from roman_datamodels.datamodels import ImageModel, MosaicModel
+from roman_datamodels.dqflags import pixel
 from stpipe import Pipeline, Step, crds_client
 
 from romancal.datamodels.fileio import open_dataset
@@ -101,6 +104,7 @@ class RomanStep(Step):
 
         if isinstance(model, ImageModel | MosaicModel):
             model.meta.cal_logs = self.log_records
+            self.populate_statistics(model)
 
         if len(reference_files_used) > 0:
             if not hasattr(model.meta, "ref_file"):
@@ -161,6 +165,35 @@ class RomanStep(Step):
         # by tests to be up-to-date.  Roman will likely need to do
         # something similar.
         return remove_suffix(name)
+
+    def populate_statistics(self, model):
+        """
+        Populate meta.statistics.
+        """
+        if not hasattr(model, "data") or model.data is None:
+            log.debug("Model has no data array; skipping statistics population.")
+            return
+
+        if getattr(model.meta, "statistics", None) is None:
+            log.debug("Creating meta.statistics node...")
+            model.meta.statistics = {}
+
+        img_median = float(np.nanmedian(model.data))
+
+        img_rms = mad_std(model.data, ignore_nan=True)
+
+        good_pix_frac = 0.0
+        if hasattr(model, "dq") and model.dq is not None:
+            num_good = np.sum((model.dq & pixel.DO_NOT_USE) == 0)
+            good_pix_frac = num_good / model.data.size
+
+        try:
+            model.meta.statistics.zodiacal_light = -1.0  # placeholder
+            model.meta.statistics.image_median = img_median
+            model.meta.statistics.image_rms = img_rms
+            model.meta.statistics.good_pixel_fraction = good_pix_frac
+        except AttributeError as e:
+            log.warning(f"Could not populate statistics stanza: {e}")
 
 
 # RomanPipeline needs to inherit from Pipeline, but also

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -6,10 +6,7 @@ import importlib.metadata
 import logging
 import time
 
-import numpy as np
-from astropy.stats import mad_std
 from roman_datamodels.datamodels import ImageModel, MosaicModel
-from roman_datamodels.dqflags import pixel
 from stpipe import Pipeline, Step, crds_client
 
 from romancal.datamodels.fileio import open_dataset

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -143,65 +143,15 @@ def test_calibration_software_version(base_image):
     assert result.meta.calibration_software_version == romancal.__version__
 
 
-class MockStepClass(RomanStep):
-    """Minimal subclass to test RomanStep methods."""
-
-    def process(self, input):
-        return input
-
-
-@pytest.mark.parametrize(
-    "model_class",
-    [("imagemodel", ImageModel), ("mosaicmodel", MosaicModel)],
-)
-@pytest.mark.parametrize(
-    "data_val, dq_val, expected_frac",
-    [
-        # all pixels good (dq=0)
-        (10.0, 0, 1.0),
-        # all pixels flagged do_not_use (fraction should be 0.0)
-        (10.0, pixel.DO_NOT_USE, 0.0),
-        # half pixels flagged do_not_use (0.5)
-        (5.0, "half_bad", 0.5),
-        # other flags set (saturated), but not do_not_use (fraction should be 1.0)
-        (10.0, pixel.SATURATED | pixel.HOT, 1.0),
-    ],
-)
-def test_populate_statistics(model_type, model_class, data_val, dq_val, expected_frac):
-    """Test statistics population."""
-    step = MockStepClass()
-    shape = (10, 10)
-
-    model = model_class.create_minimal()
-
-    model.data = np.full(shape, data_val, dtype=np.float32)
-
-    if dq_val == "half_bad":
-        dq = np.zeros(shape, dtype=np.uint32)
-        dq.view().flat[0:50] = pixel.DO_NOT_USE
-        model.dq = dq
-    else:
-        model.dq = np.full(shape, dq_val, dtype=np.uint32)
-
-    # inject a nan to verify nan-resistance (nanmedian and mad_std)
-    model.data[0, 0] = np.nan
-
-    step.populate_statistics(model)
-
-    assert model.meta.statistics.image_median == data_val
-
-    assert model.meta.statistics.image_rms == 0.0
-
-    assert model.meta.statistics.good_pixel_fraction == pytest.approx(
-        expected_frac, abs=1e-6
-    )
-
-    # check the placeholder logic (-1.0)
-    assert model.meta.statistics.zodiacal_light == -1.0
-
-
 def test_statistics_handled_in_finalize():
     """Verify finalize_result triggers the statistics population."""
+
+    class MockStepClass(RomanStep):
+        """Minimal subclass to test RomanStep methods."""
+
+        def process(self, input):
+            return input
+
     step = MockStepClass()
     shape = (10, 10)
 
@@ -216,40 +166,3 @@ def test_statistics_handled_in_finalize():
     assert hasattr(model.meta, "statistics")
     assert model.meta.statistics.image_median == 1.0
     assert model.meta.statistics.good_pixel_fraction == 1.0
-
-
-def test_statistics_graceful_exit_no_data():
-    """Ensure we don't crash if data is None."""
-    step = MockStepClass()
-
-    model = ImageModel.create_minimal()
-
-    model.data = None
-
-    step.populate_statistics(model)
-
-    # check that meta.statistics wasn't created
-    assert not hasattr(model.meta, "statistics")
-
-
-def test_populate_statistics_attribute_error(caplog):
-    step = MockStepClass()
-
-    # create a "Bad" object that raises AttributeError on any attribute assignment
-    class FailOnSet:
-        def __setattr__(self, name, value):
-            raise AttributeError("Cannot set attribute")
-
-    bad_model = type(
-        "BadModel",
-        (),
-        {
-            "data": np.ones((2, 2), dtype=np.float32),
-            "dq": np.zeros((2, 2), dtype=np.uint32),
-            "meta": type("BadMeta", (), {"statistics": FailOnSet()})(),
-        },
-    )()
-
-    step.populate_statistics(bad_model)
-
-    assert "Could not populate statistics stanza" in caplog.text

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -4,8 +4,7 @@ import logging
 import numpy as np
 import pytest
 from astropy.time import Time
-from roman_datamodels.datamodels import FlatRefModel, ImageModel, MosaicModel
-from roman_datamodels.dqflags import pixel
+from roman_datamodels.datamodels import FlatRefModel, ImageModel
 from stpipe import crds_client
 
 import romancal

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -143,7 +143,7 @@ def test_calibration_software_version(base_image):
     assert result.meta.calibration_software_version == romancal.__version__
 
 
-class MockStep(RomanStep):
+class MockStepClass(RomanStep):
     """Minimal subclass to test RomanStep methods."""
 
     def process(self, input):
@@ -169,7 +169,7 @@ class MockStep(RomanStep):
 )
 def test_populate_statistics(model_type, model_class, data_val, dq_val, expected_frac):
     """Test statistics population."""
-    step = MockStep()
+    step = MockStepClass()
     shape = (10, 10)
 
     model = model_class.create_minimal()
@@ -202,7 +202,7 @@ def test_populate_statistics(model_type, model_class, data_val, dq_val, expected
 
 def test_statistics_handled_in_finalize():
     """Verify finalize_result triggers the statistics population."""
-    step = MockStep()
+    step = MockStepClass()
     shape = (10, 10)
 
     model = ImageModel.create_minimal()
@@ -220,7 +220,7 @@ def test_statistics_handled_in_finalize():
 
 def test_statistics_graceful_exit_no_data():
     """Ensure we don't crash if data is None."""
-    step = MockStep()
+    step = MockStepClass()
 
     model = ImageModel.create_minimal()
 

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -151,7 +151,7 @@ class MockStepClass(RomanStep):
 
 
 @pytest.mark.parametrize(
-    "model_type, model_class",
+    "model_class",
     [("imagemodel", ImageModel), ("mosaicmodel", MosaicModel)],
 )
 @pytest.mark.parametrize(

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -1,9 +1,11 @@
 import json
 import logging
 
+import numpy as np
 import pytest
 from astropy.time import Time
-from roman_datamodels.datamodels import FlatRefModel, ImageModel
+from roman_datamodels.datamodels import FlatRefModel, ImageModel, MosaicModel
+from roman_datamodels.dqflags import pixel
 from stpipe import crds_client
 
 import romancal
@@ -139,3 +141,92 @@ def test_calibration_software_version(base_image):
     result = NullStep.call(im)
 
     assert result.meta.calibration_software_version == romancal.__version__
+
+
+class MockStep(RomanStep):
+    """Minimal subclass to test RomanStep methods."""
+
+    def process(self, input):
+        return input
+
+
+@pytest.mark.parametrize(
+    "model_type, model_class",
+    [("imagemodel", ImageModel), ("mosaicmodel", MosaicModel)],
+)
+@pytest.mark.parametrize(
+    "data_val, dq_val, expected_frac",
+    [
+        # all pixels good (dq=0)
+        (10.0, 0, 1.0),
+        # all pixels flagged do_not_use (fraction should be 0.0)
+        (10.0, pixel.DO_NOT_USE, 0.0),
+        # half pixels flagged do_not_use (0.5)
+        (5.0, "half_bad", 0.5),
+        # other flags set (saturated), but not do_not_use (fraction should be 1.0)
+        (10.0, pixel.SATURATED | pixel.HOT, 1.0),
+    ],
+)
+def test_populate_statistics(model_type, model_class, data_val, dq_val, expected_frac):
+    """Test statistics population."""
+    step = MockStep()
+    shape = (10, 10)
+
+    model = model_class.create_minimal()
+
+    model.data = np.full(shape, data_val, dtype=np.float32)
+
+    if dq_val == "half_bad":
+        dq = np.zeros(shape, dtype=np.uint32)
+        dq.view().flat[0:50] = pixel.DO_NOT_USE
+        model.dq = dq
+    else:
+        model.dq = np.full(shape, dq_val, dtype=np.uint32)
+
+    # inject a nan to verify nan-resistance (nanmedian and mad_std)
+    model.data[0, 0] = np.nan
+
+    step.populate_statistics(model)
+
+    assert model.meta.statistics.image_median == data_val
+
+    assert model.meta.statistics.image_rms == 0.0
+
+    assert model.meta.statistics.good_pixel_fraction == pytest.approx(
+        expected_frac, abs=1e-6
+    )
+
+    # check the placeholder logic (-1.0)
+    assert model.meta.statistics.zodiacal_light == -1.0
+
+
+def test_statistics_handled_in_finalize():
+    """Verify finalize_result triggers the statistics population."""
+    step = MockStep()
+    shape = (10, 10)
+
+    model = ImageModel.create_minimal()
+
+    model.data = np.ones(shape, dtype=np.float32)
+    model.dq = np.zeros(shape, dtype=np.uint32)
+
+    # finalize_result should trigger the populate_statistics call
+    step.finalize_result(model, [])
+
+    assert hasattr(model.meta, "statistics")
+    assert model.meta.statistics.image_median == 1.0
+    assert model.meta.statistics.good_pixel_fraction == 1.0
+
+
+def test_statistics_graceful_exit_no_data():
+    """Ensure we don't crash if data is None."""
+    step = MockStep()
+
+    model = ImageModel.create_minimal()
+
+    model.data = None
+
+    step.populate_statistics(model)
+
+    # check that meta.statistics wasn't created
+    assert not hasattr(model.meta, "statistics")

--- a/romancal/stpipe/tests/test_core.py
+++ b/romancal/stpipe/tests/test_core.py
@@ -230,3 +230,26 @@ def test_statistics_graceful_exit_no_data():
 
     # check that meta.statistics wasn't created
     assert not hasattr(model.meta, "statistics")
+
+
+def test_populate_statistics_attribute_error(caplog):
+    step = MockStepClass()
+
+    # create a "Bad" object that raises AttributeError on any attribute assignment
+    class FailOnSet:
+        def __setattr__(self, name, value):
+            raise AttributeError("Cannot set attribute")
+
+    bad_model = type(
+        "BadModel",
+        (),
+        {
+            "data": np.ones((2, 2), dtype=np.float32),
+            "dq": np.zeros((2, 2), dtype=np.uint32),
+            "meta": type("BadMeta", (), {"statistics": FailOnSet()})(),
+        },
+    )()
+
+    step.populate_statistics(bad_model)
+
+    assert "Could not populate statistics stanza" in caplog.text

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -40,6 +40,9 @@ def all_steps():
 
     steps = {}
     for module in load_sub_modules(romancal):
+        # skip if the module is part of a test suite
+        if ".tests" in module.__name__ or ".test_" in module.__name__:
+            continue
         more_steps = {
             klass_name: klass
             for klass_name, klass in inspect.getmembers(

--- a/romancal/stpipe/utilities.py
+++ b/romancal/stpipe/utilities.py
@@ -40,9 +40,6 @@ def all_steps():
 
     steps = {}
     for module in load_sub_modules(romancal):
-        # skip if the module is part of a test suite
-        if ".tests" in module.__name__ or ".test_" in module.__name__:
-            continue
         more_steps = {
             klass_name: klass
             for klass_name, klass in inspect.getmembers(
@@ -71,6 +68,8 @@ def load_sub_modules(module):
     """
 
     for package_info in walk_packages(module.__path__):
+        if "tests" in package_info.name:
+            continue
         if package_info.module_finder.path.startswith(module.__path__[0]):
             package = import_module(f"{module.__name__}.{package_info.name}")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-999](https://jira.stsci.edu/browse/RCAL-999)

<!-- describe the changes comprising this PR here -->
This PR implements a new `romancal.lib.statistics.populate_statistics()` helper and wires it into `RomanStep.finalize_result()` so that any Roman step that produces an `ImageModel` or `MosaicModel` output will have `meta.statistics` populated automatically.

### Regression tests
- https://github.com/spacetelescope/RegressionTests/actions/runs/24248120103 (04/10/26)
    - Run against context 46. All 23 failing tests are due to the new `meta.statistics` attribute being added, which will be fixed once the truth files have been "okified."
- https://github.com/spacetelescope/RegressionTests/actions/runs/24360861732 (04/13/26)
    - Run using default context value `roman-edit`. Same results as previously. All 23 failing tests are due to the new `meta.statistics` attribute being added, which will be fixed once the truth files have been "okified."

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [X] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
