### PR TITLE
Make source cataloging only use DO_NOT_USE and ignore other DQ flags

### DIFF
--- a/changes/2325.source_catalog.rst
+++ b/changes/2325.source_catalog.rst
@@ -1,0 +1,1 @@
+Source catalog DQ masking now excludes only pixels with DO_NOT_USE set, rather than any set DQ bit.

--- a/docs/roman/resample/arguments.rst
+++ b/docs/roman/resample/arguments.rst
@@ -118,7 +118,7 @@ image.
     low QE and highly nonlinear, then any of the ways listed below will
     work to set ``good_bits``:
 
-    - ``good_bits = 'LOW_QE+NON_LINEAR'`` (concatenated DQ flag labels);
+    - ``good_bits = 'LOW_QE+NONLINEAR'`` (concatenated DQ flag labels);
     - ``good_bits = '8192+65536'`` (concatenated DQ flag bit values);
     - ``good_bits = '8192,65536'`` (comma-separated DQ flag bit values);
     - ``good_bits = '73728'`` (sum of DQ flag bit values).

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -44,13 +44,12 @@ def test_dq_im(xstart, ystart, xsize, ysize, nresultants, instrument, exp_type):
     dq[100, 100] = 2  # Saturated pixel
     dq[200, 100] = 4  # Jump detected pixel
     dq[300, 100] = 8  # Dropout
-    dq[400, 100] = 32  # Persistence
+    dq[400, 100] = 16  # GW_AFFECTED_DATA
     dq[500, 100] = 1  # Do_not_use
-    dq[600, 100] = 16  # guide window affected data
     dq[100, 200] = 3  # Saturated pixel + do not use
     dq[200, 200] = 5  # Jump detected pixel + do not use
     dq[300, 200] = 9  # Dropout + do not use
-    dq[400, 200] = 33  # Persistence + do not use
+    dq[400, 200] = 17  # GW_AFFECTED_DATA + do not use
 
     # write mask model
     ref_data = MaskRefModel.create_fake_data(shape=csize[1:])
@@ -69,13 +68,12 @@ def test_dq_im(xstart, ystart, xsize, ysize, nresultants, instrument, exp_type):
     assert dqdata[100, 100] == pixel.SATURATED
     assert dqdata[200, 100] == pixel.JUMP_DET
     assert dqdata[300, 100] == pixel.DROPOUT
-    assert dqdata[400, 100] == pixel.PERSISTENCE
+    assert dqdata[400, 100] == pixel.GW_AFFECTED_DATA
     assert dqdata[500, 100] == pixel.DO_NOT_USE
-    assert dqdata[600, 100] == pixel.GW_AFFECTED_DATA
     assert dqdata[100, 200] == pixel.SATURATED + pixel.DO_NOT_USE
     assert dqdata[200, 200] == pixel.JUMP_DET + pixel.DO_NOT_USE
     assert dqdata[300, 200] == pixel.DROPOUT + pixel.DO_NOT_USE
-    assert dqdata[400, 200] == pixel.PERSISTENCE + pixel.DO_NOT_USE
+    assert dqdata[400, 200] == pixel.GW_AFFECTED_DATA + pixel.DO_NOT_USE
 
 
 def test_groupdq():

--- a/romancal/source_catalog/source_catalog_step.py
+++ b/romancal/source_catalog/source_catalog_step.py
@@ -113,11 +113,6 @@ class SourceCatalogStep(RomanStep):
 
         # Create a DQ mask for ImageModel
         if isinstance(input_model, ImageModel):
-            # Create a DQ mask for pixels to be excluded; currently all
-            # pixels with any DQ flag are excluded from the source catalog
-            # except for those in ignored_dq_flags.
-            # TODO: revisit these flags when CRDS reference files are updated
-            ignored_dq_flags = pixel.NO_LIN_CORR
             if model.dq.shape != model.data.shape:
                 msg = (
                     f"model.dq shape {model.dq.shape} does not match "
@@ -125,10 +120,7 @@ class SourceCatalogStep(RomanStep):
                     "DQ array."
                 )
                 raise ValueError(msg)
-            dq_mask = (model.dq & ~ignored_dq_flags) != 0
-
-            # TODO: to set the mask to True for *only* dq_flags use:
-            # dq_mask = (model.dq & dq_flags) != 0
+            dq_mask = (model.dq & pixel.DO_NOT_USE) != 0
             mask |= dq_mask
 
         # Initialize the source catalog model, copying the metadata


### PR DESCRIPTION
This PR makes the source catalog step ignore all bits DQ bits other than DO_NOT_USE.  Old CRDS reference files contained substantial numbers of problematic bits that were not flagged.  New reference files should address this issue so that only DO_NOT_USE pixels are in fact problematic.

On the way I also changed some test code to use GW_AFFECTED_DATA rather than PERSISTENCE, since PERSISTENCE may change names.  I also changed a doc NON_LINEAR reference to NONLINEAR, since the latter is the actual name of the pixel in question.

Regression tests here: https://github.com/spacetelescope/RegressionTests/actions/runs/25806174508
They show small improvements to the Gaia astrometric RMS, a pleasant surprise; presumably some of the formerly flagged pixels are now being used.  I am starting a fresh run to bring in the dust map updates.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
