### PR TITLE
Label GWCS transform inputs/outputs to match frame axes names

### DIFF
--- a/changes/2351.assign_wcs.rst
+++ b/changes/2351.assign_wcs.rst
@@ -1,0 +1,1 @@
+Label GWCS transform inputs/outputs to match coordinate frame axes names.

--- a/romancal/assign_wcs/assign_wcs.py
+++ b/romancal/assign_wcs/assign_wcs.py
@@ -64,7 +64,11 @@ def load_wcs(input_model, reference_files=None):
 
     # Transforms between frames
     distortion = _wfi_distortion(output_model, reference_files)
+    distortion.inputs = ("x", "y")
+    distortion.outputs = ("v2", "v3")
     tel2sky = v23tosky(output_model)
+    tel2sky.inputs = ("v2", "v3")
+    tel2sky.outputs = ("ra", "dec")
 
     # Compute differential velocity aberration (DVA) correction:
     va_corr = _dva_corr_model(
@@ -72,6 +76,8 @@ def load_wcs(input_model, reference_files=None):
         v2_ref=input_model.meta.wcsinfo.v2_ref,
         v3_ref=input_model.meta.wcsinfo.v3_ref,
     )
+    va_corr.inputs = ("v2", "v3")
+    va_corr.outputs = ("v2", "v3")
 
     pipeline = [
         Step(detector, distortion),


### PR DESCRIPTION
Closes #2347

Aligns the input/output labels on the three GWCS transforms in `load_wcs` with their coordinate frame axes names, matching the pattern established in JWST (e.g. `jwst/assign_wcs/nirspec.py`).

- `distortion`: inputs=("x", "y"), outputs=("v2", "v3")
- `tel2sky`: inputs=("v2", "v3"), outputs=("ra", "dec")
- `va_corr`: inputs=("v2", "v3"), outputs=("v2", "v3")

No functional change — purely for debugging and traceability.