### PR TITLE
RCAL-1298: Source Injection Subpixel Shift

### DIFF
--- a/changes/2339.source_catalog.rst
+++ b/changes/2339.source_catalog.rst
@@ -1,0 +1,1 @@
+Added a random pixel shift to injected sources.

--- a/romancal/source_catalog/_injection.py
+++ b/romancal/source_catalog/_injection.py
@@ -226,7 +226,8 @@ def make_cosmoslike_catalog(cen, ra, dec, exptimes, filters=None, seed=None, **k
 
 
 def make_source_grid(
-    model, yxmax=(5000, 5000), yxoffset=(50, 50), yxgrid=(20, 20), seed=None, **kwargs
+    model, yxmax=(5000, 5000), yxoffset=(50, 50), yxgrid=(20, 20), subpixeloffset=(4.0, 4.0),
+    seed=None, **kwargs
 ):
     """
     Generate a grid of points to inject sources onto. The grid is set to the yxmax
@@ -243,6 +244,8 @@ def make_source_grid(
         Edge Offset to place grid within
     yxgrid : tuple of two ints
         Grid point dimensions
+    subpixeloffset : tuple of two floats
+        Offset range for individual grid points
     seed : int
         Seed for random number generator
 
@@ -273,13 +276,11 @@ def make_source_grid(
 
     ypts *= yspace
     ypts += y0
-    # TODO: add sub-pixel shifts
-    # ypts += rng_numpy.uniform(low=-0.5, high=0.5, size=len(ypts))
+    ypts += rng_numpy.uniform(low=-subpixeloffset[0], high=subpixeloffset[0], size=len(ypts))
 
     xpts *= xspace
     xpts += x0
-    # TODO: add sub-pixel shifts
-    # xpts += rng_numpy.uniform(low=-0.5, high=0.5, size=len(xpts))
+    xpts += rng_numpy.uniform(low=-subpixeloffset[1], high=subpixeloffset[1], size=len(xpts))
 
     # Discard off-image positions
     ypts = ypts[ypts < (model.data.shape[0] - int(yxoffset[0]))]
@@ -293,6 +294,6 @@ def make_source_grid(
 
     # Discard positions in NA empty regions
     nanmask = np.isnan(model.data[y_pos_idx, x_pos_idx])
-    y_pos_idx, x_pos_idx = y_pos_idx[~nanmask], x_pos_idx[~nanmask]
+    y_pos, x_pos = y_pos[~nanmask], x_pos[~nanmask]
 
-    return y_pos_idx, x_pos_idx
+    return y_pos, x_pos

--- a/romancal/source_catalog/_injection.py
+++ b/romancal/source_catalog/_injection.py
@@ -226,8 +226,13 @@ def make_cosmoslike_catalog(cen, ra, dec, exptimes, filters=None, seed=None, **k
 
 
 def make_source_grid(
-    model, yxmax=(5000, 5000), yxoffset=(50, 50), yxgrid=(20, 20), subpixeloffset=(4.0, 4.0),
-    seed=None, **kwargs
+    model,
+    yxmax=(5000, 5000),
+    yxoffset=(50, 50),
+    yxgrid=(20, 20),
+    subpixeloffset=(4.0, 4.0),
+    seed=None,
+    **kwargs,
 ):
     """
     Generate a grid of points to inject sources onto. The grid is set to the yxmax
@@ -276,11 +281,15 @@ def make_source_grid(
 
     ypts *= yspace
     ypts += y0
-    ypts += rng_numpy.uniform(low=-subpixeloffset[0], high=subpixeloffset[0], size=len(ypts))
+    ypts += rng_numpy.uniform(
+        low=-subpixeloffset[0], high=subpixeloffset[0], size=len(ypts)
+    )
 
     xpts *= xspace
     xpts += x0
-    xpts += rng_numpy.uniform(low=-subpixeloffset[1], high=subpixeloffset[1], size=len(xpts))
+    xpts += rng_numpy.uniform(
+        low=-subpixeloffset[1], high=subpixeloffset[1], size=len(xpts)
+    )
 
     # Discard off-image positions
     ypts = ypts[ypts < (model.data.shape[0] - int(yxoffset[0]))]

--- a/romancal/source_catalog/tests/test_injection.py
+++ b/romancal/source_catalog/tests/test_injection.py
@@ -335,10 +335,12 @@ def test_make_source_grid(image_model, mosaic_model):
         # Set parameters
         yxgrid = (10, 15)
         yxoffset = (7, 11)
+        subpixeloffset = (2, 2)
         yxmax = np.subtract(SHAPE, [50, 50])
 
-        x_pos, y_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid, seed=RNG_SEED
+        y_pos, x_pos = make_source_grid(
+            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset, seed=RNG_SEED
         )
 
         # Ensure expected number of grid points
@@ -346,23 +348,24 @@ def test_make_source_grid(image_model, mosaic_model):
         assert len(y_pos) == np.prod(yxgrid)
 
         # Ensure grid is regular
-        assert np.allclose(np.diff(np.diff(np.sort(list(set(y_pos))))), 0)
-        assert np.allclose(np.diff(np.diff(np.sort(list(set(x_pos))))), 0)
+        assert np.std(np.diff(np.sort(list(set(y_pos))))) < subpixeloffset[0]
+        assert np.std(np.diff(np.sort(list(set(x_pos))))) < subpixeloffset[1]
 
         # Create NaN point
-        si_model.data[45, 32] = np.nan
+        si_model.data[int(y_pos[3]), int(x_pos[3])] = np.nan
 
         y_nan_pos, x_nan_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid, seed=RNG_SEED
+            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset, seed=RNG_SEED
         )
 
         # Ensure expected number of grid points
         assert len(y_nan_pos) == len(y_pos) - 1
         assert len(x_nan_pos) == len(x_pos) - 1
 
-        # Ensure x,y (32, 45) not in the grid
+        # Ensure NaN point not in the grid
         assert (
-            len(np.intersect1d(np.where(y_nan_pos == 45), np.where(x_nan_pos == 32)))
+            len(np.intersect1d(np.where(y_nan_pos == int(y_pos[3])), np.where(x_nan_pos == int(x_pos[3]))))
             == 0
         )
 
@@ -373,6 +376,7 @@ def test_grid_injection(image_model, mosaic_model):
         # Set parameters
         yxgrid = (10, 15)
         yxoffset = (7, 11)
+        subpixeloffset = (2, 2)
         yxmax = np.subtract(SHAPE, [25, 25])
 
         # Pointing
@@ -391,7 +395,8 @@ def test_grid_injection(image_model, mosaic_model):
 
         # Create grid
         x_pos, y_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid, seed=RNG_SEED
+            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset, seed=RNG_SEED
         )
 
         # Convert x,y to ra, dec
@@ -411,12 +416,12 @@ def test_grid_injection(image_model, mosaic_model):
 
         # Ensure that sources were actually injected along the specified grid
         ngrt = 0
-        for x_val, y_val in zip(x_pos, y_pos, strict=False):
+        for x_val, y_val in zip(x_pos.astype(int) , y_pos.astype(int), strict=False):
             ngrt += np.sum(
-                si_model.data[y_val - 1 : y_val + 2, x_val - 1 : x_val + 2]
-                > data_orig.data[y_val - 1 : y_val + 2, x_val - 1 : x_val + 2]
+                si_model.data[y_val - 3 : y_val + 4, x_val - 3 : x_val + 4]
+                > data_orig.data[y_val - 3 : y_val + 4, x_val - 3 : x_val + 4]
             )
-        assert ngrt / (9 * len(x_pos)) > 0.5
+        assert ngrt / (49 * len(x_pos)) > 0.5
 
         # Test that pixels in the offset areas are close to the original image
         # Numpy isclose is needed to determine equality, due to float precision issues

--- a/romancal/source_catalog/tests/test_injection.py
+++ b/romancal/source_catalog/tests/test_injection.py
@@ -339,8 +339,12 @@ def test_make_source_grid(image_model, mosaic_model):
         yxmax = np.subtract(SHAPE, [50, 50])
 
         y_pos, x_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
-            subpixeloffset=subpixeloffset, seed=RNG_SEED
+            si_model,
+            yxmax=yxmax,
+            yxoffset=yxoffset,
+            yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset,
+            seed=RNG_SEED,
         )
 
         # Ensure expected number of grid points
@@ -355,8 +359,12 @@ def test_make_source_grid(image_model, mosaic_model):
         si_model.data[int(y_pos[3]), int(x_pos[3])] = np.nan
 
         y_nan_pos, x_nan_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
-            subpixeloffset=subpixeloffset, seed=RNG_SEED
+            si_model,
+            yxmax=yxmax,
+            yxoffset=yxoffset,
+            yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset,
+            seed=RNG_SEED,
         )
 
         # Ensure expected number of grid points
@@ -365,7 +373,12 @@ def test_make_source_grid(image_model, mosaic_model):
 
         # Ensure NaN point not in the grid
         assert (
-            len(np.intersect1d(np.where(y_nan_pos == int(y_pos[3])), np.where(x_nan_pos == int(x_pos[3]))))
+            len(
+                np.intersect1d(
+                    np.where(y_nan_pos == int(y_pos[3])),
+                    np.where(x_nan_pos == int(x_pos[3])),
+                )
+            )
             == 0
         )
 
@@ -395,8 +408,12 @@ def test_grid_injection(image_model, mosaic_model):
 
         # Create grid
         x_pos, y_pos = make_source_grid(
-            si_model, yxmax=yxmax, yxoffset=yxoffset, yxgrid=yxgrid,
-            subpixeloffset=subpixeloffset, seed=RNG_SEED
+            si_model,
+            yxmax=yxmax,
+            yxoffset=yxoffset,
+            yxgrid=yxgrid,
+            subpixeloffset=subpixeloffset,
+            seed=RNG_SEED,
         )
 
         # Convert x,y to ra, dec
@@ -416,7 +433,7 @@ def test_grid_injection(image_model, mosaic_model):
 
         # Ensure that sources were actually injected along the specified grid
         ngrt = 0
-        for x_val, y_val in zip(x_pos.astype(int) , y_pos.astype(int), strict=False):
+        for x_val, y_val in zip(x_pos.astype(int), y_pos.astype(int), strict=False):
             ngrt += np.sum(
                 si_model.data[y_val - 3 : y_val + 4, x_val - 3 : x_val + 4]
                 > data_orig.data[y_val - 3 : y_val + 4, x_val - 3 : x_val + 4]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1298](https://jira.stsci.edu/browse/RCAL-1298)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2112
Closes #2072 

<!-- describe the changes comprising this PR here -->
This PR adds a random pixel shift to injected sources.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
