### PR TITLE
RCAL-1250: log info about which catalog is being used by TweakReg.

### DIFF
--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -499,3 +499,19 @@ def test_parquet_metadata_preserved_after_update(function_jail, tweakreg_image):
         # Check that units are readable (not None or empty when they should have units)
         if col in ["ra_centroid", "dec_centroid", "ra_psf", "dec_psf"]:
             assert updated_astropy[col].unit == u.deg
+
+
+def test_tweakreg_logs_selected_catalog_file(tweakreg_image, caplog):
+    """
+    Test that TweakReg logs which catalog file is used for an image.
+    """
+    img = tweakreg_image()
+    expected_catalog_path = img.meta.source_catalog.tweakreg_catalog_name
+
+    with caplog.at_level("INFO"):
+        TweakRegStep().get_tweakreg_catalog(img.meta.source_catalog, img)
+
+    assert (
+        f"Using tweakreg catalog file '{expected_catalog_path}' for {img.meta.filename}."
+        in caplog.text
+    )

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -458,7 +458,9 @@ class TweakRegStep(RomanStep):
         """
         twk_cat = getattr(source_catalog, "tweakreg_catalog", None)
         twk_cat_name = getattr(source_catalog, "tweakreg_catalog_name", None)
-        image_name = getattr(getattr(image_model, "meta", None), "filename", "<unknown>")
+        image_name = getattr(
+            getattr(image_model, "meta", None), "filename", "<unknown>"
+        )
 
         if twk_cat is not None:
             log.info(
@@ -469,9 +471,7 @@ class TweakRegStep(RomanStep):
             return tweakreg_catalog
 
         elif twk_cat_name is not None:
-            log.info(
-                f"Using tweakreg catalog file '{twk_cat_name}' for {image_name}."
-            )
+            log.info(f"Using tweakreg catalog file '{twk_cat_name}' for {image_name}.")
             return self.read_catalog(source_catalog.tweakreg_catalog_name)
 
         else:

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -458,13 +458,20 @@ class TweakRegStep(RomanStep):
         """
         twk_cat = getattr(source_catalog, "tweakreg_catalog", None)
         twk_cat_name = getattr(source_catalog, "tweakreg_catalog_name", None)
+        image_name = getattr(getattr(image_model, "meta", None), "filename", "<unknown>")
 
         if twk_cat is not None:
+            log.info(
+                f"Using in-memory tweakreg catalog from meta.source_catalog.tweakreg_catalog for {image_name}."
+            )
             tweakreg_catalog = Table(np.asarray(source_catalog.tweakreg_catalog))
             del image_model.meta.source_catalog["tweakreg_catalog"]
             return tweakreg_catalog
 
         elif twk_cat_name is not None:
+            log.info(
+                f"Using tweakreg catalog file '{twk_cat_name}' for {image_name}."
+            )
             return self.read_catalog(source_catalog.tweakreg_catalog_name)
 
         else:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1250](https://jira.stsci.edu/browse/RCAL-1250)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2013 

<!-- describe the changes comprising this PR here -->
This PR adds runtime log info so users can confirm exactly which catalog was used for each exposure. It updates tweakreg to explicitly report which source catalog is actually used at runtime for each image.

- Added per-image logging in `TweakRegStep.get_tweakreg_catalog`:
  - logs when an in-memory catalog from `meta.source_catalog.tweakreg_catalog` is used;
  - logs when a file-backed catalog from `meta.source_catalog.tweakreg_catalog_name` is used (including the exact path).
- Added a unit test:
  - `test_tweakreg_logs_selected_catalog_file` in `romancal/tweakreg/tests/test_tweakreg.py`;


## Regression tests
All tests are passing:
- https://github.com/spacetelescope/RegressionTests/actions/runs/24250614863/job/70808655098 (04/10/26)

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [X] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
