### PR TITLE
relax tolerances for tvac test

### DIFF
--- a/romancal/regtest/test_elp_tvac.py
+++ b/romancal/regtest/test_elp_tvac.py
@@ -62,7 +62,11 @@ def truth_filename(run_elp):
 
 def test_output_matches_truth(output_filename, truth_filename, ignore_asdf_paths):
     ignore_asdf_paths["ignore"].append("roman.meta.ref_file.dark")
-    diff = compare_asdf(output_filename, truth_filename, **ignore_asdf_paths)
+    rtol = 1e-5
+    atol = 1e-1
+    diff = compare_asdf(
+        output_filename, truth_filename, rtol=rtol, atol=atol, **ignore_asdf_paths
+    )
     assert diff.identical, diff.report()
 
 


### PR DESCRIPTION
Relax tvac test output to truth comparisons to allow test to pass on python 3.11 through 3.13 (3.14 can't be tested since lephare does not yet have a published 3.14 wheel). Where on 3.11 we are not getting the latest numpy.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/27982398735

I previously mentioned dropping 3.11 support but given the issues we have with getting a complete 3.14 environment and that we don't expect the same level of numerical stability of tvac processing relaxing tolerances seemed like the first option to explore.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
