### PR TITLE
remove ddtrace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,10 +69,10 @@ jobs:
       envs: |
         - linux: py311-oldestdeps-cov
         - linux: py311-nolegacypath
-        - linux: py312-ddtrace
+        - linux: py312
         - linux: py313-cov
           coverage: codecov
           pytest-results-summary: true
-        - macos: py313-ddtrace
+        - macos: py313
         - macos: py313-pyargs
           pytest-results-summary: true

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ description =
     regtests: with --bigdata and --slow flags
     cov: with coverage
     xdist: using parallel processing
-    ddtrace: passing test traces to DataDog agent
 pass_env =
     HOME
     CI
@@ -36,7 +35,6 @@ extras =
     alldeps: all
 deps =
     xdist: pytest-xdist
-    ddtrace: ddtrace
     oldestdeps: minimum_dependencies
     devdeps: -r requirements-dev.txt
 commands_pre =
@@ -50,6 +48,5 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n 0 \
     pyargs: {toxinidir}/docs --pyargs {posargs:romancal} \
-    ddtrace: --ddtrace \
     nolegacypath: -p no:legacypath \
     {posargs}


### PR DESCRIPTION
Resolves https://jira.stsci.edu/browse/RCAL-1369

Remove the pytest `ddtrace` plugin since it's been failing for some time, noone has noticed and noone appears to be using the reports. See https://github.com/spacetelescope/romancal/issues/2253 for more reasons to remove this.

No changes were made to any files used by regression tests so none were run.

Branch protection rules will need to be updated when merging this PR.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
