### PR TITLE
Refactor tweakreg's logic for flagging step SKIPPED, COMPLETE, or FAILED.

### DIFF
--- a/changes/2342.tweakreg.rst
+++ b/changes/2342.tweakreg.rst
@@ -1,0 +1,7 @@
+Updated ``tweakreg`` step status handling so exposures that were attempted but
+did not produce a successful WCS solution are marked ``FAILED`` (instead of
+``COMPLETE``/implicit ``INCOMPLETE``).
+
+``meta.wcs_fit_results`` is now always populated for attempted ``tweakreg``
+runs, including failed fits, and includes a new ``n_detector`` field recording
+the number of detectors used in the solve.

--- a/docs/roman/references_general/references_general.rst
+++ b/docs/roman/references_general/references_general.rst
@@ -159,10 +159,11 @@ As each pipeline step is applied to a science data product, it will record a sta
 indicator in a cal_step attribute of the science data product. These statuses
 may be included in the primary header of reference files, in order to maintain
 a history of the data that went into creating the reference file.
-Allowed values for the status Attribute are  'INCOMPLETE', 'COMPLETE'
-and 'SKIPPED'. The default value is set to 'INCOMPLETE'. The pipeline modules
-will set the value to 'COMPLETE' or 'SKIPPED'. If the pipeline steps are run
-manually and you skip a step the cal_step will remain 'INCOMPLETE'.
+Allowed values for the status Attribute are 'INCOMPLETE', 'COMPLETE',
+'SKIPPED', and 'FAILED'. The default value is set to 'INCOMPLETE'. The pipeline
+modules will set the value to 'COMPLETE', 'SKIPPED', or 'FAILED'. If the
+pipeline steps are run manually and you skip a step the cal_step will remain
+'INCOMPLETE'.
 
 Data Quality Flags
 ==================

--- a/docs/roman/tweakreg/README.rst
+++ b/docs/roman/tweakreg/README.rst
@@ -69,6 +69,10 @@ gets cross-matched and fit to an astrometric reference catalog
 (set by ``TweakRegStep.abs_refcat``) and the results are stored in
 ``model.meta.wcs_fit_results``. The pipeline initially supports fitting to any
 Gaia Data Release (defaults to `GAIADR3`).
+For each model where ``tweakreg`` is attempted (that is, step status is not
+``SKIPPED``), ``model.meta.wcs_fit_results`` is always populated. For
+unsuccessful fits, ``status`` records the failure and some numeric fields may
+be ``NaN``.
 
 An example of the content of ``model.meta.wcs_fit_results`` is as follows:
 
@@ -90,7 +94,8 @@ An example of the content of ``model.meta.wcs_fit_results`` is as follows:
             "skew": 0.0,
             "rmse": 2.854152848489525e-10,
             "mae": 2.3250544963289652e-10,
-            "nmatches": 22
+            "nmatches": 22,
+            "n_detector": 18
           }
 
 Details about most of the parameters available in ``model.meta.wcs_fit_results`` can be

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -350,7 +350,7 @@ def test_tweakreg_marks_failed_when_absolute_alignment_raises(
         assert model.meta.cal_step.tweakreg == "FAILED"
         assert hasattr(model.meta, "wcs_fit_results")
         assert model.meta.wcs_fit_results.status == "FAILED"
-        assert np.isnan(model.meta.wcs_fit_results.nmatches)
+        assert model.meta.wcs_fit_results.nmatches == 0
         assert model.meta.wcs_fit_results.n_detector == 1
         res.shelve(model, 0, modify=False)
 

--- a/romancal/tweakreg/tests/test_tweakreg.py
+++ b/romancal/tweakreg/tests/test_tweakreg.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy.modeling import models
 from astropy.table import Table
 from numpy.random import default_rng
+from stcal.tweakreg.tweakreg import TweakregError
 
 from romancal.datamodels import ModelLibrary
 from romancal.tweakreg.tweakreg_step import TweakRegStep, _validate_catalog_columns
@@ -146,6 +147,7 @@ def test_fit_results_in_meta(tmp_path, tweakreg_image):
         for i, model in enumerate(res):
             assert hasattr(model.meta, "wcs_fit_results")
             assert len(model.meta.wcs_fit_results) > 0
+            assert model.meta.wcs_fit_results.n_detector == 1
             res.shelve(model, i, modify=False)
 
 
@@ -290,10 +292,67 @@ def test_tweakreg_skips_models_without_source_catalog(tmp_path, tweakreg_image):
     with res:
         for i, m in enumerate(res):
             if i == 0:
-                assert m.meta.cal_step.tweakreg == "COMPLETE"
+                assert m.meta.cal_step.tweakreg == "FAILED"
+                assert m.meta.wcs_fit_results.n_detector == 1
             else:
                 assert m.meta.cal_step.tweakreg == "SKIPPED"
             res.shelve(m, modify=False)
+
+
+def test_tweakreg_marks_failed_when_fit_status_is_not_success(
+    monkeypatch, tweakreg_image
+):
+    """Test that attempted fits with non-success status are marked FAILED."""
+    img = tweakreg_image(shift_1=1000, shift_2=1000)
+
+    def _set_failed_fit_info(self, ref_image, imcats):
+        for imcat in imcats:
+            imcat.meta["fit_info"] = {
+                "status": "FAILED: no valid WCS correction",
+                "nmatches": 3,
+                "fitmask": np.array([True, False, False]),
+            }
+
+    monkeypatch.setattr(TweakRegStep, "do_absolute_alignment", _set_failed_fit_info)
+
+    res = TweakRegStep.call([img])
+
+    assert isinstance(res, ModelLibrary)
+    with res:
+        model = res.borrow(0)
+        assert model.meta.cal_step.tweakreg == "FAILED"
+        assert hasattr(model.meta, "wcs_fit_results")
+        assert model.meta.wcs_fit_results.status.startswith("FAILED")
+        assert model.meta.wcs_fit_results.nmatches == 3
+        assert model.meta.wcs_fit_results.n_detector == 1
+        assert "fitmask" not in model.meta.wcs_fit_results
+        res.shelve(model, 0, modify=False)
+
+
+def test_tweakreg_marks_failed_when_absolute_alignment_raises(
+    monkeypatch, tweakreg_image
+):
+    """Test that attempted fits are marked FAILED when absolute alignment raises."""
+    img = tweakreg_image(shift_1=1000, shift_2=1000)
+
+    def _raise_absolute_alignment(self, ref_image, imcats):
+        raise TweakregError("forced absolute alignment failure")
+
+    monkeypatch.setattr(
+        TweakRegStep, "do_absolute_alignment", _raise_absolute_alignment
+    )
+
+    res = TweakRegStep.call([img])
+
+    assert isinstance(res, ModelLibrary)
+    with res:
+        model = res.borrow(0)
+        assert model.meta.cal_step.tweakreg == "FAILED"
+        assert hasattr(model.meta, "wcs_fit_results")
+        assert model.meta.wcs_fit_results.status == "FAILED"
+        assert np.isnan(model.meta.wcs_fit_results.nmatches)
+        assert model.meta.wcs_fit_results.n_detector == 1
+        res.shelve(model, 0, modify=False)
 
 
 def test_tweakreg_updates_s_region(tmp_path, tweakreg_image):
@@ -477,7 +536,7 @@ def test_tweakreg_custom_catalog_via_asn_member_attribute(
     assert isinstance(res, ModelLibrary)
     with res:
         m = res.borrow(0)
-        assert m.meta.cal_step.tweakreg == "COMPLETE"
+        assert m.meta.cal_step.tweakreg == "FAILED"
         assert m.meta.source_catalog.tweakreg_catalog_name == custom_catalog_fn
         res.shelve(m, modify=False)
 

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -580,7 +580,7 @@ def _serialize_wcs_fit_results(
         fit_results["status"] = "FAILED"
 
     if fit_results.get("nmatches") is None:
-        fit_results["nmatches"] = np.nan
+        fit_results["nmatches"] = 0
 
     fit_results["n_detector"] = n_detector
     return fit_results

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -177,6 +177,8 @@ class TweakRegStep(RomanStep):
 
         # run alignment only if it was possible to build image catalogs
         if len(imcats):
+            absolute_alignment_failed = False
+
             # extract WCS correctors to use for image alignment
             if len(images.group_indices) > 1:
                 try:
@@ -188,18 +190,31 @@ class TweakRegStep(RomanStep):
                 self.do_absolute_alignment(ref_image, imcats)
             except TweakregError as e:
                 log.warning(str(e))
-                return images
+                absolute_alignment_failed = True
 
             # finalize step
             with images:
                 for imcat in imcats:
                     image_model = images.borrow(imcat.meta["model_index"])
-                    image_model.meta.cal_step.tweakreg = "COMPLETE"
+                    fit_info = imcat.meta.get("fit_info")
+                    fit_status = "" if fit_info is None else str(fit_info.get("status", ""))
+                    fit_succeeded = (
+                        not absolute_alignment_failed and "SUCCESS" in fit_status
+                    )
+
+                    image_model.meta["wcs_fit_results"] = _serialize_wcs_fit_results(
+                        fit_info=fit_info,
+                        n_detector=len(imcats),
+                        force_failed_status=absolute_alignment_failed,
+                    )
+
                     # remove source catalog
-                    del image_model.meta["tweakreg_catalog"]
+                    if "tweakreg_catalog" in image_model.meta:
+                        del image_model.meta["tweakreg_catalog"]
 
                     # retrieve fit status and update wcs if fit is successful:
-                    if "SUCCESS" in imcat.meta.get("fit_info")["status"]:
+                    if fit_succeeded:
+                        image_model.meta.cal_step.tweakreg = "COMPLETE"
                         # Update/create the WCS .name attribute with information
                         # on this astrometric fit as the only record that it was
                         # successful:
@@ -212,30 +227,6 @@ class TweakRegStep(RomanStep):
                         #       IF that is what gets recorded in the archive
                         #       for end-user searches.
                         imcat.wcs.name = f"FIT-LVL2-{self.abs_refcat}"
-
-                        # serialize object from tweakwcs
-                        # (typecasting numpy objects to python types so that it doesn't cause an
-                        # issue when saving datamodel to ASDF)
-                        wcs_fit_results = {
-                            k: (
-                                v.tolist()
-                                if isinstance(v, np.ndarray | np.bool_)
-                                else v
-                            )
-                            for k, v in imcat.meta["fit_info"].items()
-                        }
-                        # add fit results and new WCS to datamodel
-                        image_model.meta["wcs_fit_results"] = wcs_fit_results
-                        # remove unwanted keys from WCS fit results
-                        for k in [
-                            "eff_minobj",
-                            "matched_ref_idx",
-                            "matched_input_idx",
-                            "fit_RA",
-                            "fit_DEC",
-                            "fitmask",
-                        ]:
-                            del image_model.meta["wcs_fit_results"][k]
 
                         # update WCS
                         image_model.meta.wcs = imcat.wcs
@@ -255,6 +246,8 @@ class TweakRegStep(RomanStep):
                                     f"Failed to update source catalog coordinates: {e}"
                                 )
                                 raise e
+                    else:
+                        image_model.meta.cal_step.tweakreg = "FAILED"
 
                     images.shelve(image_model, imcat.meta["model_index"])
 
@@ -540,6 +533,68 @@ def _validate_catalog_columns(catalog) -> bool:
             else:
                 return False
     return True
+
+
+def _serialize_wcs_fit_results(
+    fit_info: dict | None,
+    n_detector: int,
+    force_failed_status: bool = False,
+):
+    """
+    Serialize tweakreg fit metadata for storage in datamodel metadata.
+
+    Parameters
+    ----------
+    fit_info : dict or None
+        ``fit_info`` payload from an image corrector.
+    n_detector : int
+        Number of detector images used in the tweakreg solve.
+    force_failed_status : bool
+        Force output status to ``FAILED``.
+
+    Returns
+    -------
+    dict
+        Serialized fit results.
+    """
+    fit_results = {}
+    if fit_info is not None:
+        fit_results = {
+            k: _to_python_scalar_or_list(v) for k, v in fit_info.items()
+        }
+
+    # remove unwanted keys from WCS fit results
+    for key in [
+        "eff_minobj",
+        "matched_ref_idx",
+        "matched_input_idx",
+        "fit_RA",
+        "fit_DEC",
+        "fitmask",
+    ]:
+        fit_results.pop(key, None)
+
+    if force_failed_status:
+        fit_results["status"] = "FAILED"
+    elif not fit_results.get("status"):
+        fit_results["status"] = "FAILED"
+
+    if fit_results.get("nmatches") is None:
+        fit_results["nmatches"] = np.nan
+
+    fit_results["n_detector"] = n_detector
+    return fit_results
+
+
+def _to_python_scalar_or_list(value):
+    """
+    Convert numpy values to Python-native scalars/lists for ASDF serialization.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
 
 
 def _add_required_columns(catalog):

--- a/romancal/tweakreg/tweakreg_step.py
+++ b/romancal/tweakreg/tweakreg_step.py
@@ -197,7 +197,9 @@ class TweakRegStep(RomanStep):
                 for imcat in imcats:
                     image_model = images.borrow(imcat.meta["model_index"])
                     fit_info = imcat.meta.get("fit_info")
-                    fit_status = "" if fit_info is None else str(fit_info.get("status", ""))
+                    fit_status = (
+                        "" if fit_info is None else str(fit_info.get("status", ""))
+                    )
                     fit_succeeded = (
                         not absolute_alignment_failed and "SUCCESS" in fit_status
                     )
@@ -559,9 +561,7 @@ def _serialize_wcs_fit_results(
     """
     fit_results = {}
     if fit_info is not None:
-        fit_results = {
-            k: _to_python_scalar_or_list(v) for k, v in fit_info.items()
-        }
+        fit_results = {k: _to_python_scalar_or_list(v) for k, v in fit_info.items()}
 
     # remove unwanted keys from WCS fit results
     for key in [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1379](https://jira.stsci.edu/browse/RCAL-1379)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1677 

<!-- describe the changes comprising this PR here -->
This PR updates tweakreg failure signaling and fit-result metadata so attempted-but-unsuccessful runs are clearly visible and diagnosable. It addresses the behavior discussed in #1677 ([RCAL-1379](https://jira.stsci.edu/browse/RCAL-1379)): tweakreg could report `COMPLETE` even when no successful WCS update occurred, and `wcs_fit_results` could be missing in failure paths.

The tweakreg step was update to account for the following:
- refactored finalize logic to set step status by per-model fit outcome:
    - `SKIPPED`: model was not attempted (e.g., no source catalog),
    - `COMPLETE`: successful fit and WCS update,
    - `FAILED`: attempted but no successful WCS solution.
- removed early-return behavior that left attempted models in implicit `INCOMPLETE` on absolute-alignment errors.
- added unified fit-result serialization for attempted models:
    - always populates `meta.wcs_fit_results`,
    - preserves available `nmatches` (falls back to NaN if unavailable),
    - adds `n_detector` (number of detector images used in the solve),
    - normalizes `numpy` types for metadata safety,
    - removes internal/non-user-facing fit keys defensively.

The relevant docs and unit tests were also updated accordingly.

### Regression tests
- https://github.com/spacetelescope/RegressionTests/actions/runs/26311853561 (05/22/26)

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
