### PR TITLE
Fix ELP output when provided an association or model

### DIFF
--- a/changes/2384.exposure_pipeline.rst
+++ b/changes/2384.exposure_pipeline.rst
@@ -1,0 +1,1 @@
+Fix output file suffix when exposure pipeline is run with an association or ``ModelLibrary``.

--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -208,6 +208,7 @@ class ExposurePipeline(RomanPipeline):
         )
 
     def save_model(self, model, **kwargs):
+        suffix = kwargs.get("suffix", None)
         # depending on model set suffix and ext
         if isinstance(
             model,
@@ -217,12 +218,18 @@ class ExposurePipeline(RomanPipeline):
             ),
         ):
             kwargs["ext"] = "parquet"
-            kwargs["suffix"] = kwargs.get("suffix", "cat")
+            if suffix is None:
+                suffix = "cat"
         elif isinstance(model, rdm.SegmentationMapModel):
+            if suffix is None:
+                suffix = "segm"
             kwargs["suffix"] = kwargs.get("suffix", "segm")
         elif isinstance(model, rdm.ImageModel):
             save_wfiwcs(self, model, force=True)
-            kwargs["suffix"] = kwargs.get("suffix", self.suffix)
+            if suffix is None:
+                suffix = self.suffix
+
+        kwargs["suffix"] = suffix
 
         # strip the index since these all have different extensions
         kwargs.pop("idx", None)

--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -28,29 +28,27 @@ def fake_science_raw():
 
 
 @pytest.fixture(scope="function")
-def input_value(request, tmp_path):
-    model = rdm.RampModel.create_fake_data(shape=(2, 20, 20))
-    model.meta.exposure.start_time = Time(
-        "2024-01-03T00:00:00.0", format="isot", scale="utc"
-    )
+def input_value(request, tmp_path, fake_science_raw):
     match request.param:
         case "datamodel_fn":
-            fn = tmp_path / "model.asdf"
-            model.save(fn)
+            fn = tmp_path / "test_uncal.asdf"
+            fake_science_raw.save(fn)
             return fn
         case "datamodel":
-            return model
+            return fake_science_raw
         case "asn_fn":
-            model.meta.filename = "foo.asdf"
-            model.save(tmp_path / model.meta.filename)
-            asn = asn_from_list([model.meta.filename], product_name="foo_out")
+            fake_science_raw.meta.filename = "test_uncal.asdf"
+            fake_science_raw.save(tmp_path / fake_science_raw.meta.filename)
+            asn = asn_from_list(
+                [fake_science_raw.meta.filename], product_name="foo_out"
+            )
             base_fn, contents = asn.dump()
             asn_filename = tmp_path / base_fn
             with open(asn_filename, "w") as f:
                 f.write(contents)
             return asn_filename
         case "library":
-            return ModelLibrary([model])
+            return ModelLibrary([fake_science_raw])
         case value:
             raise Exception(f"Invalid parametrization: {value}")
 
@@ -73,14 +71,21 @@ def test_input_to_output(function_jail, input_value, expected_output_type):
     pipeline = ExposurePipeline()
     # don't fetch references
     pipeline.prefetch_references = False
-    # skip all steps
-    [setattr(getattr(pipeline, k), "skip", True) for k in pipeline.step_defs]
+    # skip all steps except dq_init to allow the input ScienceRawModel to be converted to a RampModel
+    [
+        setattr(getattr(pipeline, k), "skip", True)
+        for k in pipeline.step_defs
+        if k != "dq_init"
+    ]
     output_value, _, _ = pipeline.run(input_value)
     assert isinstance(output_value, expected_output_type)
 
 
+@pytest.mark.parametrize(
+    "input_value", ["datamodel", "datamodel_fn", "asn_fn", "library"], indirect=True
+)
 @pytest.mark.parametrize("save_results", [True, False])
-def test_elp_save_results(function_jail, fake_science_raw, save_results, monkeypatch):
+def test_elp_save_results(function_jail, input_value, save_results, monkeypatch):
     """
     Test that the elp respects save_results.
     """
@@ -93,10 +98,11 @@ def test_elp_save_results(function_jail, fake_science_raw, save_results, monkeyp
 
     # don't try to actually run tweakreg as it will fail for an empty model
     monkeypatch.setattr(pipeline.tweakreg, "run", lambda init: init)
+    allowed_files = set(p.name for p in function_jail.iterdir())
 
-    pipeline.run(fake_science_raw)
+    pipeline.run(input_value)
     # check that the current directory doesn't contain extra files
-    assert set(p.name for p in function_jail.iterdir()) == {"output"}
+    assert len(set(p.name for p in function_jail.iterdir()) - allowed_files) == 0
 
     output_files = set(p.name for p in output_path.iterdir())
     if save_results:


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2383

On main when the ELP is run with an association or library as input it produces segmentation map files with a "cal" suffix (see #2383).

This PR modifies the custom `save_model` to fix the suffix handling and adds unit tests that cover this condition.

Regression tests:
https://github.com/spacetelescope/RegressionTests/actions/runs/29111640291/job/86425147635
all passed

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
