### PR TITLE
Update docs to remove usage of the word "anomaly."

### DIFF
--- a/docs/roman/pipeline_naming_conventions.rst
+++ b/docs/roman/pipeline_naming_conventions.rst
@@ -76,7 +76,7 @@ DQ initialization                              `_dqinit`
 Saturation detection                           `_saturation`
 Reference Pixel Correction                     `_refpix`
 Dark Decay Correction                          `_dark_decay`
-WFI18 Transient Anomaly Correction             `_wfi18_transient`
+WFI18 Transient Correction                     `_wfi18_transient`
 Linearity correction                           `_linearity`
 Dark current                                   `_darkcurrent`
 Corrected ramp data                            `_rampfit`

--- a/docs/roman/references_general/dq_flags.inc
+++ b/docs/roman/references_general/dq_flags.inc
@@ -10,7 +10,7 @@ Bit  Value         Name                    Description
 4    16            GW_AFFECTED_DATA        Data affected by the GW read window
 5    32            PERSISTENCE             High persistence (was RESERVED_2)
 6    64            AD_FLOOR                Below A/D floor (0 DN, was RESERVED_3)
-7    128           WFI18_TRANSIENT         Group DQ only: Affected by the WFI18 transient signal
+7    128           WFI18_TRANSIENT         Group DQ only: Affected by the WFI18 transient
 7    128           OUTLIER                 Pixel DQ only: Detected as outlier in coadded image
 8    256           UNRELIABLE_ERROR        Uncertainty exceeds quoted error
 9    512           NON_SCIENCE             Pixel not on science portion of detector

--- a/docs/roman/references_general/dq_flags.inc
+++ b/docs/roman/references_general/dq_flags.inc
@@ -10,7 +10,7 @@ Bit  Value         Name                    Description
 4    16            GW_AFFECTED_DATA        Data affected by the GW read window
 5    32            PERSISTENCE             High persistence (was RESERVED_2)
 6    64            AD_FLOOR                Below A/D floor (0 DN, was RESERVED_3)
-7    128           WFI18_TRANSIENT         Group DQ only: Affected by the WFI18 transient anomaly
+7    128           WFI18_TRANSIENT         Group DQ only: Affected by the WFI18 transient signal
 7    128           OUTLIER                 Pixel DQ only: Detected as outlier in coadded image
 8    256           UNRELIABLE_ERROR        Uncertainty exceeds quoted error
 9    512           NON_SCIENCE             Pixel not on science portion of detector

--- a/docs/roman/wfi18_transient/arguments.rst
+++ b/docs/roman/wfi18_transient/arguments.rst
@@ -6,6 +6,6 @@ The ``wfi18_transient`` step uses the following optional arguments:
 
 ``--mask_rows`` (boolean, default=False)
   If True, the rows in the first resultant that are most affected by
-  the transient anomaly will be set to DO_NOT_USE in the GROUPDQ
-  array.  If False, a fit to the transient anomaly is attempted, and
+  the transient signal will be set to DO_NOT_USE in the GROUPDQ
+  array.  If False, a fit to the transient signal is attempted, and
   the fit correction is subtracted from the first resultant.

--- a/docs/roman/wfi18_transient/description.rst
+++ b/docs/roman/wfi18_transient/description.rst
@@ -1,7 +1,7 @@
 Description
 ============
 
-The ``wfi18_transient`` step corrects for an anomalous transient signal in the first
+The ``wfi18_transient`` step corrects for a transient signal in the first
 read of exposures taken with detector WFI18.  The transient signal is strongly temperature
 dependent with significant exposure-to-exposure variations so it must be fit and
 removed separately for each exposure.
@@ -36,7 +36,7 @@ To fit the transient signal, the ``wfi18_transient`` step implements the followi
 
 This algorithm requires a minimum of 5 resultants to be successful.  If fewer resultants
 are present, or if the fit fails for any reason, the step will fall back on simply
-masking the rows most affected by the transient anomaly.  In this case, the first
+masking the rows most affected by the transient signal.  In this case, the first
 1000 rows of the first resultant will be set to DO_NOT_USE in the GROUPDQ array.
 Optionally, the user may choose to apply the mask instead of attempting a fit as above,
 by setting the ``mask_rows`` parameter for this step to ``True``.
@@ -50,5 +50,5 @@ References
 ----------
 
 The WFI18 transient correction algorithm is based on work by T. Brandt,
-"Characterizing and Correcting the Anomalous First Read of Detector 18 on Roman-WFI",
+"Characterizing and Correcting the First Read Transient Signal of Detector 18 on Roman-WFI",
 STScI Technical Document, 2025 (in prep).

--- a/docs/roman/wfi18_transient/description.rst
+++ b/docs/roman/wfi18_transient/description.rst
@@ -36,7 +36,7 @@ To fit the transient signal, the ``wfi18_transient`` step implements the followi
 
 This algorithm requires a minimum of 5 resultants to be successful.  If fewer resultants
 are present, or if the fit fails for any reason, the step will fall back on simply
-masking the rows most affected by the transient signal.  In this case, the first
+masking the rows most affected by the transient.  In this case, the first
 1000 rows of the first resultant will be set to DO_NOT_USE in the GROUPDQ array.
 Optionally, the user may choose to apply the mask instead of attempting a fit as above,
 by setting the ``mask_rows`` parameter for this step to ``True``.

--- a/docs/roman/wfi18_transient/description.rst
+++ b/docs/roman/wfi18_transient/description.rst
@@ -50,5 +50,5 @@ References
 ----------
 
 The WFI18 transient correction algorithm is based on work by T. Brandt,
-"Characterizing and Correcting the First Read Transient Signal of Detector 18 on Roman-WFI",
+"Characterizing and Correcting a High Amplitude Transient in Detector 18 on Roman-WFI",
 STScI Technical Document, 2025 (in prep).

--- a/docs/roman/wfi18_transient/index.rst
+++ b/docs/roman/wfi18_transient/index.rst
@@ -1,7 +1,7 @@
 .. _wfi18_transient_step:
 
 ==================================
-WFI18 Transient Anomaly Correction
+WFI18 Transient Correction
 ==================================
 
 .. toctree::


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1402](https://jira.stsci.edu/browse/RCAL-1402)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2208 

<!-- describe the changes comprising this PR here -->
This PR updates WFI18 documentation terminology to remove use of the word “anomaly.”

## What changed

- Updated page title in `docs/roman/wfi18_transient/index.rst`:
- WFI18 Transient Anomaly Correction → WFI18 Transient Correction
- Updated WFI18 step narrative in `docs/roman/wfi18_transient/description.rst` to use “transient” phrasing.
- Updated -`-mask_rows` argument text in `docs/roman/wfi18_transient/arguments.rst` to use “transient.”
- Updated suffix table entry in `docs/roman/pipeline_naming_conventions.rst`:
    - WFI18 Transient Anomaly Correction → WFI18 Transient Correction
- Updated `WFI18_TRANSIENT` flag description in `docs/roman/references_general/dq_flags.inc` to remove “anomaly” wording.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
