### PR TITLE
Refactor dq_init to move logic out of dq_init_step

### DIFF
--- a/changes/2282.dq_init.rst
+++ b/changes/2282.dq_init.rst
@@ -1,0 +1,1 @@
+Moved DQ init logic into dq_initialization.py and added expand_gw_flagging step parameter.

--- a/docs/roman/dq_init/arguments.rst
+++ b/docs/roman/dq_init/arguments.rst
@@ -1,3 +1,6 @@
 Step Arguments
 ==============
-The Data Quality Initialization step has no step-specific arguments.
+
+``expand_gw_flagging``
+  The number of pixels by which to expand the ``DO_NOT_USE`` flagging around
+  the guide window rectangle in each direction. Default is 0 (no expansion).

--- a/docs/roman/dq_init/description.rst
+++ b/docs/roman/dq_init/description.rst
@@ -27,10 +27,11 @@ The actual process consists of the following steps:
  - Propagate the DQ flags from the reference file DQ array to the science data "PIXELDQ"
    array using numpy's ``bitwise_or`` function.
 
-Note that when applying the ``dq_init`` step to guide star data, the flags from the MASK reference
-file are propagated into the guide star dataset "dq" array, instead of the "pixeldq" array.
-The step identifies guide star data based on the following exposure type (exposure.type keyword attribute) values:
-WFI_WIM_ACQ, WFI_WIM_TRACK, WFI_WSM_ACQ1, WFI_WSM_ACQ2, WFI_WSM_TRACK.
+ - Flag pixels affected by the guide window readout. All pixels in the columns
+   spanned by the guide window are flagged ``GW_AFFECTED_DATA``. The pixels
+   within the guide window rectangle itself are additionally flagged
+   ``DO_NOT_USE``. The ``expand_gw_flagging`` step argument extends this
+   ``DO_NOT_USE`` region by a given number of pixels in each direction.
 
 Conversion from Level 1 uncal files
 -----------------------------------

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -5,11 +5,9 @@ import logging
 from typing import TYPE_CHECKING
 
 import roman_datamodels as rdm
-from roman_datamodels.datamodels import FpsModel, RampModel, ScienceRawModel, TvacModel
-from roman_datamodels.dqflags import pixel
 
 from romancal.datamodels.fileio import open_dataset
-from romancal.dq_init import dq_initialization
+from romancal.dq_init.dq_initialization import do_dqinit
 from romancal.stpipe import RomanStep
 
 if TYPE_CHECKING:
@@ -51,85 +49,18 @@ class DQInitStep(RomanStep):
         """
         # Open datamodel
         input_model = open_dataset(dataset, update_version=self.update_version)
-        is_tvac = isinstance(input_model, (FpsModel | TvacModel))
-        try:
-            # note that this succeeds even for ScienceRawModels
-            input_model = ScienceRawModel.from_tvac_raw(input_model)
-        except ValueError:
-            pass
-
-        # Convert to RampModel
-        output_model = RampModel.from_science_raw(input_model)
-
-        # guide window range information
-        x_start = int(input_model.meta.guide_star.window_xstart)
-        x_stop = int(input_model.meta.guide_star.window_xstop)
-        y_start = int(input_model.meta.guide_star.window_ystart)
-        y_stop = int(input_model.meta.guide_star.window_ystop)
-        # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
-        output_model.pixeldq[:, x_start:x_stop] = pixel.GW_AFFECTED_DATA
-        log.info(
-            f"Flagging rows from: {x_start} to {x_stop} as affected by guide window read"
-        )
-        output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= pixel.DO_NOT_USE
 
         # Get reference file path
-        reference_file_name = self.get_reference_file(output_model, "mask")
-
-        # the reference read has been subtracted from the science data
-        # in the L1 files.  Add it back into the data.
-        # the TVAC files are special and there the reference read was
-        # already added back in
-        reference_read = getattr(input_model, "reference_read", None)
-        if reference_read is not None and not is_tvac:
-            output_model.data += reference_read
-            del output_model.reference_read
-        reference_amp33 = getattr(input_model, "reference_amp33", None)
-        if reference_amp33 is not None and not is_tvac:
-            output_model.amp33 += reference_amp33
-            del output_model.reference_amp33
-
-        # If a data encoding offset was added to the data, remove it
-        data_encoding_offset = getattr(
-            input_model.meta.instrument, "data_encoding_offset", 0
-        )
-        output_model.data -= data_encoding_offset
-
-        # Test for reference file
+        reference_file_name = self.get_reference_file(input_model, "mask")
         if reference_file_name != "N/A" and reference_file_name is not None:
             # If there are mask files, perform dq step
             # Open the relevant reference files as datamodels
             reference_file_model = rdm.open(reference_file_name)
             log.debug(f"Using MASK ref file: {reference_file_name}")
-
-            # Apply the DQ step, in place
-            dq_initialization.do_dqinit(
-                output_model,
-                reference_file_model,
-            )
-
-            # copy original border reference file arrays (data and dq)
-            # to their own attributes. they will also remain attached to
-            # the science data until they are trimmed at ramp_fit
-            # these arrays include the overlap regions in the corners
-
-            output_model.border_ref_pix_right = output_model.data[:, :, -4:].copy()
-            output_model.border_ref_pix_left = output_model.data[:, :, :4].copy()
-            output_model.border_ref_pix_top = output_model.data[:, :4, :].copy()
-            output_model.border_ref_pix_bottom = output_model.data[:, -4:, :].copy()
-
-            output_model.dq_border_ref_pix_right = output_model.pixeldq[:, -4:].copy()
-            output_model.dq_border_ref_pix_left = output_model.pixeldq[:, :4].copy()
-            output_model.dq_border_ref_pix_top = output_model.pixeldq[:4, :].copy()
-            output_model.dq_border_ref_pix_bottom = output_model.pixeldq[-4:, :].copy()
-
         else:
-            # Skip DQ step if no mask files
             reference_file_model = None
-            log.warning("No MASK reference file found.")
-            log.warning("DQ initialization step will be skipped.")
 
-            output_model.meta.cal_step.dq_init = "SKIPPED"
+        output_model = do_dqinit(input_model, mask=reference_file_model)
 
         # Close the input and reference files
         input_model.close()

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -22,15 +22,20 @@ class DQInitStep(RomanStep):
     """Initialize the Data Quality extension from the
     mask reference file.
 
-    The dq_init step initializes the pixeldq attribute of the
-    input datamodel using the MASK reference file.  For some
-    Guiding and Image model types, initalize the dq attribute of
-    the input model instead.  The dq attribute of the MASK model
-    is bitwise OR'd with the pixeldq (or dq) attribute of the
-    input model.
+    The dq_init step initializes the pixeldq attribute of the input
+    datamodel using the MASK reference file.  The dq attribute of the
+    MASK model is bitwise OR'd with the pixeldq attribute of the input
+    model.
+
+    Also adjust data for data_encoding_offset and reference_read offsets,
+    and mark guide-window affected pixels' masks.
     """
 
     class_alias = "dq_init"
+
+    spec = """
+        expand_gw_flagging = integer(default=0)  # expand guide window flagging this many pixels around guide window
+    """
 
     reference_file_types: ClassVar = ["mask"]
 
@@ -60,7 +65,8 @@ class DQInitStep(RomanStep):
         else:
             reference_file_model = None
 
-        output_model = do_dqinit(input_model, mask=reference_file_model)
+        output_model = do_dqinit(input_model, mask=reference_file_model,
+                                 expand_gw_flagging=self.expand_gw_flagging)
 
         # Close the input and reference files
         input_model.close()

--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -65,8 +65,11 @@ class DQInitStep(RomanStep):
         else:
             reference_file_model = None
 
-        output_model = do_dqinit(input_model, mask=reference_file_model,
-                                 expand_gw_flagging=self.expand_gw_flagging)
+        output_model = do_dqinit(
+            input_model,
+            mask=reference_file_model,
+            expand_gw_flagging=self.expand_gw_flagging,
+        )
 
         # Close the input and reference files
         input_model.close()

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -6,17 +6,8 @@ from roman_datamodels.dqflags import pixel
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-# Guide star mode exposure types
-GUIDER_LIST = [
-    "WFI_WIM_ACQ",
-    "WFI_WIM_TRACK",
-    "WFI_WSM_ACQ1",
-    "WFI_WSM_ACQ2",
-    "WFI_WSM_TRACK",
-]
 
-
-def do_dqinit(model, mask):
+def do_dqinit(model, mask, expand_gw_flagging=0):
     """Convert model to a RampModel and update DQ flags.
 
     Parameters
@@ -26,6 +17,9 @@ def do_dqinit(model, mask):
 
     mask : MaskRefModel
         reference mask model to use to update model DQ
+
+    expand_gw_flagging : int
+        expand GW-flagged region by this many pixels
 
     Returns
     -------
@@ -46,15 +40,24 @@ def do_dqinit(model, mask):
     x_stop = int(output_model.meta.guide_star.window_xstop)
     y_start = int(output_model.meta.guide_star.window_ystart)
     y_stop = int(output_model.meta.guide_star.window_ystop)
-    # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
 
     npix = output_model.pixeldq.shape[0]
     if x_start >= 0 and x_start < npix and y_start >= 0 and y_start < npix:
+        # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
         output_model.pixeldq[:, x_start:x_stop] = pixel.GW_AFFECTED_DATA
         log.info(
             f"Flagging rows from: {x_start} to {x_stop} as affected by guide window read"
         )
-        output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= pixel.DO_NOT_USE
+
+        # expand guide window if requested
+        if expand_gw_flagging > 0:
+            x_start = np.clip(x_start - expand_gw_flagging, 0, npix)
+            x_stop = np.clip(x_stop + expand_gw_flagging, 0, npix)
+            y_start = np.clip(x_start - expand_gw_flagging, 0, npix)
+            y_stop = np.clip(x_stop + expand_gw_flagging, 0, npix)
+
+        output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= (
+            pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA)
     else:
         log.info(
             f'Invalid guide window location: {x_start}, {x_stop}, {y_start}, {y_stop}')
@@ -79,16 +82,12 @@ def do_dqinit(model, mask):
     )
     output_model.data -= data_encoding_offset
 
-    dqfield = 'pixeldq' if model.meta.exposure.type not in GUIDER_LIST else 'dq'
-
-    outmodeldq = getattr(output_model, dqfield)
-
-    if mask is not None and outmodeldq.shape == mask.dq.shape:
-        outmodeldq |= mask.dq
+    if mask is not None and output_model.pixeldq.shape == mask.dq.shape:
+        output_model.pixeldq |= mask.dq
         output_model.meta.cal_step.dq_init = "COMPLETE"
     else:
         log.warning("Mask data array is not the same shape as the science data")
-        log.warning("Mask is not updated and stel is marked skipped")
+        log.warning("Mask is not updated and step is marked skipped")
         output_model.meta.cal_step.dq_init = "SKIPPED"
 
     output_model.border_ref_pix_right = output_model.data[:, :, -4:].copy()

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,5 +1,8 @@
 import logging
 
+from roman_datamodels.datamodels import FpsModel, RampModel, ScienceRawModel, TvacModel
+from roman_datamodels.dqflags import pixel
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -13,74 +16,89 @@ GUIDER_LIST = [
 ]
 
 
-def do_dqinit(input_model, mask=None):
-    """Check that the input model pixeldq attribute has the same dimensions as
-    the image plane of the input model science data, call apply_dqinit, and update
-    log and cal_step.  Changes input model in place.
+def do_dqinit(model, mask):
+    """Convert model to a RampModel and update DQ flags.
 
     Parameters
     ----------
-    input_model : input Roman datamodel
-        The Roman datamodel to be data quality  corrected
+    model : Roman data model, ScienceRawModel, FpsModel
+        model for which to update DQ
 
-    mask_model : Roman data model, or None
-        The mask model to use in the data quality correction
+    mask : MaskRefModel
+        reference mask model to use to update model DQ
 
     Returns
     -------
-    output_model : Roman datamodel
-        The data quality corrected Roman datamodel
+    RampModel constructed from model, with updated DQ flags.
     """
+    is_tvac = isinstance(model, (FpsModel | TvacModel))
+    try:
+        # note that this succeeds even for ScienceRawModels
+        output_model = ScienceRawModel.from_tvac_raw(model)
+    except ValueError:
+        output_model = model
 
-    # Change model in place
-    output_model = input_model
+    # Convert to RampModel
+    output_model = RampModel.from_science_raw(output_model)
 
-    # Determine if mask is shapewise compatable with the input
-    skip_step = False
-    if input_model.meta.exposure.type in GUIDER_LIST:
-        # Check to see if the shape of the mask data array
-        # is not equal to the shape of the science data
-        if input_model.dq.shape != mask.dq.shape:
-            skip_step = True
+    # guide window range information
+    x_start = int(output_model.meta.guide_star.window_xstart)
+    x_stop = int(output_model.meta.guide_star.window_xstop)
+    y_start = int(output_model.meta.guide_star.window_ystart)
+    y_stop = int(output_model.meta.guide_star.window_ystop)
+    # set pixeldq array to GW_AFFECTED_DATA (2**4) for the given range
+
+    npix = output_model.pixeldq.shape[0]
+    if x_start >= 0 and x_start < npix and y_start >= 0 and y_start < npix:
+        output_model.pixeldq[:, x_start:x_stop] = pixel.GW_AFFECTED_DATA
+        log.info(
+            f"Flagging rows from: {x_start} to {x_stop} as affected by guide window read"
+        )
+        output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= pixel.DO_NOT_USE
     else:
-        # Check to see if the shape of the mask data array
-        # is not equal to the shape of the science data
-        if input_model.pixeldq.shape != mask.dq.shape:
-            skip_step = True
+        log.info(
+            f'Invalid guide window location: {x_start}, {x_stop}, {y_start}, {y_stop}')
 
-    # Apply or skip dq correction
-    if skip_step:
-        log.warning("Mask data array is not the same shape as the science data")
-        log.warning("Step will be skipped")
-        output_model.meta.cal_step.dq_init = "SKIPPED"
-    else:
-        output_model = apply_dqinit(input_model, mask)
+
+    # the reference read has been subtracted from the science data
+    # in the L1 files.  Add it back into the data.
+    # the TVAC files are special and there the reference read was
+    # already added back in
+    reference_read = getattr(model, "reference_read", None)
+    if reference_read is not None and not is_tvac:
+        output_model.data += reference_read
+        del output_model.reference_read
+    reference_amp33 = getattr(model, "reference_amp33", None)
+    if reference_amp33 is not None and not is_tvac:
+        output_model.amp33 += reference_amp33
+        del output_model.reference_amp33
+
+    # If a data encoding offset was added to the data, remove it
+    data_encoding_offset = getattr(
+        model.meta.instrument, "data_encoding_offset", 0
+    )
+    output_model.data -= data_encoding_offset
+
+    dqfield = 'pixeldq' if model.meta.exposure.type not in GUIDER_LIST else 'dq'
+
+    outmodeldq = getattr(output_model, dqfield)
+
+    if mask is not None and outmodeldq.shape == mask.dq.shape:
+        outmodeldq |= mask.dq
         output_model.meta.cal_step.dq_init = "COMPLETE"
+    else:
+        log.warning("Mask data array is not the same shape as the science data")
+        log.warning("Mask is not updated and stel is marked skipped")
+        output_model.meta.cal_step.dq_init = "SKIPPED"
+
+    output_model.border_ref_pix_right = output_model.data[:, :, -4:].copy()
+    output_model.border_ref_pix_left = output_model.data[:, :, :4].copy()
+    output_model.border_ref_pix_top = output_model.data[:, :4, :].copy()
+    output_model.border_ref_pix_bottom = output_model.data[:, -4:, :].copy()
+
+    output_model.dq_border_ref_pix_right = output_model.pixeldq[:, -4:].copy()
+    output_model.dq_border_ref_pix_left = output_model.pixeldq[:, :4].copy()
+    output_model.dq_border_ref_pix_top = output_model.pixeldq[:4, :].copy()
+    output_model.dq_border_ref_pix_bottom = output_model.pixeldq[-4:, :].copy()
 
     return output_model
-
-
-def apply_dqinit(science, mask):
-    """Apply data quality mask to the dq or pixeldq arrays.
-
-    Extended summary
-    ----------------
-    The dq attribute of the MASK model is bitwise OR'd with the
-    pixeldq (or dq) attribute of the input model.
-
-    Parameters
-    ----------
-    science : Roman data model
-        input science data model
-
-    mask : Roman data model
-        data quality mask data model
-    """
-
-    # Set model-specific data quality in output
-    if science.meta.exposure.type in GUIDER_LIST:
-        science.dq |= mask.dq
-    else:
-        science.pixeldq |= mask.dq
-
-    return science

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 
 from roman_datamodels.datamodels import FpsModel, RampModel, ScienceRawModel, TvacModel
 from roman_datamodels.dqflags import pixel
@@ -15,7 +16,7 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
     model : Roman data model, ScienceRawModel, FpsModel
         model for which to update DQ
 
-    mask : MaskRefModel
+    mask : MaskRefModel or None
         reference mask model to use to update model DQ
 
     expand_gw_flagging : int
@@ -53,8 +54,8 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
         if expand_gw_flagging > 0:
             x_start = np.clip(x_start - expand_gw_flagging, 0, npix)
             x_stop = np.clip(x_stop + expand_gw_flagging, 0, npix)
-            y_start = np.clip(x_start - expand_gw_flagging, 0, npix)
-            y_stop = np.clip(x_stop + expand_gw_flagging, 0, npix)
+            y_start = np.clip(y_start - expand_gw_flagging, 0, npix)
+            y_stop = np.clip(y_stop + expand_gw_flagging, 0, npix)
 
         output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= (
             pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA)
@@ -86,7 +87,7 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
         output_model.pixeldq |= mask.dq
         output_model.meta.cal_step.dq_init = "COMPLETE"
     else:
-        log.warning("Mask data array is not the same shape as the science data")
+        log.warning("Mask data array is None or not the same shape as the science data")
         log.warning("Mask is not updated and step is marked skipped")
         output_model.meta.cal_step.dq_init = "SKIPPED"
 

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,6 +1,6 @@
 import logging
-import numpy as np
 
+import numpy as np
 from roman_datamodels.datamodels import FpsModel, RampModel, ScienceRawModel, TvacModel
 from roman_datamodels.dqflags import pixel
 
@@ -58,11 +58,12 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
             y_stop = np.clip(y_stop + expand_gw_flagging, 0, npix)
 
         output_model.pixeldq[y_start:y_stop, x_start:x_stop] |= (
-            pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA)
+            pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA
+        )
     else:
         log.info(
-            f'Invalid guide window location: {x_start}, {x_stop}, {y_start}, {y_stop}')
-
+            f"Invalid guide window location: {x_start}, {x_stop}, {y_start}, {y_stop}"
+        )
 
     # the reference read has been subtracted from the science data
     # in the L1 files.  Add it back into the data.
@@ -78,9 +79,7 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
         del output_model.reference_amp33
 
     # If a data encoding offset was added to the data, remove it
-    data_encoding_offset = getattr(
-        model.meta.instrument, "data_encoding_offset", 0
-    )
+    data_encoding_offset = getattr(model.meta.instrument, "data_encoding_offset", 0)
     output_model.data -= data_encoding_offset
 
     if mask is not None and output_model.pixeldq.shape == mask.dq.shape:

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -331,3 +331,38 @@ def test_dqinit_sub_data_encoding_offset():
     result2 = DQInitStep.call(wfi_sci_raw_model.copy())
 
     assert np.allclose(result.data - result2.data, offset)
+
+
+def test_dqinit_gw_expansion():
+    """Test that expand_gw_flagging extends the DO_NOT_USE zone around the guide window."""
+    shape = (2, 100, 100)
+    x_start, x_stop = 30, 40
+    y_start, y_stop = 50, 60
+    expand = 5
+
+    model = rawim(shape, "WFI", "WFI_IMAGE")
+    model.meta["guide_star"]["window_xstart"] = x_start
+    model.meta["guide_star"]["window_xstop"] = x_stop
+    model.meta["guide_star"]["window_ystart"] = y_start
+    model.meta["guide_star"]["window_ystop"] = y_stop
+
+    result = do_dqinit(model, mask=None, expand_gw_flagging=expand)
+    pq = result.pixeldq
+
+    # All rows in the GW column range should be flagged GW_AFFECTED_DATA
+    assert np.all(pq[:, x_start:x_stop] & pixel.GW_AFFECTED_DATA != 0)
+    assert pq[0, x_start - 1] & pixel.GW_AFFECTED_DATA == 0
+
+    # Expanded rectangle should have both DO_NOT_USE and GW_AFFECTED_DATA set
+    combined = pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA
+    assert np.all(
+        pq[y_start - expand:y_stop + expand, x_start - expand:x_stop + expand]
+        & combined
+        == combined
+    )
+
+    # Pixels just outside the expanded rectangle should not have DO_NOT_USE
+    assert pq[y_start - expand - 1, x_start] & pixel.DO_NOT_USE == 0
+    assert pq[y_stop + expand, x_start] & pixel.DO_NOT_USE == 0
+    assert pq[y_start, x_start - expand - 1] & pixel.DO_NOT_USE == 0
+    assert pq[y_start, x_stop + expand] & pixel.DO_NOT_USE == 0

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -356,7 +356,7 @@ def test_dqinit_gw_expansion():
     # Expanded rectangle should have both DO_NOT_USE and GW_AFFECTED_DATA set
     combined = pixel.DO_NOT_USE | pixel.GW_AFFECTED_DATA
     assert np.all(
-        pq[y_start - expand:y_stop + expand, x_start - expand:x_stop + expand]
+        pq[y_start - expand : y_stop + expand, x_start - expand : x_stop + expand]
         & combined
         == combined
     )

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -310,11 +310,11 @@ def test_dqinit_add_reference_read():
     shape = (2, 20, 20)
 
     wfi_sci_raw_model = rawim(shape, "WFI", "WFI_IMAGE")
-    result = DQInitStep.call(wfi_sci_raw_model)
+    result = DQInitStep.call(wfi_sci_raw_model.copy())
 
     wfi_sci_raw_model.reference_read = wfi_sci_raw_model.data[0] * 0 + offset
     wfi_sci_raw_model.reference_amp33 = wfi_sci_raw_model.amp33[0] * 0 + offset
-    result2 = DQInitStep.call(wfi_sci_raw_model)
+    result2 = DQInitStep.call(wfi_sci_raw_model.copy())
 
     assert np.allclose(result2.data - result.data, offset)
     assert np.allclose(result2.amp33 - result.amp33, offset)
@@ -325,9 +325,9 @@ def test_dqinit_sub_data_encoding_offset():
     shape = (2, 20, 20)
 
     wfi_sci_raw_model = rawim(shape, "WFI", "WFI_IMAGE")
-    result = DQInitStep.call(wfi_sci_raw_model)
+    result = DQInitStep.call(wfi_sci_raw_model.copy())
 
     wfi_sci_raw_model.meta.instrument.data_encoding_offset = offset
-    result2 = DQInitStep.call(wfi_sci_raw_model)
+    result2 = DQInitStep.call(wfi_sci_raw_model.copy())
 
     assert np.allclose(result.data - result2.data, offset)

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -84,16 +84,16 @@ class ExposurePipeline(RomanPipeline):
         log.info("Starting Roman exposure calibration pipeline ...")
 
         # determine the input type
+        # Because we're processing raw files, let's open without any
+        # laziness; we need to propagate all of the bits into the ramps
+        # anyway.  It also avoids bugs like:
+        # https://github.com/spacetelescope/roman_datamodels/issues/631
         lib, input_type = open_dataset(
             dataset,
             update_version=self.update_version,
             return_type=True,
             as_library=True,
             open_kwargs={"on_disk": self.on_disk, "lazy_load": False},
-            # Because we're processing raw files, let's open without any
-            # laziness; we need to propagate all of the bits into the ramps
-            # anyway.  It also avoids bugs like:
-            # https://github.com/spacetelescope/roman_datamodels/issues/631
         )
         return_lib = input_type in ("ModelLibrary", "asn")
 

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -89,7 +89,11 @@ class ExposurePipeline(RomanPipeline):
             update_version=self.update_version,
             return_type=True,
             as_library=True,
-            open_kwargs={"on_disk": self.on_disk},
+            open_kwargs={"on_disk": self.on_disk, "lazy_load": False},
+            # Because we're processing raw files, let's open without any
+            # laziness; we need to propagate all of the bits into the ramps
+            # anyway.  It also avoids bugs like:
+            # https://github.com/spacetelescope/roman_datamodels/issues/631
         )
         return_lib = input_type in ("ModelLibrary", "asn")
 


### PR DESCRIPTION
This PR simplifies the dq_init step.  The primary goal is to separate the step & reference handling logic from the more algorithmic logic; the former stays in the stpipe step infrastructure and the latter moves to dq_initialization.py.  This allows other callers (specifically, the HLIS PIT) to use this step without using the full stpipe infrastructure.

While making these changes, I also did the following:
- removed support for guider type exposures.  I do not believe these can ever go through romancal.  @tddesjardins confirmed this.  @ddavis-stsci , do you remember the history here?  I'm not sure what romancal could usefully do for these exposures.  The old code largely skipped dq_init for them, but I feel like every other step should likewise be skipped for them.
- added a feature to expand the guide-window masks by one pixel.  The HLIS PIT supports this so I didn't want to drop this mode; it's possible we'll want it as well.  Default off.
- added a test for the new guide-window expansion feature
- clipped the x_start / x_stop / y_start / y_stop pixels to no longer mask way off the image for -999999 starts / stops.
- added lazy_load = False to the initial file opening in the pipeline.  This is because (1) we need to access everything in this file anyway in dq_init, so lazy loading provides no benefit, and (2) because of the way this step interacts with TVAC files, not lazy loading leads to errors for TVAC files.  See https://github.com/spacetelescope/roman_datamodels/issues/631#issuecomment-3969512538 for more details.

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job (https://github.com/spacetelescope/RegressionTests/actions/runs/25011793884/job/73249179511)