### PR TITLE
Add support for `Step.call(association_dict)`

### DIFF
--- a/changes/2393.general.rst
+++ b/changes/2393.general.rst
@@ -1,0 +1,1 @@
+Allow passing association dictionaries to steps that support associations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # "stcal>=1.18.0,<2",
     "stcal@git+https://github.com/spacetelescope/stcal@main",
     # "stpipe>=0.11.0,<2",
-    "stpipe@git+https://github.com/braingram/stpipe@simplify_parameter_handling",
+    "stpipe@git+https://github.com/spacetelescope/stpipe@main",
     "spherical-geometry>=1.4.0,<1.5",
     "tweakwcs>=0.9.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "gwcs>=1.0.1,<2",
     # "stcal>=1.18.0,<2",
     "stcal@git+https://github.com/spacetelescope/stcal@main",
-    "stpipe>=0.11.0,<2",
+    # "stpipe>=0.11.0,<2",
+    "stpipe@git+https://github.com/braingram/stpipe@simplify_parameter_handling",
     "spherical-geometry>=1.4.0,<1.5",
     "tweakwcs>=0.9.0",
 ]

--- a/romancal/conftest.py
+++ b/romancal/conftest.py
@@ -122,14 +122,17 @@ class TestDescriptionPlugin:
 
 @pytest.fixture(scope="function")
 def create_mock_asn_file():
-    def _create_asn_file(tmp_path: str, members_mapping: dict | None = None) -> str:
+    def _create_asn_file(
+        tmp_path: str | None, members_mapping: dict | None = None
+    ) -> str:
         """
         Create a mock association file with the provided members mapping.
 
         Parameters
         ----------
-        tmp_path : str
+        tmp_path : str or None
             Path to the temporary directory to store the association file.
+            If None return association dictionary.
         members_mapping : list, optional
             Mapping of members to include in the association file (default: None).
 
@@ -173,6 +176,9 @@ def create_mock_asn_file():
             for x in members_mapping:
                 asn_dict["products"][0]["members"].append(x)
             asn_content = json.dumps(asn_dict)
+
+        if tmp_path is None:
+            return json.loads(asn_content)
 
         asn_file_path = str(tmp_path / "sample_asn.json")
         asn_file = StringIO()

--- a/romancal/datamodels/filetype.py
+++ b/romancal/datamodels/filetype.py
@@ -1,5 +1,6 @@
 import io
 import os
+from collections.abc import MutableMapping
 from pathlib import Path
 
 import roman_datamodels as rdm
@@ -49,6 +50,9 @@ def check(init: os.PathLike | Path | io.FileIO) -> str:
 
     elif isinstance(init, ModelLibrary):
         return "ModelLibrary"
+
+    elif isinstance(init, MutableMapping):
+        return "asn"
 
     elif hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)

--- a/romancal/datamodels/tests/test_fileio.py
+++ b/romancal/datamodels/tests/test_fileio.py
@@ -1,3 +1,5 @@
+import json
+import os
 from contextlib import nullcontext
 
 import pytest
@@ -36,6 +38,18 @@ def library_filename(library, tmp_path):
 
 
 @pytest.fixture()
+def association_dict(library_filename, tmp_path):
+    with open(library_filename) as f:
+        asn = json.load(f)
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        yield asn
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.fixture()
 def list_of_models(model):
     return [model]
 
@@ -54,6 +68,7 @@ def list_of_filenames(model_filename):
         ("library", "ModelLibrary", ModelLibrary),
         ("model_filename", "asdf", rdm.DataModel),
         ("library_filename", "asn", ModelLibrary),
+        ("association_dict", "asn", ModelLibrary),
         ("list_of_models", "unknown", ModelLibrary),
         ("list_of_filenames", "unknown", ModelLibrary),
     ],
@@ -86,6 +101,7 @@ def test_open_dataset(
     [
         ("model_filename", False),
         ("library_filename", True),
+        ("association_dict", True),
         ("list_of_models", False),
         ("list_of_filenames", False),
     ],
@@ -119,6 +135,7 @@ def test_open_kwargs(dataset_fixture_name, expect_on_disk, monkeypatch, request)
     [
         "model",
         "model_filename",
+        "association_dict",
         "library_filename",
         "list_of_filenames",
     ],

--- a/romancal/datamodels/tests/test_filetype.py
+++ b/romancal/datamodels/tests/test_filetype.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -8,41 +9,66 @@ from romancal.datamodels import ModelLibrary, filetype
 DATA_DIRECTORY = Path(__file__).parent / "data"
 
 
-def test_filetype():
-    file_1 = filetype.check(DATA_DIRECTORY / "empty.json")
-    file_2 = filetype.check(DATA_DIRECTORY / "example_schema.json")
-    with open(DATA_DIRECTORY / "fake.json") as file_h:
-        file_3 = filetype.check(file_h)
-    file_4 = filetype.check(DATA_DIRECTORY / "empty.asdf")
-    file_5 = filetype.check(DATA_DIRECTORY / "pluto.asdf")
-    with open(DATA_DIRECTORY / "pluto.asdf", "rb") as file_h:
-        file_6 = filetype.check(file_h)
-    file_7 = filetype.check(DATA_DIRECTORY / "fake.asdf")
-    with open(DATA_DIRECTORY / "fake.json") as file_h:
-        file_8 = filetype.check(file_h)
-    file_9 = filetype.check(str(DATA_DIRECTORY / "pluto.asdf"))
-    im1 = rdm.datamodels.ImageModel.create_fake_data(shape=(20, 20))
-    file_11 = filetype.check(im1)
-    model_library = ModelLibrary([im1])
-    file_10 = filetype.check(model_library)
+@pytest.fixture
+def model():
+    model = rdm.datamodels.ImageModel.create_fake_data(shape=(20, 20))
+    model.meta.filename = "test.asdf"
+    return model
 
-    assert file_1 == "asn"
-    assert file_2 == "asn"
-    assert file_3 == "asn"
-    assert file_4 == "asdf"
-    assert file_5 == "asdf"
-    assert file_6 == "asdf"
-    assert file_7 == "asdf"
-    assert file_8 == "asn"
-    assert file_9 == "asdf"
-    assert file_10 == "ModelLibrary"
-    assert file_11 == "DataModel"
 
+@pytest.fixture
+def model_filename(model, tmp_path):
+    fn = tmp_path / "test.asdf"
+    model.save(fn)
+    return fn
+
+
+@pytest.fixture
+def model_file_handle(model_filename):
+    with open(model_filename, "rb") as fh:
+        yield fh
+
+
+@pytest.fixture
+def library(model):
+    return ModelLibrary([model])
+
+
+@pytest.fixture
+def association_filename(library, function_jail):
+    return library._save(function_jail)
+
+
+@pytest.fixture
+def association_file_handle(association_filename):
+    with open(association_filename) as fh:
+        yield fh
+
+
+@pytest.fixture
+def association_dict(association_filename):
+    with open(association_filename) as f:
+        asn = json.load(f)
+    return asn
+
+
+@pytest.mark.parametrize(
+    "init_fixture, expected",
+    [
+        ("model", "DataModel"),
+        ("model_filename", "asdf"),
+        ("model_file_handle", "asdf"),
+        ("library", "ModelLibrary"),
+        ("association_filename", "asn"),
+        ("association_file_handle", "asn"),
+        ("association_dict", "asn"),
+    ],
+)
+def test_filetype(init_fixture, expected, request):
+    assert filetype.check(request.getfixturevalue(init_fixture)) == expected
+
+
+@pytest.mark.parametrize("init_value", [2, "missing.txt", "test"])
+def test_failures(init_value, function_jail):
     with pytest.raises(ValueError):
-        filetype.check(DATA_DIRECTORY / "empty.txt")
-
-    with pytest.raises(ValueError):
-        filetype.check(2)
-
-    with pytest.raises(ValueError):
-        filetype.check("test")
+        filetype.check(init_value)

--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -18,7 +18,33 @@ def test_outlier_skips_step_on_invalid_number_of_elements_in_input(base_image):
             res.shelve(m, i, modify=False)
 
 
-def test_outlier_valid_input_asn(tmp_path, base_image, create_mock_asn_file):
+def test_outlier_valid_input_asn(function_jail, base_image, create_mock_asn_file):
+    """
+    Test that OutlierDetection runs with valid ASN as input.
+    """
+    img_1 = base_image()
+    img_1.meta.filename = "img_1.asdf"
+    img_1.save(function_jail / "img_1.asdf")
+    img_2 = base_image()
+    img_1.meta.filename = "img_2.asdf"
+    img_2.save(function_jail / "img_2.asdf")
+
+    asn = create_mock_asn_file(None)
+
+    res = OutlierDetectionStep(
+        output_dir=function_jail.as_posix(),
+        in_memory=True,
+        resample_data=False,
+    ).run(asn)
+
+    # assert step.skip is False
+    with res:
+        for i, m in enumerate(res):
+            assert m.meta.cal_step.outlier_detection == "COMPLETE"
+            res.shelve(m, i, modify=False)
+
+
+def test_outlier_valid_input_asn_filename(tmp_path, base_image, create_mock_asn_file):
     """
     Test that OutlierDetection runs with valid ASN file as input.
     """
@@ -44,7 +70,7 @@ def test_outlier_valid_input_asn(tmp_path, base_image, create_mock_asn_file):
             res.shelve(m, i, modify=False)
 
 
-def test_outlier_valid_input_modelcontainer(tmp_path, base_image):
+def test_outlier_valid_input_modellibrary(tmp_path, base_image):
     """
     Test that OutlierDetection runs with valid ModelLibrary as input.
     """
@@ -212,11 +238,12 @@ def test_identical_images(tmp_path, base_image, caplog):
     [
         "ModelLibrary",
         "ASNFile",
+        "ASN",
         "DataModelList",
         "ASDFFilenameList",
     ],
 )
-def test_outlier_detection_always_returns_modelcontainer_with_updated_datamodels(
+def test_outlier_detection_always_returns_modellibrary_with_updated_datamodels(
     input_type,
     base_image,
     create_mock_asn_file,
@@ -239,6 +266,13 @@ def test_outlier_detection_always_returns_modelcontainer_with_updated_datamodels
         "ModelLibrary": library,
         "ASNFile": create_mock_asn_file(
             function_jail,
+            members_mapping=[
+                {"expname": img_1.meta.filename, "exptype": "science"},
+                {"expname": img_2.meta.filename, "exptype": "science"},
+            ],
+        ),
+        "ASN": create_mock_asn_file(
+            None,
             members_mapping=[
                 {"expname": img_1.meta.filename, "exptype": "science"},
                 {"expname": img_2.meta.filename, "exptype": "science"},

--- a/romancal/outlier_detection/tests/test_outlier_detection.py
+++ b/romancal/outlier_detection/tests/test_outlier_detection.py
@@ -18,9 +18,12 @@ def test_outlier_skips_step_on_invalid_number_of_elements_in_input(base_image):
             res.shelve(m, i, modify=False)
 
 
-def test_outlier_valid_input_asn(function_jail, base_image, create_mock_asn_file):
+@pytest.mark.parametrize("as_filename", [True, False])
+def test_outlier_valid_input_asn(
+    function_jail, as_filename, base_image, create_mock_asn_file
+):
     """
-    Test that OutlierDetection runs with valid ASN as input.
+    Test that OutlierDetection runs with valid ASN input.
     """
     img_1 = base_image()
     img_1.meta.filename = "img_1.asdf"
@@ -29,41 +32,14 @@ def test_outlier_valid_input_asn(function_jail, base_image, create_mock_asn_file
     img_1.meta.filename = "img_2.asdf"
     img_2.save(function_jail / "img_2.asdf")
 
-    asn = create_mock_asn_file(None)
+    dataset = create_mock_asn_file(function_jail if as_filename else None)
 
     res = OutlierDetectionStep(
         output_dir=function_jail.as_posix(),
         in_memory=True,
         resample_data=False,
-    ).run(asn)
+    ).run(dataset)
 
-    # assert step.skip is False
-    with res:
-        for i, m in enumerate(res):
-            assert m.meta.cal_step.outlier_detection == "COMPLETE"
-            res.shelve(m, i, modify=False)
-
-
-def test_outlier_valid_input_asn_filename(tmp_path, base_image, create_mock_asn_file):
-    """
-    Test that OutlierDetection runs with valid ASN file as input.
-    """
-    img_1 = base_image()
-    img_1.meta.filename = "img_1.asdf"
-    img_1.save(tmp_path / "img_1.asdf")
-    img_2 = base_image()
-    img_1.meta.filename = "img_2.asdf"
-    img_2.save(tmp_path / "img_2.asdf")
-
-    asn_filepath = create_mock_asn_file(tmp_path)
-
-    res = OutlierDetectionStep(
-        output_dir=tmp_path.as_posix(),
-        in_memory=True,
-        resample_data=False,
-    ).run(asn_filepath)
-
-    # assert step.skip is False
     with res:
         for i, m in enumerate(res):
             assert m.meta.cal_step.outlier_detection == "COMPLETE"

--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -36,6 +36,12 @@ def input_value(request, tmp_path, fake_science_raw):
             return fn
         case "datamodel":
             return fake_science_raw
+        case "asn":
+            fake_science_raw.meta.filename = "test_uncal.asdf"
+            fake_science_raw.save(tmp_path / fake_science_raw.meta.filename)
+            return dict(
+                asn_from_list([fake_science_raw.meta.filename], product_name="foo_out")
+            )
         case "asn_fn":
             fake_science_raw.meta.filename = "test_uncal.asdf"
             fake_science_raw.save(tmp_path / fake_science_raw.meta.filename)
@@ -58,6 +64,7 @@ def input_value(request, tmp_path, fake_science_raw):
     [
         ("datamodel_fn", rdm.DataModel),
         ("datamodel", rdm.DataModel),
+        ("asn", ModelLibrary),
         ("asn_fn", ModelLibrary),
         ("library", ModelLibrary),
     ],
@@ -82,7 +89,9 @@ def test_input_to_output(function_jail, input_value, expected_output_type):
 
 
 @pytest.mark.parametrize(
-    "input_value", ["datamodel", "datamodel_fn", "asn_fn", "library"], indirect=True
+    "input_value",
+    ["datamodel", "datamodel_fn", "asn", "asn_fn", "library"],
+    indirect=True,
 )
 @pytest.mark.parametrize("save_results", [True, False])
 def test_elp_save_results(function_jail, input_value, save_results, monkeypatch):

--- a/romancal/skymatch/tests/test_skymatch.py
+++ b/romancal/skymatch/tests/test_skymatch.py
@@ -397,6 +397,7 @@ def test_skymatch_2x(wfi_rate, skymethod, subtract):
     [
         "ModelLibrary",
         "ASNFile",
+        "ASN",
         "DataModelList",
         "ASDFFilenameList",
     ],
@@ -423,6 +424,16 @@ def test_skymatch_always_returns_modellibrary_with_updated_datamodels(
 
     step_input_map = {
         "ModelLibrary": library,
+        "ASN": create_mock_asn_file(
+            None,
+            members_mapping=[
+                {"expname": im1a.meta.filename, "exptype": "science"},
+                {"expname": im1b.meta.filename, "exptype": "science"},
+                {"expname": im2a.meta.filename, "exptype": "science"},
+                {"expname": im2b.meta.filename, "exptype": "science"},
+                {"expname": im3.meta.filename, "exptype": "science"},
+            ],
+        ),
         "ASNFile": create_mock_asn_file(
             function_jail,
             members_mapping=[


### PR DESCRIPTION
Closes https://github.com/spacetelescope/romancal/issues/2392

Add support for `Step.call(association_dict)`.

Regtests:
https://github.com/spacetelescope/RegressionTests/actions/runs/29836247328

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
