### PR TITLE
Remove usage of NON_SCIENCE dq bit.

### DIFF
--- a/changes/2315.general.rst
+++ b/changes/2315.general.rst
@@ -1,0 +1,1 @@
+Remove ``NON_SCIENCE`` from the default ``good_bits``/``dqbits`` parameter in the resample, skymatch, and outlier_detection steps.

--- a/docs/roman/resample/arguments.rst
+++ b/docs/roman/resample/arguments.rst
@@ -111,8 +111,7 @@ image.
     Either a single bit value or a combination of them can be provided.
     If the string starts with a tilde (`~`), then the provided bit(s)
     will be excluded when creating the resampling mask.
-    A value of ``~DO_NOT_USE+NON_SCIENCE`` will exclude pixels
-    flagged with ``DO_NOT_USE`` and ``NON_SCIENCE``.
+    A value of ``~DO_NOT_USE`` will exclude pixels flagged with ``DO_NOT_USE``.
 
     The bit value can be provided in a few different ways, but always as
     a string type. For example, if the user deems OK to use pixels with

--- a/docs/roman/skymatch/arguments.rst
+++ b/docs/roman/skymatch/arguments.rst
@@ -37,12 +37,11 @@ The ``skymatch`` step uses the following optional arguments:
   computations. Supported values are: `mean`, `mode`, `midpt`,
   and `median`.
 
-``dqbits`` (str, default='~DO_NOT_USE+NON_SCIENCE')
+``dqbits`` (str, default='~DO_NOT_USE')
   The DQ bit values from the input images' DQ arrays that
   should be considered "good" when building masks for sky computations. See
   DQ flag :ref:`dq_init_step` for details. The default value
-  rejects pixels flagged as either 'DO_NOT_USE' or 'NON_SCIENCE' and considers
-  all others to be good.
+  rejects pixels flagged as 'DO_NOT_USE' and considers all others to be good.
 
 ``lower`` (float, default=None)
   An optional value indicating the lower limit of usable pixel

--- a/romancal/outlier_detection/outlier_detection_step.py
+++ b/romancal/outlier_detection/outlier_detection_step.py
@@ -43,7 +43,7 @@ class OutlierDetectionStep(RomanStep):
         save_intermediate_results = boolean(default=False) # Specifies whether or not to write out intermediate products to disk
         resample_data = boolean(default=True) # Specifies whether or not to resample the input images when performing outlier detection
         resample_on_skycell = boolean(default=True) # if association contains skycell information use the skycell wcs for resampling
-        good_bits = string(default="~DO_NOT_USE+NON_SCIENCE")  # DQ bit value to be considered 'good'
+        good_bits = string(default="~DO_NOT_USE")  # DQ bit value to be considered 'good'
         in_memory = boolean(default=True) # Specifies whether or not to keep all intermediate products and datamodels in memory, ignored if run as part of a pipeline
         pixmap_stepsize = float(default=10)  # step size for computation of the pixel map
         pixmap_order = integer(1, 3, default=3)  # interpolating spline order (1 or 3) used when pixmap_stepsize > 1

--- a/romancal/resample/resample_step.py
+++ b/romancal/resample/resample_step.py
@@ -66,7 +66,7 @@ class ResampleStep(RomanStep):
         output_wcs = string(default='')  # Custom output WCS.
         resample_on_skycell = boolean(default=True)  # if association contains skycell information use it for the wcs
         in_memory = boolean(default=True)
-        good_bits = string(default='~DO_NOT_USE+NON_SCIENCE')  # The good bits to use for building the resampling mask.
+        good_bits = string(default='~DO_NOT_USE')  # The good bits to use for building the resampling mask.
         include_var_flat = boolean(default=False)  # include var_flat in output image
         propagate_dq = boolean(default=False)  # propagate DQ during resampling
         pixmap_stepsize = integer(default=10)  # step size for computation of the pixel map

--- a/romancal/resample/tests/test_resample_step.py
+++ b/romancal/resample/tests/test_resample_step.py
@@ -153,10 +153,8 @@ def test_wcs_wcsinfo_matches(base_image):
 @pytest.mark.parametrize(
     "good_bits",
     [
-        "~DO_NOT_USE+NON_SCIENCE",
-        "~513",
-        "~1+512",
-        "~1,512",
+        "~DO_NOT_USE",
+        "~1",
         "LOW_QE+NONLINEAR",
         "73728",
         "8192+65536",

--- a/romancal/skymatch/skymatch_step.py
+++ b/romancal/skymatch/skymatch_step.py
@@ -42,7 +42,7 @@ class SkyMatchStep(RomanStep):
 
         # Sky statistics parameters:
         skystat = option('median', 'midpt', 'mean', 'mode', default='mode') # sky statistics
-        dqbits = string(default='~DO_NOT_USE+NON_SCIENCE') # "good" DQ bits
+        dqbits = string(default='~DO_NOT_USE') # "good" DQ bits
         lower = float(default=None) # Lower limit of "good" pixel values
         upper = float(default=None) # Upper limit of "good" pixel values
         nclip = integer(min=0, default=5) # number of sky clipping iterations


### PR DESCRIPTION
Closes #2312 .

This PR removes usage of the NON_SCIENCE bit.  This bit has some limited usage in romancal.  The bit is likely to be removed or repurposed and its usage has no effect on the pipeline at present because this bit is never set.

I have not removed the flag from roman_datamodels, which contains its definition, nor from rad, which references it in some example documentation.  I don't think that fixing that example documentation is worth bumping schemas.

Regression tests are as expected here: https://github.com/spacetelescope/RegressionTests/actions/runs/25520563016 .  They require some okifying to reflect the change of good_bits to no longer include NON_SCIENCE.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [X] update relevant docstrings and / or `docs/` page
  - [X] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [X] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
