### PR TITLE
switch check in elp to use result instead of model

### DIFF
--- a/romancal/pipeline/exposure_pipeline.py
+++ b/romancal/pipeline/exposure_pipeline.py
@@ -120,7 +120,7 @@ class ExposurePipeline(RomanPipeline):
 
                 if not self.tweakreg.skip and catalog is not None:
                     # attach the catalog to the model so tweakreg can see it
-                    if "source_catalog" not in model.meta:
+                    if "source_catalog" not in result.meta:
                         result.meta["source_catalog"] = {}
                     result.meta.source_catalog.tweakreg_catalog = catalog.source_catalog
 


### PR DESCRIPTION
While working on some related changes I noticed that the elp is accessing `model` (the input model, which may be closed) instead of `result` when checking the `source_catalog` sub-tree. This PR switches the access to use `result`. I don't think by itself the code on main can cause an issue with current asdf and roman_datamodels but it seems more correct to use `result` (and if we change how roman_datamodels handles a closed asdf file the code on main could be problematic).

Regression tests:
https://github.com/spacetelescope/RegressionTests/actions/runs/29345171004/job/87126875995

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
