### PR TITLE
RCAL-1393: remove the false mnemonics SCF_AC_FGS_TBL_Qb*

### DIFF
--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -104,18 +104,17 @@ TYPES_TO_UPDATE = set()
 # Mnemonics needed.
 COARSE_MNEMONICS_QUATERNION_ECI = [f"SCF_AC_SDR_QBJ_{idx + 1}" for idx in range(4)]
 COARSE_MNEMONICS_B2FGS_EST = [f"SCF_AC_EST_FGS_QBR_{idx + 1}" for idx in range(4)]
-COARSE_MNEMONICS_B2FGS_PRELOAD = [f"SCF_AC_FGS_TBL_Qb{idx + 1}" for idx in range(4)]
 COARSE_MNEMONICS = (
     COARSE_MNEMONICS_QUATERNION_ECI
     + COARSE_MNEMONICS_B2FGS_EST
-    + COARSE_MNEMONICS_B2FGS_PRELOAD
 )
 
 # Default and pre-defined matricies.
 # Conversion of the FGS Unified Frame (FGS) reference point from the V-Frame.
 # This is the pre-launch value, later to be refined and provided
-# in the SIAF
-FGS_DEFAULT_QUATERNION = np.array([-0.18597289, 0.68379795, -0.18006017, 0.68221269])
+# in the SIAF.
+# Last update: 20260505 by T.Sohn
+FGS_DEFAULT_QUATERNION = np.array([-0.18596734175399293, 0.6837984564491885, -0.1800546332580956, 0.6822141509826322])
 
 # Maximum absolute speed of the observatory. Used for sanity check is defined
 # as the sum of the absolute components of the velocity.
@@ -1088,16 +1087,6 @@ def mnemonics_to_pointings(ordered_mnemonics):
                 "One or more of the B-to-FGS quaternion mnemonics are not in the telementry %s",
                 COARSE_MNEMONICS_B2FGS_EST,
             )
-        if fgs_q is None:
-            try:
-                fgs_q = np.array(
-                    [mnemonics_at_time[m].value for m in COARSE_MNEMONICS_B2FGS_PRELOAD]
-                )
-            except KeyError:
-                logger.warning(
-                    "One or more of the B-to-FGS quaternion mnemonics are not in the telementry %s",
-                    COARSE_MNEMONICS_B2FGS_PRELOAD,
-                )
 
         pointing = Pointing(fgs_q=fgs_q, obstime=obstime, q=q)
         pointings.append(pointing)

--- a/romancal/orientation/set_telescope_pointing.py
+++ b/romancal/orientation/set_telescope_pointing.py
@@ -104,17 +104,16 @@ TYPES_TO_UPDATE = set()
 # Mnemonics needed.
 COARSE_MNEMONICS_QUATERNION_ECI = [f"SCF_AC_SDR_QBJ_{idx + 1}" for idx in range(4)]
 COARSE_MNEMONICS_B2FGS_EST = [f"SCF_AC_EST_FGS_QBR_{idx + 1}" for idx in range(4)]
-COARSE_MNEMONICS = (
-    COARSE_MNEMONICS_QUATERNION_ECI
-    + COARSE_MNEMONICS_B2FGS_EST
-)
+COARSE_MNEMONICS = COARSE_MNEMONICS_QUATERNION_ECI + COARSE_MNEMONICS_B2FGS_EST
 
 # Default and pre-defined matricies.
 # Conversion of the FGS Unified Frame (FGS) reference point from the V-Frame.
 # This is the pre-launch value, later to be refined and provided
 # in the SIAF.
 # Last update: 20260505 by T.Sohn
-FGS_DEFAULT_QUATERNION = np.array([-0.18596734175399293, 0.6837984564491885, -0.1800546332580956, 0.6822141509826322])
+FGS_DEFAULT_QUATERNION = np.array(
+    [-0.18596734175399293, 0.6837984564491885, -0.1800546332580956, 0.6822141509826322]
+)
 
 # Maximum absolute speed of the observatory. Used for sanity check is defined
 # as the sum of the absolute components of the velocity.

--- a/romancal/orientation/tests/test_set_telescope_pointing.py
+++ b/romancal/orientation/tests/test_set_telescope_pointing.py
@@ -248,10 +248,6 @@ def test_mnemonic_list():
             "SCF_AC_EST_FGS_QBR_2",
             "SCF_AC_EST_FGS_QBR_3",
             "SCF_AC_EST_FGS_QBR_4",
-            "SCF_AC_FGS_TBL_Qb1",
-            "SCF_AC_FGS_TBL_Qb2",
-            "SCF_AC_FGS_TBL_Qb3",
-            "SCF_AC_FGS_TBL_Qb4",
         )
     )
 


### PR DESCRIPTION
Resolves [RCAL-1393](https://jira.stsci.edu/browse/RCAL-1393)

This PR removes the attempted reading of the mnemonics SCF_AC_FGS_TBL_Qb[1-4]. 

From a misunderstanding, these were thought to be actual mnemonics found in the engineering database. However, the specifications where simply just a way of specifying hard-coded parameters.

Remove the attempted reading of these false mnemonics.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
