### PR TITLE
add CRDS to get_stpipe_loggers

### DIFF
--- a/changes/2310.stpipe.rst
+++ b/changes/2310.stpipe.rst
@@ -1,0 +1,1 @@
+Add "CRDS" to list of loggers configured by pipeline runs.

--- a/romancal/stpipe/core.py
+++ b/romancal/stpipe/core.py
@@ -81,6 +81,7 @@ class RomanStep(Step):
             "stpipe",
             "tweakwcs",
             "py.warnings",  # python uses this since stipe enables captureWarnings
+            "CRDS",  # crds uses a specially named logger
         )
 
     def finalize_result(self, model, reference_files_used):


### PR DESCRIPTION
stpipe now has a viable path for logging crds log messages.

In preparation for those changes this PR adds "CRDS" to the list of stpipe-aware loggers. The name is upper-case since crds uses that particular name:
https://github.com/spacetelescope/crds/blob/8785ff0a1f5bef8a9fc629ccf19fc12d198ff4cf/crds/core/log.py#L278

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/25522417601
and with stpipe main: https://github.com/spacetelescope/RegressionTests/actions/runs/25574428798
both all pass

Testing locally with stpipe main this works as expected and the crds log messages are logged. This was tricky to test since most crds usage (for my setup with a valid crds cache) that results in log messages are errors during pre-step code where steps are missing pars files. These aren't captured yet so I had to enable debug logging in crds which produced the expected flood of log messages.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
