### PR TITLE
Photom should be marked complete in grism regtest

### DIFF
--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -102,9 +102,9 @@ def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths
         ("ramp_fit", "COMPLETE"),
         ("saturation", "COMPLETE"),
         ("refpix", "COMPLETE"),
+        ("photom", "COMPLETE"),
         # skipped
         ("flat_field", "SKIPPED"),
-        ("photom", "SKIPPED"),
         ("source_catalog", "SKIPPED"),
         ("tweakreg", "SKIPPED"),
     ),


### PR DESCRIPTION
I introduced a bug in the regtest in #2327 ; for grism exposures, the photom step should now be marked complete.  This PR addresses that bug.

Regtests now passing: https://github.com/spacetelescope/RegressionTests/actions/runs/25893795657