### PR TITLE
Fix the tests for the RDM removal of LNode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ dependencies = [
     # the roman_datamodels pin to the released version. If there
     # is a need to change this to main then we need a new
     # roman_datamodels release.
-    "roman_datamodels>=0.31.0, <0.32",
-    "romanisim>=0.13.1,<0.14",
+    # "roman_datamodels>=0.31.0, <0.32",
+    "roman_datamodels @ git+https://github.com/WilliamJamieson/roman_datamodels.git@refactor/remove_LNode",
+    # "romanisim>=0.13.1,<0.14",
+    "romanisim @ git+https://github.com/WilliamJamieson/romanisim.git@bugfix/lnode_remove",
     "asdf>=4.1.0,<6",
     "crds>=13.0.2",
     "drizzle>=2.2.0,<2.3.0",

--- a/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
@@ -53,7 +53,12 @@ def test_bad_readpattern():
     ramp_model, gain_model, readnoise_model, dark_model = make_data(
         SIMPLE_RESULTANTS, 1, 0.01, False
     )
-    bad_pattern = ramp_model.meta.exposure.read_pattern.data[1:]
+    # With LNode gone this is just a list now, this check is just
+    #   for backwards compatibility with the old code that expected a string.
+    if isinstance(ramp_model.meta.exposure.read_pattern, list):
+        bad_pattern = ramp_model.meta.exposure.read_pattern[1:]
+    else:
+        bad_pattern = ramp_model.meta.exposure.read_pattern.data[1:]
     ramp_model.meta.exposure.read_pattern = bad_pattern
 
     with pytest.raises(RuntimeError):

--- a/romancal/ramp_fitting/tests/test_ramp_fit_likelihood.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_likelihood.py
@@ -66,7 +66,12 @@ def test_bad_readpattern():
     ramp_model, gain_model, readnoise_model, dark_model = make_data(
         SIMPLE_RESULTANTS, 1, 0.01, False
     )
-    bad_pattern = ramp_model.meta.exposure.read_pattern.data[1:]
+    # With LNode gone this is just a list now, this check is just
+    #   for backwards compatibility with the old code that expected a string.
+    if isinstance(ramp_model.meta.exposure.read_pattern, list):
+        bad_pattern = ramp_model.meta.exposure.read_pattern[1:]
+    else:
+        bad_pattern = ramp_model.meta.exposure.read_pattern.data[1:]
     ramp_model.meta.exposure.read_pattern = bad_pattern
 
     with pytest.raises(ValueError):

--- a/romancal/source_catalog/injection.py
+++ b/romancal/source_catalog/injection.py
@@ -105,7 +105,8 @@ def make_cosmoslike_catalog(cen, ra, dec, exptimes, filters=None, seed=None, **k
     all_cat : astropy.Table
         Table for use with table_to_catalog to generate catalog for simulation.
     """
-    from romanisim import bandpass, catalog
+    from romanisim import catalog
+    from romanisim.models import bandpass
 
     # WFI bandpasses
     if filters is None:

--- a/romancal/source_catalog/tests/test_injection.py
+++ b/romancal/source_catalog/tests/test_injection.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from roman_datamodels.datamodels import ImageModel, MosaicModel
-from romanisim import bandpass, parameters
+from romanisim.models import parameters, bandpass
 
 from romancal.skycell.tests.test_skycell_match import mk_gwcs
 from romancal.source_catalog import injection

--- a/romancal/source_catalog/tests/test_injection.py
+++ b/romancal/source_catalog/tests/test_injection.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from roman_datamodels.datamodels import ImageModel, MosaicModel
-from romanisim.models import parameters, bandpass
+from romanisim.models import bandpass, parameters
 
 from romancal.skycell.tests.test_skycell_match import mk_gwcs
 from romancal.source_catalog import injection


### PR DESCRIPTION
In PR spacetelescope/roman_datamodels#658, the `LNode` is being removed. This means that in the two instances here in the RCAL tests instead of accessing the pure list inside `LNode.data` one will just have a pure list at this point in the node.

This PR creates a RDM version backward compatible fix for this change for the RCAL tests.

Note a similar change is needed for romanisim, see spacetelescope/romanisim#358.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
