### PR TITLE
Wrap tests in temp folder.

### DIFF
--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -240,7 +240,6 @@ def test_multiband_catalog_populates_dust_ebv(library_model, function_jail):
         fit_psf=False,
         save_results=False,
         deblend=True,
-        output_dir=str(tmp_path),
     )
     cat = result.source_catalog
     assert "dust_ebv" in cat.colnames

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -229,7 +229,7 @@ def test_multiband_catalog(
     shared_tests(result, cat, library_model, save_results, function_jail)
 
 
-def test_multiband_catalog_populates_dust_ebv(library_model):
+def test_multiband_catalog_populates_dust_ebv(library_model, tmp_path):
     """Ensure the joined multiband catalog contains the detection-level dust_ebv."""
     step = MultibandCatalogStep()
     result = step.call(
@@ -240,6 +240,7 @@ def test_multiband_catalog_populates_dust_ebv(library_model):
         fit_psf=False,
         save_results=False,
         deblend=True,
+        output_dir=str(tmp_path),
     )
     cat = result.source_catalog
     assert "dust_ebv" in cat.colnames

--- a/romancal/multiband_catalog/tests/test_multiband_catalog.py
+++ b/romancal/multiband_catalog/tests/test_multiband_catalog.py
@@ -229,7 +229,7 @@ def test_multiband_catalog(
     shared_tests(result, cat, library_model, save_results, function_jail)
 
 
-def test_multiband_catalog_populates_dust_ebv(library_model, tmp_path):
+def test_multiband_catalog_populates_dust_ebv(library_model, function_jail):
     """Ensure the joined multiband catalog contains the detection-level dust_ebv."""
     step = MultibandCatalogStep()
     result = step.call(

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -348,7 +348,6 @@ def test_source_catalog_populates_dust_ebv(model_fixture, request, function_jail
         snr_threshold=3,
         npixels=10,
         save_results=False,
-        output_dir=str(tmp_path),
     )
     cat = result.source_catalog
     assert "dust_ebv" in cat.colnames

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -337,7 +337,7 @@ def test_background(mosaic_model, function_jail):
 
 
 @pytest.mark.parametrize("model_fixture", ("image_model", "mosaic_model"))
-def test_source_catalog_populates_dust_ebv(model_fixture, request, tmp_path):
+def test_source_catalog_populates_dust_ebv(model_fixture, request, function_jail):
     """Ensure prompt source catalogs include a per-source dust_ebv column."""
     model = request.getfixturevalue(model_fixture)
     step = SourceCatalogStep()

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -348,7 +348,7 @@ def test_source_catalog_populates_dust_ebv(model_fixture, request, tmp_path):
         snr_threshold=3,
         npixels=10,
         save_results=False,
-        output_dir=str(tmp_path)
+        output_dir=str(tmp_path),
     )
     cat = result.source_catalog
     assert "dust_ebv" in cat.colnames

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -337,7 +337,7 @@ def test_background(mosaic_model, function_jail):
 
 
 @pytest.mark.parametrize("model_fixture", ("image_model", "mosaic_model"))
-def test_source_catalog_populates_dust_ebv(model_fixture, request):
+def test_source_catalog_populates_dust_ebv(model_fixture, request, tmp_path):
     """Ensure prompt source catalogs include a per-source dust_ebv column."""
     model = request.getfixturevalue(model_fixture)
     step = SourceCatalogStep()
@@ -348,6 +348,7 @@ def test_source_catalog_populates_dust_ebv(model_fixture, request):
         snr_threshold=3,
         npixels=10,
         save_results=False,
+        output_dir=str(tmp_path)
     )
     cat = result.source_catalog
     assert "dust_ebv" in cat.colnames


### PR DESCRIPTION
Previously, the dust maps work added two new unit tests that were not using temp folders, and for that reason, they were creating the following files without ever cleaning after:

- `multiband_catalog_cat.parquet`
- `multiband_catalog_segm.asdf`
- `none_cat.parquet`
- `none_segm.asdf`

This PR makes sure the new unit tests do not litter.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
