### PR TITLE
Document that romancal.scripts, lib, associations do not yet have a stable public API

### DIFF
--- a/docs/roman/versioning.rst
+++ b/docs/roman/versioning.rst
@@ -26,7 +26,7 @@ Any API not officially documented (i.e., you only found it after some extensive
 code-diving) is also considered private.
 
 Additionally, code under the following modules:
-* ``romancal.association``
+* ``romancal.associations``
 * ``romancal.lib``
 * ``romancal.scripts``
 does not yet have a stable public API and will change in future releases.

--- a/docs/roman/versioning.rst
+++ b/docs/roman/versioning.rst
@@ -25,11 +25,12 @@ As per Python convention, any API name that starts with underscore
 Any API not officially documented (i.e., you only found it after some extensive
 code-diving) is also considered private.
 
-Additionally, code under the following modules:
+Additionally, the following modules do not yet have a stable public API and will change in future releases:
+
 * ``romancal.associations``
 * ``romancal.lib``
 * ``romancal.scripts``
-does not yet have a stable public API and will change in future releases.
+
 
 Finally, test code is considered private. This includes:
 

--- a/docs/roman/versioning.rst
+++ b/docs/roman/versioning.rst
@@ -25,7 +25,13 @@ As per Python convention, any API name that starts with underscore
 Any API not officially documented (i.e., you only found it after some extensive
 code-diving) is also considered private.
 
-Additionally test code is considered private. This includes:
+Additionally, code under the following modules:
+* ``romancal.association``
+* ``romancal.lib``
+* ``romancal.scripts``
+does not yet have a stable public API and will change in future releases.
+
+Finally, test code is considered private. This includes:
 
 * all ``conftest.py`` files
 * modules that start with ``test_*`` or are named ``tests``


### PR DESCRIPTION
This PR is a documentation-only PR that indicates that the following modules:
* romancal.scripts
* romancal.lib
* romancal.associations

do not yet have a stable public API that external users can depend on.