### PR TITLE
ignore crds context for regtest differences

### DIFF
--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -280,6 +280,7 @@ def ignore_metadata_paths():
         "asdf_library",
         "history",
         "roman.meta.ref_file.crds.version",
+        "roman.meta.ref_file.crds.context",
         "roman.meta.calibration_software_version",
         "roman.cal_logs",
         "roman.meta.cal_logs",

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -501,7 +501,7 @@ class DiffResult:
     def _file_info(file):
         try:
             with rdm.open(file) as model:
-                model_type = model.__class__.__name__
+                model_type = type(model).__name__
                 crds_context = (
                     model.get("meta", {})
                     .get("ref_file", {})

--- a/romancal/regtest/regtestdata.py
+++ b/romancal/regtest/regtestdata.py
@@ -14,6 +14,7 @@ import deepdiff
 import gwcs
 import numpy as np
 import requests
+import roman_datamodels as rdm
 from astropy.units import Quantity
 from ci_watson.artifactory_helpers import (
     BigdataError,
@@ -497,23 +498,33 @@ class DiffResult:
         return not self.diff
 
     @staticmethod
-    def _model_type(file):
-        import roman_datamodels as rdm
-
+    def _file_info(file):
         try:
-            with rdm.open(file) as mdl:
-                return mdl.__class__.__name__
+            with rdm.open(file) as model:
+                model_type = model.__class__.__name__
+                crds_context = (
+                    model.get("meta", {})
+                    .get("ref_file", {})
+                    .get("crds", {})
+                    .get("context", "Unknown context")
+                )
         except Exception:
-            return "Not a model"
+            model_type = "Not a model"
+            crds_context = "Unknown context"
+        return model_type, crds_context
 
     def report(self, **kwargs):
+        result_model_type, result_crds_context = self._file_info(self.result)
+        truth_model_type, truth_crds_context = self._file_info(self.truth)
         title = dedent(
             f"""
             Diff report for:
                 result file: {self.result}
-                    model type: {self._model_type(self.result)}
+                    model type: {result_model_type}
+                    crds_context: {result_crds_context}
                 truth file: {self.truth}
-                    model type: {self._model_type(self.result)}
+                    model type: {truth_model_type}
+                    crds_context: {truth_crds_context}
             """
         )
         report = pprint.pformat(self.diff)

--- a/romancal/regtest/test_regtestdata.py
+++ b/romancal/regtest/test_regtestdata.py
@@ -97,6 +97,40 @@ def test_model_difference(tmp_path):
     )
 
 
+def test_crds_context_difference(tmp_path, ignore_asdf_paths):
+    """
+    Test that a crds context difference is only reported if another difference is found.
+    """
+    ignores = {"ignore": ["roman.meta.filename", *ignore_asdf_paths["ignore"]]}
+    pmap_0 = "roman_1234.pmap"
+    pmap_1 = "roman_5678.pmap"
+    model = rdm.ImageModel.create_fake_data()
+    model.meta.wcs = None
+    model.meta.ref_file.crds.context = pmap_0
+    fn0 = tmp_path / "a.asdf"
+    fn1 = tmp_path / "b.asdf"
+    model.save(fn0)
+
+    # just change context
+    model.meta.ref_file.crds.context = pmap_1
+    model.save(fn1)
+
+    # no difference
+    diff = compare_asdf(fn0, fn1, **ignores)
+    assert diff.identical
+
+    # change one other value
+    model.meta.ref_file.flat = "abc.asdf"
+    model.save(fn1)
+
+    # a difference should be reported
+    diff = compare_asdf(fn0, fn1, **ignores)
+    assert not diff.identical
+    report = diff.report()
+    assert f"crds_context: {pmap_0}" in report
+    assert f"crds_context: {pmap_1}" in report
+
+
 @pytest.mark.parametrize("n_diffs", [1, 3, 7])
 def test_n_diffs(tmp_path, n_diffs):
     fn0 = tmp_path / "test0.asdf"


### PR DESCRIPTION
When new crds contexts become operational they introduce regression tests failures like the following:
https://github.com/spacetelescope/RegressionTests/actions/runs/27574958627/job/81520850070#step:40:5008

As Eddie noted, these are helpful to see when the context change can explain data differences but when no data differences are seen are noise that requires okifying regtests to fix the errors.

This PR switches the compare_asdf logic to:
- ignore roman.meta.ref_file.crds.context
- display the crds contexts of truth and result files in the report (which is shown when the diff fails)

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/27645496881

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
