### PR TITLE
Fix dq_init model handling to allow re-enabling lazy_load for elp

### DIFF
--- a/romancal/dq_init/dq_init_step.py
+++ b/romancal/dq_init/dq_init_step.py
@@ -72,8 +72,6 @@ class DQInitStep(RomanStep):
         )
 
         # Close the input and reference files
-        input_model.close()
-
         try:
             reference_file_model.close()
         except AttributeError:

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -8,6 +8,48 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
+def to_ramp_model(model):
+    if isinstance(model, RampModel):
+        return model
+
+    if isinstance(model, (FpsModel | TvacModel)):
+        science_raw = ScienceRawModel.create_fake_data(model)
+        if "statistics" in science_raw.meta:
+            science_raw["extras"] = {"tvac": science_raw.meta.pop("statistics")}
+        return to_ramp_model(science_raw)
+
+    ramp_model = RampModel.create_from_model(
+        {
+            **model,
+            "data": None,
+        }
+    )
+
+    ramp_model.meta.cal_step = {}
+    for step_name in ramp_model.schema_info("required")["roman"]["meta"]["cal_step"][
+        "required"
+    ].info:
+        ramp_model.meta.cal_step[step_name] = model.meta.get("cal_step", {}).get(
+            step_name, "INCOMPLETE"
+        )
+
+    shape = model.data.shape
+    ramp_model.data = model.data.astype(np.float32)
+    ramp_model.pixeldq = np.zeros(shape[1:], dtype=np.uint32)
+
+    # check if the input model has a resultantdq from SDF
+    if hasattr(ramp_model, "resultantdq"):
+        ramp_model.groupdq = ramp_model.pop("resultantdq")
+    else:
+        ramp_model.groupdq = np.zeros(shape, dtype=np.uint8)
+
+    # check for exposure data_problem
+    if isinstance(data_problem := ramp_model.meta.exposure.data_problem, bool):
+        ramp_model.meta.exposure.data_problem = "True" if data_problem else None
+
+    return ramp_model
+
+
 def do_dqinit(model, mask, expand_gw_flagging=0):
     """Convert model to a RampModel and update DQ flags.
 
@@ -27,14 +69,9 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
     RampModel constructed from model, with updated DQ flags.
     """
     is_tvac = isinstance(model, (FpsModel | TvacModel))
-    try:
-        # note that this succeeds even for ScienceRawModels
-        output_model = ScienceRawModel.from_tvac_raw(model)
-    except ValueError:
-        output_model = model
 
     # Convert to RampModel
-    output_model = RampModel.from_science_raw(output_model)
+    output_model = to_ramp_model(model)
 
     # guide window range information
     x_start = int(output_model.meta.guide_star.window_xstart)
@@ -69,11 +106,11 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
     # in the L1 files.  Add it back into the data.
     # the TVAC files are special and there the reference read was
     # already added back in
-    reference_read = getattr(model, "reference_read", None)
+    reference_read = getattr(output_model, "reference_read", None)
     if reference_read is not None and not is_tvac:
         output_model.data += reference_read
         del output_model.reference_read
-    reference_amp33 = getattr(model, "reference_amp33", None)
+    reference_amp33 = getattr(output_model, "reference_amp33", None)
     if reference_amp33 is not None and not is_tvac:
         output_model.amp33 += reference_amp33
         del output_model.reference_amp33

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+from astropy.time import Time
 from roman_datamodels.datamodels import FpsModel, RampModel, ScienceRawModel, TvacModel
 from roman_datamodels.dqflags import pixel
 
@@ -16,6 +17,7 @@ def to_ramp_model(model):
         science_raw = ScienceRawModel.create_fake_data(model)
         if "statistics" in science_raw.meta:
             science_raw["extras"] = {"tvac": science_raw.meta.pop("statistics")}
+        science_raw.meta.file_date = Time(science_raw.meta.file_date)
         return to_ramp_model(science_raw)
 
     ramp_model = RampModel.create_from_model(

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -1,3 +1,5 @@
+import copy
+import functools
 import logging
 
 import numpy as np
@@ -14,10 +16,32 @@ def to_ramp_model(model):
         return model
 
     if isinstance(model, (FpsModel | TvacModel)):
-        science_raw = ScienceRawModel.create_fake_data(model)
+        science_raw = ScienceRawModel.create_fake_data(
+            {
+                **model,
+                "data": model.data.value,
+                "amp33": model.amp33.value,
+            }
+        )
+
+        science_raw.meta.exposure.read_pattern = copy.deepcopy(
+            model.meta.exposure.read_pattern
+        )
+
+        # drop old tagged scalars
         if "statistics" in science_raw.meta:
-            science_raw["extras"] = {"tvac": science_raw.meta.pop("statistics")}
+            science_raw["extras"] = {
+                "tvac": {"meta": {"statistics": science_raw.meta.pop("statistics")}}
+            }
+
         science_raw.meta.file_date = Time(science_raw.meta.file_date)
+        for key, value in science_raw.items():
+            if hasattr(value, "_tag") and isinstance(value, str):
+                new_value = str(value)
+            else:
+                continue
+            *branches, leaf = key.split(".")
+            functools.reduce(getattr, branches, science_raw)[leaf] = new_value
         return to_ramp_model(science_raw)
 
     ramp_model = RampModel.create_from_model(

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -24,16 +24,18 @@ def to_ramp_model(model):
             }
         )
 
+        # work-around issue with roman_datamodels not copying the nested read_pattern
         science_raw.meta.exposure.read_pattern = copy.deepcopy(
             model.meta.exposure.read_pattern
         )
 
-        # drop old tagged scalars
+        # move statistics to avoid conflicts with meta.statistics
         if "statistics" in science_raw.meta:
             science_raw["extras"] = {
                 "tvac": {"meta": {"statistics": science_raw.meta.pop("statistics")}}
             }
 
+        # drop old tagged scalars
         science_raw.meta.file_date = Time(science_raw.meta.file_date)
         for key, value in science_raw.items():
             if hasattr(value, "_tag") and isinstance(value, str):

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -93,7 +93,7 @@ class ExposurePipeline(RomanPipeline):
             update_version=self.update_version,
             return_type=True,
             as_library=True,
-            open_kwargs={"on_disk": self.on_disk, "lazy_load": False},
+            open_kwargs={"on_disk": self.on_disk},
         )
         return_lib = input_type in ("ModelLibrary", "asn")
 
@@ -105,7 +105,10 @@ class ExposurePipeline(RomanPipeline):
                 self.dq_init.suffix = "dq_init"
                 result = self.dq_init.run(model)
 
-                del model
+                if model is not result:
+                    # dq_init converted this to a new model type so close the input
+                    model.close()
+                    del model
 
                 result = self.saturation.run(result)
 

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -9,6 +9,7 @@ import pytest
 from roman_datamodels.datamodels import RampModel, SaturationRefModel, ScienceRawModel
 from roman_datamodels.dqflags import group, pixel
 
+from romancal.dq_init.dq_initialization import to_ramp_model
 from romancal.saturation import SaturationStep
 from romancal.saturation.saturation import flag_saturation
 
@@ -327,7 +328,7 @@ def test_saturation_getbestref(setup_wfi_datamodels):
     wfi_sci_raw_model.meta["guide_star"]["window_xsize"] = 16
     wfi_sci_raw_model.meta.exposure.type = "WFI_IMAGE"
     wfi_sci_raw_model.data = np.ones(shape, dtype=np.uint16)
-    input_model = RampModel.from_science_raw(wfi_sci_raw_model)
+    input_model = to_ramp_model(wfi_sci_raw_model)
 
     # Run the pipeline
     result = SaturationStep.call(input_model, override_saturation="N/A")

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -6,10 +6,9 @@ Unit tests for saturation flagging
 
 import numpy as np
 import pytest
-from roman_datamodels.datamodels import RampModel, SaturationRefModel, ScienceRawModel
+from roman_datamodels.datamodels import RampModel, SaturationRefModel
 from roman_datamodels.dqflags import group, pixel
 
-from romancal.dq_init.dq_initialization import to_ramp_model
 from romancal.saturation import SaturationStep
 from romancal.saturation.saturation import flag_saturation
 
@@ -320,15 +319,13 @@ def test_saturation_getbestref(setup_wfi_datamodels):
     shape = (2, 20, 20)
 
     # Create test science raw model
-    wfi_sci_raw_model = ScienceRawModel.create_fake_data(shape=shape)
-    wfi_sci_raw_model.meta.instrument.name = "WFI"
-    wfi_sci_raw_model.meta.instrument.detector = "WFI01"
-    wfi_sci_raw_model.meta.instrument.optical_element = "F158"
-    wfi_sci_raw_model.meta["guide_star"]["window_xstart"] = 1012
-    wfi_sci_raw_model.meta["guide_star"]["window_xsize"] = 16
-    wfi_sci_raw_model.meta.exposure.type = "WFI_IMAGE"
-    wfi_sci_raw_model.data = np.ones(shape, dtype=np.uint16)
-    input_model = to_ramp_model(wfi_sci_raw_model)
+    input_model = RampModel.create_fake_data(shape=shape)
+    input_model.meta.instrument.name = "WFI"
+    input_model.meta.instrument.detector = "WFI01"
+    input_model.meta.instrument.optical_element = "F158"
+    input_model.meta["guide_star"]["window_xstart"] = 1012
+    input_model.meta["guide_star"]["window_xsize"] = 16
+    input_model.meta.exposure.type = "WFI_IMAGE"
 
     # Run the pipeline
     result = SaturationStep.call(input_model, override_saturation="N/A")


### PR DESCRIPTION
Follow up to https://github.com/spacetelescope/romancal/pull/2282

This PR:
- fixes the dq_init model handling to not close the provided input file (which may not always be appropriate)
- adds a model closing to elp (when dq_init returns a different model)
- drops use of `from_tvac_fps` and `from_science_raw` replacing these with a new method `to_ramp_model` which largely uses `create_fake_data` (for tvac/fps files) and `create_from_model` (for science raw). More on this below.
- re-enables lazy_load for elp

Regtests show unrelated failures and some differences:
https://github.com/spacetelescope/RegressionTests/actions/runs/25078786707
The differences are:
- the elp no longer produces a file with the tagged scalar TvacPrdSoftwareVersion and instead uses the correct str
- the elp no longer produces cal_step metadata with the non-existent source_detection and jump steps
(Note I will need to make a clean run for okifying as the above is a rerun).

Also memory usage of elp is improved by 1.4x (1379 MB vs 1935 MB).

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
