### PR TITLE
RCAL-1273-patch: Clarify association file usage in tweakreg documentation.

### DIFF
--- a/docs/roman/tweakreg/README.rst
+++ b/docs/roman/tweakreg/README.rst
@@ -26,11 +26,11 @@ indicate source *image* coordinates (in pixels). Pixel coordinates are
 
 Association files can also be used as ``tweakreg`` input for custom catalogs.
 When an association is provided, ``tweakreg`` reads the custom catalog
-information for each member from that member's ``tweakreg_catalog`` attribute 
-and sets it as the value for that member's 
-``meta.source_catalog.tweakreg_catalog_name`` metadata. 
-For example, the following association contains two members 
-(``image1.asdf`` and ``image2.asdf``) with custom catalogs and one member 
+information for each member from that member's ``tweakreg_catalog`` attribute
+and sets it as the value for that member's
+``meta.source_catalog.tweakreg_catalog_name`` metadata.
+For example, the following association contains two members
+(``image1.asdf`` and ``image2.asdf``) with custom catalogs and one member
 (``image3.asdf``) without a custom catalog:
 
   .. code-block:: json
@@ -55,8 +55,8 @@ For example, the following association contains two members
 
 In this case, ``tweakreg`` will read the custom catalogs for ``image1.asdf`` and
 ``image2.asdf`` from the specified file paths and use them for alignment, while
-it will attempt to read the source catalog for ``image3.asdf`` from the file path 
-specified in its ``meta.source_catalog.tweakreg_catalog_name`` metadata 
+it will attempt to read the source catalog for ``image3.asdf`` from the file path
+specified in its ``meta.source_catalog.tweakreg_catalog_name`` metadata
 (which is expected to be set by a previous step such as `SourceCatalogStep`).
 
 .. note::

--- a/docs/roman/tweakreg/README.rst
+++ b/docs/roman/tweakreg/README.rst
@@ -23,11 +23,41 @@ for ``.parquet`` files). The catalog must contain
 either ``'x'`` and ``'y'`` or ``'x_psf'`` and ``'y_psf'`` columns which
 indicate source *image* coordinates (in pixels). Pixel coordinates are
 0-indexed.
+
 Association files can also be used as ``tweakreg`` input for custom catalogs.
 When an association is provided, ``tweakreg`` reads the custom catalog
-information for each member from that member's
-``meta.source_catalog.tweakreg_catalog`` or
-``meta.source_catalog.tweakreg_catalog_name`` metadata.
+information for each member from that member's ``tweakreg_catalog`` attribute 
+and sets it as the value for that member's 
+``meta.source_catalog.tweakreg_catalog_name`` metadata. 
+For example, the following association contains two members 
+(``image1.asdf`` and ``image2.asdf``) with custom catalogs and one member 
+(``image3.asdf``) without a custom catalog:
+
+  .. code-block:: json
+
+    {
+      "asn_type": "tweakreg",
+      "asn_id": "tweakreg_12345678",
+      "members": [
+        {
+          "expname": "image1.asdf",
+          "tweakreg_catalog": "/path/to/image1_catalog.parquet"
+        },
+        {
+          "expname": "image2.asdf",
+          "tweakreg_catalog": "/path/to/image2_catalog.parquet"
+        },
+        {
+          "expname": "image3.asdf",
+        }
+      ]
+    }
+
+In this case, ``tweakreg`` will read the custom catalogs for ``image1.asdf`` and
+``image2.asdf`` from the specified file paths and use them for alignment, while
+it will attempt to read the source catalog for ``image3.asdf`` from the file path 
+specified in its ``meta.source_catalog.tweakreg_catalog_name`` metadata 
+(which is expected to be set by a previous step such as `SourceCatalogStep`).
 
 .. note::
     ``tweakreg`` requires ``meta.source_catalog`` to be present.


### PR DESCRIPTION


<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1273](https://jira.stsci.edu/browse/RCAL-1273)

<!-- describe the changes comprising this PR here -->
This PR updates documentation to clarify how association files can be used as input for TweakReg, including details on custom catalogs and metadata handling.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
