### PR TITLE
Remove use of some stpipe API in test

### DIFF
--- a/romancal/stpipe/tests/test_integration.py
+++ b/romancal/stpipe/tests/test_integration.py
@@ -1,6 +1,3 @@
-from stpipe import entry_points
-from stpipe.utilities import import_class
-
 import romancal.pipeline
 import romancal.step
 from romancal.stpipe import RomanPipeline, RomanStep
@@ -15,15 +12,12 @@ def test_get_steps():
     )
 
     for class_name, class_alias, is_pipeline in tuples:
-        step_class = import_class(class_name)
+        # parse class path returning only class name
+        _, name = class_name.rsplit(".", maxsplit=1)
+        if is_pipeline:
+            step_class = getattr(romancal.pipeline, name)
+            assert issubclass(step_class, RomanPipeline)
+        else:
+            step_class = getattr(romancal.step, name)
         assert issubclass(step_class, RomanStep)
         assert step_class.class_alias == class_alias
-        if is_pipeline:
-            assert issubclass(step_class, RomanPipeline)
-
-
-def test_entry_point():
-    all_steps = entry_points.get_steps()
-    roman_steps = [s for s in all_steps if s.package_name == "romancal"]
-    tuples = {(s.class_name, s.class_alias, s.is_pipeline) for s in roman_steps}
-    assert tuples == set(get_steps())


### PR DESCRIPTION
Remove a redundant test that checks if the stpipe
entry point is working (which stpipe already tests) and update a test to not rely on a stpipe utility function.

The bigger plan with this PR is:
- merge these changes into romancal
- make a stpipe 1.0.0 release (likely for the next jwst release) which keeps:
  - utilities
  - entry_points
- deprecate the above submodules
- for stpipe 2.0.0 remove the submodules

This only changes unit tests so regtests were not run.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
