### PR TITLE
fix flux test dtypes

### DIFF
--- a/romancal/flux/tests/test_flux_step.py
+++ b/romancal/flux/tests/test_flux_step.py
@@ -89,10 +89,17 @@ def image_model():
     rng = np.random.default_rng()
     shape = (10, 10)
     image_model = datamodels.ImageModel.create_fake_data(shape=shape)
-    image_model.data = rng.poisson(2.5, size=shape).astype(np.float32)
-    image_model.var_rnoise = rng.normal(1, 0.05, size=shape).astype(np.float32)
-    image_model.var_poisson = rng.poisson(1, size=shape).astype(np.float32)
-    image_model.var_flat = rng.uniform(0, 1, size=shape).astype(np.float32)
+    image_model.data = rng.poisson(2.5, size=shape).astype(image_model.data.dtype)
+    # var_* other than poisson are optional, use var_poisson dtype
+    image_model.var_rnoise = rng.normal(1, 0.05, size=shape).astype(
+        image_model.var_poisson.dtype
+    )
+    image_model.var_poisson = rng.poisson(1, size=shape).astype(
+        image_model.var_poisson.dtype
+    )
+    image_model.var_flat = rng.uniform(0, 1, size=shape).astype(
+        image_model.var_poisson.dtype
+    )
     image_model.meta.photometry.conversion_megajanskys = (2.0 * u.MJy / u.sr).value
     image_model.meta.cal_step = {}
     for step_name in image_model.schema_info("required")["roman"]["meta"]["cal_step"][
@@ -100,6 +107,8 @@ def image_model():
     ].info:
         image_model.meta.cal_step[step_name] = "INCOMPLETE"
     image_model.meta.cal_logs = []
+    # validate the above modifications
+    image_model.validate()
 
     return image_model
 


### PR DESCRIPTION
I noticed the flux_step tests were using invalid datatypes.

This fixes the datatypes. No regtests were run as this is only a unit test change.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
