### PR TITLE
Update TweakReg step fitgeometry default to general

### DIFF
--- a/changes/2260.tweakreg.rst
+++ b/changes/2260.tweakreg.rst
@@ -1,0 +1,1 @@
+Change default fit geometry from `rshift` to `general`.

--- a/docs/roman/tweakreg/README.rst
+++ b/docs/roman/tweakreg/README.rst
@@ -130,7 +130,7 @@ Step Arguments
   - ``'rscale'``: rotation, shifts, and scale
   - ``'general'``: rotation, shifts, scale, and skew
 
-  The default value is "rshift".
+  The default value is "general".
 
   .. note::
       Mathematically, alignment of images observed in different tangent planes
@@ -191,7 +191,7 @@ Parameters used for absolute astrometry to a reference catalog.
   - ``'rscale'``: rotation and scale
   - ``'general'``: shift, rotation, and scale
 
-  The default value is "rshift". Note that the same conditions/restrictions
+  The default value is "general". Note that the same conditions/restrictions
   that apply to ``fitgeometry`` also apply to ``abs_fitgeometry``.
 
 * ``abs_nclip``: A non-negative integer number of clipping iterations

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -54,7 +54,7 @@ class TweakRegStep(RomanStep):
         use2dhist = boolean(default=True) # Use 2d histogram to find initial offset?
         separation = float(default=1.0) # Minimum object separation in arcsec
         tolerance = float(default=0.7) # Matching tolerance for xyxymatch in arcsec
-        fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='rshift') # Fitting geometry
+        fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='general') # Fitting geometry
         nclip = integer(min=0, default=3) # Number of clipping iterations in fit
         sigma = float(min=0.0, default=3.0) # Clipping limit in sigma units
         abs_refcat = string(default='{DEFAULT_ABS_REFCAT}')  # Absolute reference catalog
@@ -66,7 +66,7 @@ class TweakRegStep(RomanStep):
         abs_separation = float(default=1.0) # Minimum object separation in arcsec when performing absolute astrometry
         abs_tolerance = float(default=0.7) # Matching tolerance for xyxymatch in arcsec when performing absolute astrometry
         # Fitting geometry when performing absolute astrometry
-        abs_fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='rshift')
+        abs_fitgeometry = option('shift', 'rshift', 'rscale', 'general', default='general')
         abs_nclip = integer(min=0, default=3) # Number of clipping iterations in fit when performing absolute astrometry
         abs_sigma = float(min=0.0, default=3.0) # Clipping limit in sigma units when performing absolute astrometry
         output_use_model = boolean(default=True)  # When saving use `DataModel.meta.filename`


### PR DESCRIPTION
This PR addresses a request from RTB (via the Calibration Working Group) to change the fit geometry in the astrometric alignment to a generalized six-parameter fit.

## Regression tests
- https://github.com/spacetelescope/RegressionTests/actions/runs/25377121660 (05/05/2026; passing after being okified).

## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
