### PR TITLE
Save cat/segm files in ELP only if requested by self.save_results.

### DIFF
--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -88,6 +88,10 @@ class ExposurePipeline(RomanPipeline):
 
         # make sure source_catalog returns the updated datamodel
         self.source_catalog.return_updated_model = True
+        # keep source_catalog sidecar products aligned with pipeline save_results
+        # without writing the intermediate sourcecatalog datamodel file
+        self.source_catalog.save_results = False
+        self.source_catalog.save_catalog_results = self.save_results
         # make sure we update source catalog coordinates afer running TweakRegStep
         self.tweakreg.update_source_catalog_coordinates = True
         # make output filenames based on input filenames

--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -99,9 +99,10 @@ def test_elp_save_results(function_jail, fake_science_raw, save_results, monkeyp
     assert set(p.name for p in function_jail.iterdir()) == {"output"}
 
     output_files = set(p.name for p in output_path.iterdir())
-    # TODO shouldn't this be empty?
-    expected = {"test_segm.asdf", "test_cat.parquet"}
+    expected = set()
     if save_results:
+        expected.add("test_segm.asdf")
+        expected.add("test_cat.parquet")
         expected.add("test_cal.asdf")
         expected.add("test_wcs.asdf")
     assert output_files == expected

--- a/romancal/source_catalog/_save_utils.py
+++ b/romancal/source_catalog/_save_utils.py
@@ -147,7 +147,9 @@ def save_all_results(
 
     # save the segmentation image only when results are requested
     if save_catalog_results:
-        save_segment_image(self, segment_img, cat_model, output_filename, save_debug_info)
+        save_segment_image(
+            self, segment_img, cat_model, output_filename, save_debug_info
+        )
 
     # Update the source catalog filename metadata
     self.output_ext = "parquet"

--- a/romancal/source_catalog/_save_utils.py
+++ b/romancal/source_catalog/_save_utils.py
@@ -102,7 +102,7 @@ def save_all_results(
     """
     Return and save the results of the source catalog step.
 
-    The segmentation image is always saved.
+    The segmentation image is saved only when ``save_results`` is True.
 
     If ``save_results`` is True, then either the input model with
     updated metadata or the source catalog model is saved/returned
@@ -143,20 +143,22 @@ def save_all_results(
     output_filename = (
         self.output_file if self.output_file is not None else cat_model.meta.filename
     )
+    save_catalog_results = getattr(self, "save_catalog_results", self.save_results)
 
-    # always save the segmentation image
-    save_segment_image(self, segment_img, cat_model, output_filename, save_debug_info)
+    # save the segmentation image only when results are requested
+    if save_catalog_results:
+        save_segment_image(self, segment_img, cat_model, output_filename, save_debug_info)
 
     # Update the source catalog filename metadata
     self.output_ext = "parquet"
     output_catalog_name = self.make_output_path(basepath=output_filename, suffix="cat")
     self.output_ext = "asdf"
 
-    # Always save the source catalog, but don't save it twice.
-    # If save_results=False or return_updated_model=True, we need to
-    # explicitly save it.
+    # Explicitly save the source catalog only when sidecar saving is enabled and
+    # return_updated_model=True. In this case the returned object is the
+    # input model, so we must write the catalog product here.
     return_updated_model = getattr(self, "return_updated_model", False)
-    if not self.save_results or return_updated_model:
+    if save_catalog_results and return_updated_model:
         self.output_ext = "parquet"
         self.save_model(
             cat_model,
@@ -177,11 +179,16 @@ def save_all_results(
         # overwriting the source catalog file with a datamodel
         self.suffix = "sourcecatalog"
 
-        # update the input datamodel with the tweakreg catalog name
+        # update the input datamodel with source-catalog info for tweakreg
         if isinstance(input_model, ImageModel):
-            input_model.meta.source_catalog = {
-                "tweakreg_catalog_name": output_catalog_name
-            }
+            if save_catalog_results:
+                input_model.meta.source_catalog = {
+                    "tweakreg_catalog_name": output_catalog_name
+                }
+            else:
+                input_model.meta.source_catalog = {
+                    "tweakreg_catalog": cat_model.source_catalog.as_array()
+                }
             input_model.meta.cal_step.source_catalog = "COMPLETE"
 
         result = input_model

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -515,10 +515,7 @@ def test_do_psf_photometry_column_names(function_jail, image_model, fit_psf):
             False,
             True,
             ImageModel,
-            {
-                "cat": ImageSourceCatalogModel,
-                "segm": SegmentationMapModel,
-            },
+            {},
         ),
         (
             20,
@@ -527,10 +524,7 @@ def test_do_psf_photometry_column_names(function_jail, image_model, fit_psf):
             False,
             False,
             ImageSourceCatalogModel,
-            {
-                "cat": ImageSourceCatalogModel,
-                "segm": SegmentationMapModel,
-            },
+            {},
         ),
     ),
 )
@@ -589,6 +583,37 @@ def test_l2_source_catalog_keywords(
             assert isinstance(tbl, pyarrow.Table)
         else:
             assert isinstance(rdm.open(filepath), expected_outputs.get(suffix))
+
+    basefilename = result.meta.filename.split("_")[0]
+    assert Path(function_jail / f"{basefilename}_cat.parquet").exists() == save_results
+    assert Path(function_jail / f"{basefilename}_segm.asdf").exists() == save_results
+
+
+def test_l2_return_updated_model_uses_in_memory_catalog_when_not_saving(
+    image_model,
+    monkeypatch,
+    function_jail,
+):
+    monkeypatch.setattr(
+        SourceCatalogStep, "return_updated_model", True, raising=False
+    )
+
+    result = SourceCatalogStep.call(
+        image_model,
+        bkg_boxsize=50,
+        kernel_fwhm=2.0,
+        snr_threshold=3,
+        npixels=10,
+        save_results=False,
+    )
+
+    assert isinstance(result, ImageModel)
+    assert "tweakreg_catalog" in result.meta.source_catalog
+    assert "tweakreg_catalog_name" not in result.meta.source_catalog
+
+    basefilename = result.meta.filename.split("_")[0]
+    assert not Path(function_jail / f"{basefilename}_cat.parquet").exists()
+    assert not Path(function_jail / f"{basefilename}_segm.asdf").exists()
 
 
 @pytest.mark.parametrize(
@@ -665,10 +690,7 @@ def test_dust_ebv_property_returns_nan_on_failure(monkeypatch):
             False,
             True,
             MosaicModel,
-            {
-                "cat": MosaicSourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
-            },
+            {},
         ),
         (
             20,
@@ -677,10 +699,7 @@ def test_dust_ebv_property_returns_nan_on_failure(monkeypatch):
             False,
             False,
             MosaicSourceCatalogModel,
-            {
-                "cat": MosaicSourceCatalogModel,
-                "segm": MosaicSegmentationMapModel,
-            },
+            {},
         ),
     ),
 )
@@ -735,6 +754,10 @@ def test_l3_source_catalog_keywords(
             assert isinstance(tbl, pyarrow.Table)
         else:
             assert isinstance(rdm.open(filepath), expected_outputs.get(suffix))
+
+    basefilename = result.meta.filename.split("_")[0]
+    assert Path(function_jail / f"{basefilename}_cat.parquet").exists() == save_results
+    assert Path(function_jail / f"{basefilename}_segm.asdf").exists() == save_results
 
 
 @pytest.mark.parametrize(

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -594,9 +594,7 @@ def test_l2_return_updated_model_uses_in_memory_catalog_when_not_saving(
     monkeypatch,
     function_jail,
 ):
-    monkeypatch.setattr(
-        SourceCatalogStep, "return_updated_model", True, raising=False
-    )
+    monkeypatch.setattr(SourceCatalogStep, "return_updated_model", True, raising=False)
 
     result = SourceCatalogStep.call(
         image_model,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1139](https://jira.stsci.edu/browse/RCAL-1139)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR makes `ExposurePipeline` honor `save_results` for source-catalog sidecar products `*_cat.parquet` and `*_segm.asdf`. These files are now created only when `save_results = True`.

### What changed

- Updated `romancal/source_catalog/_save_utils.py` so cat/segm sidecar files are only written when save output is enabled;
    - added a sidecar-save gate via `save_catalog_results` (defaults to `save_results`);
    - segm is now saved only when that gate is `True`;
    - explicit cat save for `return_updated_model = True` is also gated;
    - when not saving sidecars and `return_updated_model = True`, the step now stores an in-memory catalog at `meta.source_catalog.tweakreg_catalog` (instead of a filename), so tweakreg can still consume it without on-disk cat;
- updated `romancal/pipeline/exposure_pipeline.py` to keep pipeline behavior clean:
    - `self.source_catalog.return_updated_model = True` (existing behavior).
    - `self.source_catalog.save_results = False` to avoid writing `*_sourcecatalog.asdf`.
    - `self.source_catalog.save_catalog_results = self.save_results` so cat/segm follow pipeline `save_results`.

### Tests updated

- `romancal/pipeline/tests/test_exposure_pipeline.py`
  - `test_elp_save_results` now expects:
    - `save_results = True`: `test_cal.asdf`, `test_wcs.asdf`, `test_cat.parquet`, `test_segm.asdf`
    - `save_results = False`: no outputs in the output dir.
- `romancal/source_catalog/tests/test_source_catalog.py`
  - updated `test_l2_source_catalog_keywords` and `test_l3_source_catalog_keywords` expectations for `save_results = False` to no cat/segm outputs.
  - added explicit assertions that `*_cat.parquet` and `*_segm.asdf` existence matches `save_results`.
  - added `test_l2_return_updated_model_uses_in_memory_catalog_when_not_saving` to verify:
    - in-memory `tweakreg_catalog` is populated,
    - no `tweakreg_catalog_name`,
    - and no cat/segm files are created.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
