### PR TITLE
update romanisim dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     # roman_datamodels release.
     # "roman_datamodels>=0.31.0, <0.32",
     "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels@main",
-    # "romanisim>=0.13.1,<0.14",
-    "romanisim@git+https://github.com/spacetelescope/romanisim@main",
+    "romanisim>=0.14,<0.15",
+    # "romanisim@git+https://github.com/spacetelescope/romanisim@main",
     "asdf>=4.1.0,<6",
     "crds>=13.0.2",
     "drizzle>=2.2.0,<2.3.0",


### PR DESCRIPTION
This PR updates the romanisim dependency of romancal to point to a release rather than dev in preparation for the romancal release.

We needed to shift to romanisim v0.14 to accommodate the new spacecraft parameter API, which now comes from roman-technical-information; that caused some romancal test code to need to look for some parameters in new parts of romanisim.

Regression tests are passing: https://github.com/spacetelescope/RegressionTests/actions/runs/25863026616

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))