### PR TITLE
Seed the flux test RNG and set float16-appropriate allclose tolerances

### DIFF
--- a/changes/2406.flux.rst
+++ b/changes/2406.flux.rst
@@ -1,0 +1,3 @@
+Seed the flux test RNG and set comparison tolerances appropriate to float16,
+fixing an intermittent failure when scaled-down variances underflow to
+subnormal.

--- a/romancal/flux/tests/test_flux_step.py
+++ b/romancal/flux/tests/test_flux_step.py
@@ -43,7 +43,12 @@ def test_attributes(flux_step, attr, factor):
             original_value = getattr(original_model, attr)
             result_value = getattr(result_model, attr)
 
-            assert np.allclose(original_value * scale, result_value)
+            # Tolerances are set for float16, the dtype of err and the
+            # variances: rtol is ~eps and atol covers subnormal rounding,
+            # which small scaled-down values underflow into.
+            assert np.allclose(
+                original_value * scale, result_value, rtol=1e-3, atol=1e-7
+            )
 
             original_library.shelve(original_model, i, modify=False)
             result_library.shelve(result_model, i, modify=False)
@@ -86,7 +91,7 @@ def flux_step(request):
 def image_model():
     """Product a basic ImageModel"""
     # Create a random image and specify a conversion
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(42)
     shape = (10, 10)
     image_model = datamodels.ImageModel.create_fake_data(shape=shape)
     image_model.data = rng.poisson(2.5, size=shape).astype(image_model.data.dtype)


### PR DESCRIPTION
We occasionally get random test failures in the test_flux_step test.  This is because the default tolerances are too tight for the new float16s, and sometimes we get a bad random seed and hit the issue.  This PR fixes the random seed and makes teh tolerances more forgiving.

This PR only touches a unit test and accordingly doesn't need regtests / docs.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
