### PR TITLE
RCAL-1367: Apply data_encoding_offset

### DIFF
--- a/changes/2250.dq_init.rst
+++ b/changes/2250.dq_init.rst
@@ -1,0 +1,1 @@
+Added support for the data encoding offset with a unit test.

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -90,11 +90,11 @@ class DQInitStep(RomanStep):
             del output_model.reference_amp33
 
         # If a data encoding offset was added to the data, remove it
-        data_encoding_offset = \
-            getattr(input_model.meta.instrument, "data_encoding_offset", None)
+        data_encoding_offset = getattr(
+            input_model.meta.instrument, "data_encoding_offset", None
+        )
         if data_encoding_offset is not None and not is_tvac:
             output_model.data -= data_encoding_offset
-
 
         # Test for reference file
         if reference_file_name != "N/A" and reference_file_name is not None:

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -89,6 +89,13 @@ class DQInitStep(RomanStep):
             output_model.amp33 += reference_amp33
             del output_model.reference_amp33
 
+        # If a data encoding offset was added to the data, remove it
+        data_encoding_offset = \
+            getattr(input_model.meta.instrument, "data_encoding_offset", None)
+        if data_encoding_offset is not None and not is_tvac:
+            output_model.data -= data_encoding_offset
+
+
         # Test for reference file
         if reference_file_name != "N/A" and reference_file_name is not None:
             # If there are mask files, perform dq step

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -91,10 +91,9 @@ class DQInitStep(RomanStep):
 
         # If a data encoding offset was added to the data, remove it
         data_encoding_offset = getattr(
-            input_model.meta.instrument, "data_encoding_offset", None
+            input_model.meta.instrument, "data_encoding_offset", 0
         )
-        if data_encoding_offset is not None and not is_tvac:
-            output_model.data -= data_encoding_offset
+        output_model.data -= data_encoding_offset
 
         # Test for reference file
         if reference_file_name != "N/A" and reference_file_name is not None:

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -319,6 +319,7 @@ def test_dqinit_add_reference_read():
     assert np.allclose(result2.data - result.data, offset)
     assert np.allclose(result2.amp33 - result.amp33, offset)
 
+
 def test_dqinit_sub_data_encoding_offset():
     offset = 7
     shape = (2, 20, 20)

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -318,3 +318,15 @@ def test_dqinit_add_reference_read():
 
     assert np.allclose(result2.data - result.data, offset)
     assert np.allclose(result2.amp33 - result.amp33, offset)
+
+def test_dqinit_sub_data_encoding_offset():
+    offset = 7
+    shape = (2, 20, 20)
+
+    wfi_sci_raw_model = rawim(shape, "WFI", "WFI_IMAGE")
+    result = DQInitStep.call(wfi_sci_raw_model)
+
+    wfi_sci_raw_model.meta.instrument.data_encoding_offset = offset
+    result2 = DQInitStep.call(wfi_sci_raw_model)
+
+    assert np.allclose(result.data - result2.data, offset)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1367](https://jira.stsci.edu/browse/RCAL-1367)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2249

<!-- describe the changes comprising this PR here -->
This PR adds support for the data encoding offset with a unit test.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
