### PR TITLE
Fix test for L3 vs. L2 PSF

### DIFF
--- a/changes/2321.source_catalog.rst
+++ b/changes/2321.source_catalog.rst
@@ -1,0 +1,1 @@
+Fix PSF model selection to correctly identify L3 coadd vs. L2 image data models.

--- a/romancal/source_catalog/psf.py
+++ b/romancal/source_catalog/psf.py
@@ -569,7 +569,7 @@ def create_l3_psf_model(
     xx, yy = np.meshgrid(pts, pts)
     psf = gridpsf.evaluate(xx, yy, 1, center, center)
     detector_pixel_scale = 0.11  # Roman native scale
-    # psf is now a stamp going 10 pixels out from the center of the PSF
+    # psf is now a stamp going stamp_radius pixels out from the center of the PSF
     # at the native PSF scale, oversampled by a factor of oversample.
 
     # Smooth to account for the pixfrac used to create the L3 image.
@@ -649,7 +649,7 @@ class _PSFCatalog:
         A gridded PSF model based on instrument and detector
         information.
         """
-        if hasattr(self.model.meta, "instrument"):
+        if not hasattr(self.model.meta, "resample"):
             # ImageModel (L2 datamodel)
             psf_model = get_gridded_psf_model(self.psf_ref_model)
         else:

--- a/romancal/source_catalog/tests/test_psf.py
+++ b/romancal/source_catalog/tests/test_psf.py
@@ -15,9 +15,8 @@ from astropy.stats import mad_std
 from astropy.table import QTable
 from astropy.time import Time
 from photutils.datasets import make_model_image
-from roman_datamodels.datamodels import ImageModel, MosaicModel
-
 from photutils.psf import GriddedPSFModel, ImagePSF
+from roman_datamodels.datamodels import ImageModel, MosaicModel
 
 from romancal.source_catalog.psf import (
     _azimuthally_average_via_fft,

--- a/romancal/source_catalog/tests/test_psf.py
+++ b/romancal/source_catalog/tests/test_psf.py
@@ -15,7 +15,9 @@ from astropy.stats import mad_std
 from astropy.table import QTable
 from astropy.time import Time
 from photutils.datasets import make_model_image
-from roman_datamodels.datamodels import ImageModel
+from roman_datamodels.datamodels import ImageModel, MosaicModel
+
+from photutils.psf import GriddedPSFModel, ImagePSF
 
 from romancal.source_catalog.psf import (
     _azimuthally_average_via_fft,
@@ -325,3 +327,22 @@ def test_central_stamp():
     assert cen.shape[0] == 20
     cen = _central_stamp(img, 21)
     assert cen.shape[0] == 22  # needed to make it bigger to be central
+
+
+def test_psf_model_type(setup_inputs):
+    """ImageModel uses GriddedPSFModel; MosaicModel uses ImagePSF (L3 PSF)."""
+    psf_ref_model = setup_inputs["psf_ref_model_f087"]
+    center = np.array([[image_model_shape[0] / 2, image_model_shape[1] / 2]])
+
+    # L2: ImageModel gets a GriddedPSFModel
+    catalog = _PSFCatalog(setup_inputs["image"], psf_ref_model, center)
+    assert isinstance(catalog.psf_model, GriddedPSFModel)
+
+    # L3: MosaicModel gets an ImagePSF
+    mosaic = MosaicModel.create_fake_data(shape=image_model_shape)
+    mosaic.meta.resample.pixfrac = 1.0
+    mosaic.meta.wcsinfo.pixel_scale = 1.5277777769528157e-05  # 0.055 arcsec
+    mosaic.data = setup_inputs["image"].data
+    mosaic.err = setup_inputs["image"].err
+    catalog2 = _PSFCatalog(mosaic, psf_ref_model, center)
+    assert isinstance(catalog2.psf_model, ImagePSF)


### PR DESCRIPTION
This PR addresses an error in the PSF fluxes we measure in the source catalog step.

@darioflute identified an issue that the L3 PSF fluxes were systematically underestimated.  He also tested that using our L3 PSFs with photutils PSFPhotometry delivered good fluxes.  This PR fixes the root of the issue: that we were inadvertently using the L2 PSFs instead of the L3 PSF in the coadd PSF measurements, due to a change in the L3 schema and a brittle test.  This PR improves that test to look for the 'meta.resample' keyword rather than the 'meta.instrument' keyword, which should be a better test of an image being a MosaicModel.

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/25687253309 .

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
