### PR TITLE
make test compatible with pytest 9.1

### DIFF
--- a/romancal/source_catalog/tests/test_psf.py
+++ b/romancal/source_catalog/tests/test_psf.py
@@ -102,11 +102,13 @@ def add_sources(image_model, psf_model, x_true, y_true, flux_true, background=10
 
 @pytest.mark.parametrize(
     "dx, dy, true_flux",
-    zip(
-        rng.uniform(-1, 1, n_trials),
-        rng.uniform(-1, 1, n_trials),
-        np.geomspace(1_000, 100_000, n_trials),
-        strict=False,
+    list(
+        zip(
+            rng.uniform(-1, 1, n_trials),
+            rng.uniform(-1, 1, n_trials),
+            np.geomspace(1_000, 100_000, n_trials),
+            strict=False,
+        )
     ),
 )
 def test_psf_fit(setup_inputs, dx, dy, true_flux):


### PR DESCRIPTION
pytest 9.1 emits a warning when a `zip` result is used to parameterize a test, causing an error during test collection:
https://github.com/spacetelescope/RegressionTests/actions/runs/27526502510/job/81354791607#step:40:909

This PR passes the `zip` result to `list` to work around the issue.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/27549282617

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
