### PR TITLE
Remove broken pytest-astropy meta-package

### DIFF
--- a/changes/2405.general.rst
+++ b/changes/2405.general.rst
@@ -1,8 +1,2 @@
-Replace the ``pytest-astropy`` test dependency with the ``pytest-cov`` and
-``pytest-doctestplus`` sub-packages that are actually used. As of 0.12.0 the
-``pytest-astropy`` meta-package pulls in ``pytest-skip-slow``, whose ``--slow``
-command-line option collides with the one provided by ``ci-watson``, causing
-pytest to fail at plugin-load time before collecting any tests. Dropping the
-meta-package also removes a second ``slow`` marker gate that required
-``--run-slow`` in addition to ``--slow``, so ``--slow`` now behaves as
-documented.
+Depend on ``pytest-cov`` and ``pytest-doctestplus`` directly; ``pytest-astropy``
+0.12.0 pulls in a ``--slow`` option that collides with ``ci-watson``.

--- a/changes/2405.general.rst
+++ b/changes/2405.general.rst
@@ -1,0 +1,8 @@
+Replace the ``pytest-astropy`` test dependency with the ``pytest-cov`` and
+``pytest-doctestplus`` sub-packages that are actually used. As of 0.12.0 the
+``pytest-astropy`` meta-package pulls in ``pytest-skip-slow``, whose ``--slow``
+command-line option collides with the one provided by ``ci-watson``, causing
+pytest to fail at plugin-load time before collecting any tests. Dropping the
+meta-package also removes a second ``slow`` marker gate that required
+``--run-slow`` in addition to ``--slow``, so ``--slow`` now behaves as
+documented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ docs = [
 test = [
     "ci-watson>=0.11.0",
     "pytest>=9.0",
-    "pytest-astropy>=0.11.0",
+    # only the parts of pytest-astropy we actually use; the meta-package
+    # pulls in pytest-skip-slow, whose --slow flag collides with ci-watson's
+    "pytest-cov>=2.3.1",
+    "pytest-doctestplus>=1.0.0",
     "pysiaf>=0.13.0",
     "deepdiff",
     "stpreview>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,6 @@ docs = [
 test = [
     "ci-watson>=0.11.0",
     "pytest>=9.0",
-    # only the parts of pytest-astropy we actually use; the meta-package
-    # pulls in pytest-skip-slow, whose --slow flag collides with ci-watson's
     "pytest-cov>=2.3.1",
     "pytest-doctestplus>=1.0.0",
     "pysiaf>=0.13.0",


### PR DESCRIPTION
CI has started failing due to an update to pytest-astropy.  @pllim recommends trying to directly add the underlying pytest dependencies.  This PR starts trying that.

The one test failure is unrelated and has to do with float16 var_poisson; I'll address that separately.

Regtest started here: https://github.com/spacetelescope/RegressionTests/actions/runs/30936017368 .

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
