### PR TITLE
RCAL-1372: Fix L3 Datamodels for Required Keys

### DIFF
--- a/romancal/datamodels/migration.py
+++ b/romancal/datamodels/migration.py
@@ -30,13 +30,19 @@ def update_model_version(model, *, close_on_update=False):
     if type(updated_model.meta.file_date) is not Time:
         updated_model.meta.file_date = Time(updated_model.meta.file_date)
 
-    # old files (<B21) lacks WFI_parallel
+    # old files (<B21) lack WFI_parallel
     if ("wfi_parallel" not in model.meta.get("observation", {})) and (
         visit_file_sequence := model.meta.get("observation", {}).get(
             "visit_file_sequence", None
         )
     ):
         updated_model.meta.observation.wfi_parallel = visit_file_sequence > 1
+
+    # old L3 files (<B22) lack pixmap_stepsize
+    if ("resample" in model.get("meta", {})) and (
+        "pixmap_stepsize" not in model.meta.get("resample", {})
+    ):
+        updated_model.meta.resample.pixmap_stepsize = 1
 
     new_ref_files = ["darkdecaysignal", "integralnonlinearity", "inverselinearity"]
     ref_file = model.meta.get("ref_file", None)

--- a/romancal/datamodels/tests/test_migration.py
+++ b/romancal/datamodels/tests/test_migration.py
@@ -8,6 +8,7 @@ from romancal.datamodels.migration import update_model_version
 def latest_model():
     return rdm.ImageModel.create_fake_data()
 
+
 @pytest.fixture
 def latest_L3_model():
     return rdm.MosaicModel.create_fake_data()
@@ -64,6 +65,7 @@ def test_L3_update(old_L3_model, latest_L3_model):
     assert new_L3_model.tag != old_L3_model.tag
     assert new_L3_model.tag == latest_L3_model.tag
     assert new_L3_model.meta.resample.pixmap_stepsize == 1
+
 
 def test_no_update(latest_model):
     new_model = update_model_version(latest_model)

--- a/romancal/datamodels/tests/test_migration.py
+++ b/romancal/datamodels/tests/test_migration.py
@@ -8,11 +8,22 @@ from romancal.datamodels.migration import update_model_version
 def latest_model():
     return rdm.ImageModel.create_fake_data()
 
+@pytest.fixture
+def latest_L3_model():
+    return rdm.MosaicModel.create_fake_data()
+
 
 @pytest.fixture
 def old_model():
     return rdm.ImageModel.create_fake_data(
         tag="asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.4.0"
+    )
+
+
+@pytest.fixture
+def old_L3_model():
+    return rdm.MosaicModel.create_fake_data(
+        tag="asdf://stsci.edu/datamodels/roman/tags/wfi_mosaic-1.4.0"
     )
 
 
@@ -46,6 +57,13 @@ def test_update(old_model, latest_model, vfs_value, wp_bool):
     assert new_model.tag == latest_model.tag
     assert new_model.meta.observation.wfi_parallel == wp_bool
 
+
+def test_L3_update(old_L3_model, latest_L3_model):
+    new_L3_model = update_model_version(old_L3_model)
+    assert new_L3_model is not old_L3_model
+    assert new_L3_model.tag != old_L3_model.tag
+    assert new_L3_model.tag == latest_L3_model.tag
+    assert new_L3_model.meta.resample.pixmap_stepsize == 1
 
 def test_no_update(latest_model):
     new_model = update_model_version(latest_model)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1372](https://jira.stsci.edu/browse/RCAL-1372)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2262

<!-- describe the changes comprising this PR here -->
This PR adds migration support for newly required resample keywords.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
