### PR TITLE
Update stcal upper pin in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "crds>=13.0.2",
     "drizzle>=2.2.0,<2.3.0",
     "gwcs>=1.0.1,<2",
-    "stcal>=1.18.0,<1.19",
+    "stcal>=1.18.0,<2",
     "stpipe>=0.11.0,<2",
     "spherical-geometry>=1.4.0,<1.5",
 ]


### PR DESCRIPTION
We are hoping to move to something closer  to semantic versioning with stcal.  Webb currently imposes a <2 pin.  This PR changes romancal to follow their example.
