### PR TITLE
Correct amp33 for encoding offset and update docs

### DIFF
--- a/changes/2307.dq_init.rst
+++ b/changes/2307.dq_init.rst
@@ -1,0 +1,1 @@
+Fix application of data encoding offset to also subtract from the amp33 array.

--- a/docs/roman/dq_init/description.rst
+++ b/docs/roman/dq_init/description.rst
@@ -58,7 +58,7 @@ including the reference read contribution.  Accordingly, the DQ
 initialization step also adds the reference read and the
 reference_amp33 read to the data and amp33 pixels, respectively, so
 that the ramp model always contains the total number of DN present
-in the detector. Additionally, if an encoding offset was added to the 
-pixel values onboard (used to ensure no negative pixel values after reference 
-read subtraction), then the offset value is also subtracted from the data 
+in the detector. Additionally, if an encoding offset was added to the
+pixel values onboard (used to ensure no negative pixel values after reference
+read subtraction), then the offset value is also subtracted from the data
 and amp33 arrays.

--- a/docs/roman/dq_init/description.rst
+++ b/docs/roman/dq_init/description.rst
@@ -58,4 +58,7 @@ including the reference read contribution.  Accordingly, the DQ
 initialization step also adds the reference read and the
 reference_amp33 read to the data and amp33 pixels, respectively, so
 that the ramp model always contains the total number of DN present
-in the detector.
+in the detector. Additionally, if an encoding offset was added to the 
+pixel values onboard (used to ensure no negative pixel values after reference 
+read subtraction), then the offset value is also subtracted from the data 
+and amp33 arrays.

--- a/romancal/dq_init/dq_initialization.py
+++ b/romancal/dq_init/dq_initialization.py
@@ -144,8 +144,10 @@ def do_dqinit(model, mask, expand_gw_flagging=0):
         del output_model.reference_amp33
 
     # If a data encoding offset was added to the data, remove it
+    # from the data and amp33 arrays
     data_encoding_offset = getattr(model.meta.instrument, "data_encoding_offset", 0)
     output_model.data -= data_encoding_offset
+    output_model.amp33 -= data_encoding_offset
 
     if mask is not None and output_model.pixeldq.shape == mask.dq.shape:
         output_model.pixeldq |= mask.dq


### PR DESCRIPTION
This PR corrects the amp33 array for the data encoding offset in the DQ initialization step. According to Tim, a DC offset should result in either a negligible or no change in the IRRC correction, but it is more correct to account for this in the amp33 array. Documentation on the step has also been updated to mention the encoding offset.