### PR TITLE
loosen is_extended definition to aper04/aper02 < 1.2 * ee04/ee02

### DIFF
--- a/changes/2317.source_catalog.rst
+++ b/changes/2317.source_catalog.rst
@@ -1,0 +1,1 @@
+Loosen is_extended cut and fix enclosed energy fraction computation.

--- a/docs/roman/source_catalog/main.rst
+++ b/docs/roman/source_catalog/main.rst
@@ -119,6 +119,12 @@ background flux is calculated as the sigma-clipped median value within
 the annulus. Although this local background value is included in the
 source catalog, it is not subtracted from any of the measured fluxes.
 
+Each source has a field, `is_extended`, intended to indicate whether the
+source is more extended than expected, were the object a point source.
+The determination is made on the basis of the ratio of aperture fluxes
+at 0.4 and 0.2 arcsec being more than 1.2x larger than expected for
+a point source.
+
 
 Source Catalog Table
 --------------------

--- a/romancal/source_catalog/_aperture.py
+++ b/romancal/source_catalog/_aperture.py
@@ -247,7 +247,7 @@ class ApertureCatalog:
         """
         if self.ee_spline is not None:
             for radius, name in zip(
-                self.aperture_radii["circle_pix"],
+                self.aperture_radii["circle"],
                 self.aperture_radius_name,
                 strict=True,
             ):
@@ -273,7 +273,7 @@ class ApertureCatalog:
             return np.zeros(self.xypos_finite.shape[0], dtype=bool)
 
         ee_ratio = self.ee_fraction_04 / self.ee_fraction_02
-        return self.aper04_flux > (self.aper02_flux * 1.1 * ee_ratio)
+        return self.aper04_flux > (self.aper02_flux * 1.2 * ee_ratio)
 
     def calc_aperture_photometry(self, subtract_local_bkg=False):
         """


### PR DESCRIPTION
The aperture correction reference file was updated yesterday to include sensible values.  This PR now uses those sensible values to compute sensible is_extended measurements.  The key thing is that we want to flag objects as extended if their aper04 / aper02 ratios exceed expectations for a PSF from the aperture correction reference file, given by ee04 / ee02, times some tolerance.  This PR does two things:
1. It increases the tolerance to 1.2 from 1.1
2. It fixes a bug where the ee_fractions were evaluated at a location in pixels but were tabulated at locations in arcseconds.  Now the tabulation and evaluation are both done in arcseconds.

The result has reasonable is_extended flagging.

<img width="1342" height="844" alt="image" src="https://github.com/user-attachments/assets/4afb949d-82ba-4090-8c0c-b7244eea1d66" />

Crosses are flagged extended objects and exes are flagged non-extended objects.  The locus of bright points at low ee04 / ee02 are Gaia stars that we want to flag as non-extended.  The clump of fainter objects at higher ee04/ee02 are galaxies.  This cut does a good job.  The quality of this cut is exaggerated in this plot because the stars don't go faint enough; in reality there will be plenty of faint stars with noisy aper04 / aper02 that are challenging to distinguish from galaxies.

Regression tests pass: https://github.com/spacetelescope/RegressionTests/actions/runs/25564037982 .

## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
