### PR TITLE
RCAL-1396 no authentication header if no token and velocity checking

### DIFF
--- a/romancal/lib/engdb/engdb_mast.py
+++ b/romancal/lib/engdb/engdb_mast.py
@@ -408,10 +408,11 @@ class EngdbMast(EngdbABC):
     def _set_session(self):
         """Set up HTTP session."""
         headers = dict()
-        if self.rsdp_auth:
-            headers["x-asb-auth"] = self.token
-        else:
-            headers["Authorization"] = f"token {self.token}"
+        if self.token:
+            if self.rsdp_auth:
+                headers["x-asb-auth"] = self.token
+            else:
+                headers["Authorization"] = f"token {self.token}"
 
         self._datareq = requests.Request(
             method="GET",

--- a/romancal/lib/engdb/tests/test_engdb_mast.py
+++ b/romancal/lib/engdb/tests/test_engdb_mast.py
@@ -117,13 +117,22 @@ def test_get_values_nozip(engdb):
 
 
 @pytest.mark.parametrize(
-    'envs, expected',
+    "envs, expected",
     [
-        ({'MAST_AUTH_TOKEN': None, 'MAST_API_TOKEN': None}, {}),
-        ({'MAST_AUTH_TOKEN': 'MAST_AUTH_TOKEN', 'MAST_API_TOKEN': None}, {'x-asb-auth': 'MAST_AUTH_TOKEN'}),
-        ({'MAST_AUTH_TOKEN': None, 'MAST_API_TOKEN': 'MAST_API_TOKEN'}, {'Authorization': 'token MAST_API_TOKEN'}),
-        ({'MAST_AUTH_TOKEN': 'MAST_AUTH_TOKEN', 'MAST_API_TOKEN': 'MAST_API_TOKEN'}, {'x-asb-auth': 'MAST_AUTH_TOKEN'}),
-    ]
+        ({"MAST_AUTH_TOKEN": None, "MAST_API_TOKEN": None}, {}),
+        (
+            {"MAST_AUTH_TOKEN": "MAST_AUTH_TOKEN", "MAST_API_TOKEN": None},
+            {"x-asb-auth": "MAST_AUTH_TOKEN"},
+        ),
+        (
+            {"MAST_AUTH_TOKEN": None, "MAST_API_TOKEN": "MAST_API_TOKEN"},
+            {"Authorization": "token MAST_API_TOKEN"},
+        ),
+        (
+            {"MAST_AUTH_TOKEN": "MAST_AUTH_TOKEN", "MAST_API_TOKEN": "MAST_API_TOKEN"},
+            {"x-asb-auth": "MAST_AUTH_TOKEN"},
+        ),
+    ],
 )
 def test_headers_env(envs, expected, monkeypatch):
     """Check that headers are being appropriately set from environment"""
@@ -139,12 +148,12 @@ def test_headers_env(envs, expected, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    'kwargs, expected',
+    "kwargs, expected",
     [
         ({}, {}),
-        ({'token': 'token'}, {'Authorization': 'token token'}),
-        ({'token': 'token', 'rsdp_auth': True}, {'x-asb-auth': 'token'})
-    ]
+        ({"token": "token"}, {"Authorization": "token token"}),
+        ({"token": "token", "rsdp_auth": True}, {"x-asb-auth": "token"}),
+    ],
 )
 def test_headers_kwargs(kwargs, expected):
     """Check that headers are being appropriately set"""

--- a/romancal/lib/engdb/tests/test_engdb_mast.py
+++ b/romancal/lib/engdb/tests/test_engdb_mast.py
@@ -116,6 +116,43 @@ def test_get_values_nozip(engdb):
     assert_xfail(isinstance(result.value[0], str))
 
 
+@pytest.mark.parametrize(
+    'envs, expected',
+    [
+        ({'MAST_AUTH_TOKEN': None, 'MAST_API_TOKEN': None}, {}),
+        ({'MAST_AUTH_TOKEN': 'MAST_AUTH_TOKEN', 'MAST_API_TOKEN': None}, {'x-asb-auth': 'MAST_AUTH_TOKEN'}),
+        ({'MAST_AUTH_TOKEN': None, 'MAST_API_TOKEN': 'MAST_API_TOKEN'}, {'Authorization': 'token MAST_API_TOKEN'}),
+        ({'MAST_AUTH_TOKEN': 'MAST_AUTH_TOKEN', 'MAST_API_TOKEN': 'MAST_API_TOKEN'}, {'x-asb-auth': 'MAST_AUTH_TOKEN'}),
+    ]
+)
+def test_headers_env(envs, expected, monkeypatch):
+    """Check that headers are being appropriately set from environment"""
+    for env, value in envs.items():
+        if value is None:
+            monkeypatch.delenv(env, raising=False)
+        else:
+            monkeypatch.setenv(env, value)
+
+    edb = engdb_mast.EngdbMast(check_aliveness=False)
+
+    assert edb._metareq.headers == expected
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected',
+    [
+        ({}, {}),
+        ({'token': 'token'}, {'Authorization': 'token token'}),
+        ({'token': 'token', 'rsdp_auth': True}, {'x-asb-auth': 'token'})
+    ]
+)
+def test_headers_kwargs(kwargs, expected):
+    """Check that headers are being appropriately set"""
+    edb = engdb_mast.EngdbMast(check_aliveness=False, **kwargs)
+
+    assert edb._metareq.headers == expected
+
+
 def test_negative_aliveness():
     """Ensure failure occurs with a bad url"""
     with pytest.raises(RuntimeError):

--- a/romancal/orientation/_lib.py
+++ b/romancal/orientation/_lib.py
@@ -23,9 +23,9 @@ FGS_DEFAULT_QUATERNION = np.array(
     [-0.18596734175399293, 0.6837984564491885, -0.1800546332580956, 0.6822141509826322]
 )
 
-# Maximum absolute speed of the observatory. Used for sanity check is defined
-# as the sum of the absolute components of the velocity.
-MAX_OBSERVATORY_SPEED = 150
+# Maximum absolute speed of the observatory. Used for sanity check for any
+# individual component of the velocity.
+MAX_OBSERVATORY_SPEED = 500  # km/s
 
 # Common conversions.
 # Yes, these are available in a number of packages. However, they are explicitly defined

--- a/romancal/orientation/_transforms.py
+++ b/romancal/orientation/_transforms.py
@@ -231,9 +231,11 @@ def calc_gsapp2gs(m_eci2gsapp, velocity):
     # Check velocity. If present, negate the velocity since
     # the desire is to remove the correction.
     velocity = np.array(velocity)
-    if None in velocity \
-       or np.all(velocity == 0.) \
-       or np.sum(np.abs(velocity) > olib.MAX_OBSERVATORY_SPEED):
+    if (
+        None in velocity
+        or np.all(velocity == 0.0)
+        or np.sum(np.abs(velocity) > olib.MAX_OBSERVATORY_SPEED)
+    ):
         logger.warning(
             "Velocity: %s is either unspecified or contains unreasonable values. Cannot calculate aberration. Returning identity matrix",
             velocity,

--- a/romancal/orientation/_transforms.py
+++ b/romancal/orientation/_transforms.py
@@ -231,7 +231,9 @@ def calc_gsapp2gs(m_eci2gsapp, velocity):
     # Check velocity. If present, negate the velocity since
     # the desire is to remove the correction.
     velocity = np.array(velocity)
-    if not velocity.all() or np.sum(np.abs(velocity) > olib.MAX_OBSERVATORY_SPEED):
+    if None in velocity \
+       or np.all(velocity == 0.) \
+       or np.sum(np.abs(velocity) > olib.MAX_OBSERVATORY_SPEED):
         logger.warning(
             "Velocity: %s is either unspecified or contains unreasonable values. Cannot calculate aberration. Returning identity matrix",
             velocity,

--- a/romancal/orientation/tests/test_set_telescope_pointing.py
+++ b/romancal/orientation/tests/test_set_telescope_pointing.py
@@ -360,13 +360,13 @@ def test_update_meta(attr, expected, updated_model):
 
 
 @pytest.mark.parametrize(
-    'velocity, is_identity',
+    "velocity, is_identity",
     [
         ([None, None, None], True),
         ([0, 0, 0], True),
         ([2000, 2000, 2000], True),
         ([-50, 0, 50], False),
-    ]
+    ],
 )
 def test_velocity_check(velocity, is_identity):
     """Test velocity check"""

--- a/romancal/orientation/tests/test_set_telescope_pointing.py
+++ b/romancal/orientation/tests/test_set_telescope_pointing.py
@@ -359,6 +359,27 @@ def test_update_meta(attr, expected, updated_model):
         assert value == expected
 
 
+@pytest.mark.parametrize(
+    'velocity, is_identity',
+    [
+        ([None, None, None], True),
+        ([0, 0, 0], True),
+        ([2000, 2000, 2000], True),
+        ([-50, 0, 50], False),
+    ]
+)
+def test_velocity_check(velocity, is_identity):
+    """Test velocity check"""
+    m = np.identity(3)
+
+    m_v = tlib.calc_gsapp2gs(m, velocity)
+
+    if is_identity:
+        assert np.array_equal(m_v, m)
+    else:
+        assert not np.array_equal(m_v, m)
+
+
 # ######################
 # Utilities and fixtures
 # ######################


### PR DESCRIPTION
Resolves [RCAL-1396](https://jira.stsci.edu/browse/RCAL-1396)

This PR addresses two bugs:
- Using MAST, the authentication header was generated whether there is a token or not
- Observatory velocity check too strict and inconsistent

Fixes include:
- If no token, no authentication is generated
- Velocity constraint loosened and check is more consistent.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
