### PR TITLE
switch roman_datamodels dependency back to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     # the roman_datamodels pin to the released version. If there
     # is a need to change this to main then we need a new
     # roman_datamodels release.
-    "roman_datamodels>=1.0,<1.1",
-    # "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels@main",
+    # "roman_datamodels>=1.0,<1.1",
+    "roman_datamodels@git+https://github.com/spacetelescope/roman_datamodels@main",
     "romanisim>=0.14,<0.15",
     # "romanisim@git+https://github.com/spacetelescope/romanisim@main",
     "asdf>=4.1.0,<6",


### PR DESCRIPTION
This is largely to pick up:
https://github.com/spacetelescope/rad/pull/893
to allow okifying regtests with the expected differences to allow further development on rad and rdm.

Regtests:
https://github.com/spacetelescope/RegressionTests/actions/runs/28886088005
shows only the expected differences from the above linked rad PR.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
