### PR TITLE
Add read pattern test

### DIFF
--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -361,6 +361,35 @@ def test_source_catalog_populates_dust_ebv(model_fixture, request, function_jail
     assert cat["dust_ebv"].dtype == np.float32
 
 
+def test_nested_metadata_propagated_to_catalog_and_segmentation(
+    image_model, function_jail
+):
+    """
+    Nested (list-of-list) metadata such as ``meta.exposure.read_pattern``
+    should be propagated to both the source catalog and segmentation map
+    models.  Regression test for the value being silently emptied while the
+    scalar metadata around it copied fine.
+    """
+    read_pattern = [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10]]
+    image_model.meta.exposure.read_pattern = read_pattern
+
+    result_catalog, result_segmentation_map = SourceCatalogStep.call(
+        image_model,
+        bkg_boxsize=50,
+        kernel_fwhm=2.0,
+        snr_threshold=5,
+        npixels=10,
+        save_results=False,
+        fit_psf=False,
+    )
+
+    assert isinstance(result_catalog, ImageSourceCatalogModel)
+    assert isinstance(result_segmentation_map, SegmentationMapModel)
+
+    for result in (result_catalog, result_segmentation_map):
+        assert [list(r) for r in result.meta.exposure.read_pattern] == read_pattern
+
+
 def test_l2_input_model_unchanged(image_model, function_jail):
     """
     Test that the input model data and error arrays are unchanged after

--- a/romancal/source_catalog/tests/test_source_catalog.py
+++ b/romancal/source_catalog/tests/test_source_catalog.py
@@ -367,8 +367,7 @@ def test_nested_metadata_propagated_to_catalog_and_segmentation(
     """
     Nested (list-of-list) metadata such as ``meta.exposure.read_pattern``
     should be propagated to both the source catalog and segmentation map
-    models.  Regression test for the value being silently emptied while the
-    scalar metadata around it copied fine.
+    models.
     """
     read_pattern = [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10]]
     image_model.meta.exposure.read_pattern = read_pattern


### PR DESCRIPTION
This PR adds a new test to make sure that read_pattern is propagated into catalogs / segmentation maps.  It is a nested arrays and so there is some roman_datamodels handling that can cause problems.

Only adds a unit test (which should fail).  Regtests pointing to https://github.com/spacetelescope/roman_datamodels/pull/692 should pass:
https://github.com/spacetelescope/RegressionTests/actions/runs/29610396350

Marking this no changelog entry needed since it only changes test code.  I'll hold this in draft until the corresponding roman_datamodels PR is merged.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [X] update or add relevant tests
  - [X] update relevant docstrings and / or `docs/` page
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
