### PR TITLE
Change multiband catalog to default to a single kernel

### DIFF
--- a/changes/2323.multiband_catalog.rst
+++ b/changes/2323.multiband_catalog.rst
@@ -1,0 +1,1 @@
+Changed default ``kernel_fwhms`` from ``[2.0, 5.0]`` to ``[2.0]``.

--- a/romancal/multiband_catalog/_multiband_catalog.py
+++ b/romancal/multiband_catalog/_multiband_catalog.py
@@ -81,7 +81,7 @@ def process_detection_image(self, library, example_model, ee_spline, catalog_mod
     # TODO: sensible defaults
     # TODO: redefine in terms of intrinsic FWHM
     if self.kernel_fwhms is None:
-        self.kernel_fwhms = [2.0, 5.0]
+        self.kernel_fwhms = [2.0]
 
     detection_image = make_detection_image(library, self.kernel_fwhms)
 

--- a/romancal/regtest/test_multiband_catalog.py
+++ b/romancal/regtest/test_multiband_catalog.py
@@ -52,6 +52,8 @@ def test_multiband_catalog(rtdata_module, resource_tracker, request, dms_logger)
         inputasnfn,
         "--deblend",
         "True",  # use deblending, DMS 393
+        "--kernel_fwhms",
+        "2.0,5.0",  # DMS 391: explicitly test both PSF-like and extended-source kernels
         "--inject_sources",  # turn on source injection, DMS 396
         "True",
     ]


### PR DESCRIPTION
This PR changes the multiband default kernel selection to use a single kernel.  We continue to support running with multiple kernels, but make a single kernel default to ease understanding of the detection image and downstream impacts on shape measurements and kron fluxes.

Regression tests are all passing: https://github.com/spacetelescope/RegressionTests/actions/runs/25751748293 .

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
