### PR TITLE
Optionally populate tweakreg_catalog in associations made with asn_from_list

### DIFF
--- a/changes/2408.associations.rst
+++ b/changes/2408.associations.rst
@@ -1,0 +1,2 @@
+Add a provisional ``asn_from_list`` option that records source catalog names in
+association members, so that tweakreg can be run on already calibrated images.

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -67,16 +67,13 @@ def _add_tweakreg_catalogs(asn):
     """Add a source catalog name to every member of an association.
 
     ``tweakreg`` uses a member's ``tweakreg_catalog`` attribute as the
-    source catalog for that member. Setting it here allows ``tweakreg``
-    to be run on already calibrated images, which no longer carry the
-    catalog name in their own metadata.
+    source catalog for that member.  This function guesses default names
+    for catalogs from image file names, so that associations can be
+    generated including references to the corresponding catalogs.
 
     Catalog names are derived from each member's ``expname`` by replacing
     the known suffix with the ``cat`` suffix, so ``x_cal.asdf`` becomes
-    ``x_cat.parquet``. Names are relative, matching how the catalog name
-    was previously stored in image metadata.
-
-    This is provisional and may change.
+    ``x_cat.parquet``.
 
     Parameters
     ----------
@@ -221,10 +218,7 @@ def _cli(args=None):
         "--_tweakreg-catalogs",
         action="store_true",
         dest="_tweakreg_catalogs",
-        help=(
-            "Add a source catalog name to each member so that tweakreg can be"
-            " run on already calibrated images. Provisional; may change."
-        ),
+        help="Add a source catalog name to each member, inferred from image name.",
     )
 
     parser.add_argument(

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -51,11 +51,40 @@ def asn_from_list(items, rule=DMS_ELPP_Base, **kwargs):
     if kwargs.get("psf_match_reference_filter") is not None:
         asn["psf_match_reference_filter"] = kwargs["psf_match_reference_filter"]
 
+    if kwargs.get("_tweakreg_catalogs"):
+        _add_tweakreg_catalogs(asn)
+
     # Always set data_release_id; default to 'p' if not provided
     asn["data_release_id"] = kwargs.get("data_release_id", "p")
     asn = _create_ordered_meta(asn)
 
     return asn
+
+
+def _add_tweakreg_catalogs(asn):
+    """Add a source catalog name to every member of an association.
+
+    ``tweakreg`` uses a member's ``tweakreg_catalog`` attribute as the
+    source catalog for that member. Setting it here allows ``tweakreg``
+    to be run on already calibrated images, which no longer carry the
+    catalog name in their own metadata.
+
+    Catalog names are derived from each member's ``expname`` by replacing
+    the final suffix with the ``cat`` suffix, so ``x_cal.asdf`` becomes
+    ``x_cat.parquet``. Names are relative, matching how the catalog name
+    was previously stored in image metadata.
+
+    This is provisional and may change.
+
+    Parameters
+    ----------
+    asn : Association
+        The association to modify in place.
+    """
+    for product in asn["products"]:
+        for member in product["members"]:
+            stem = member["expname"].rsplit("_", 1)[0]
+            member["tweakreg_catalog"] = f"{stem}_cat.parquet"
 
 
 def _create_ordered_meta(asn):
@@ -186,6 +215,16 @@ def _cli(args=None):
     )
 
     parser.add_argument(
+        "--_tweakreg-catalogs",
+        action="store_true",
+        dest="_tweakreg_catalogs",
+        help=(
+            "Add a source catalog name to each member so that tweakreg can be"
+            " run on already calibrated images. Provisional; may change."
+        ),
+    )
+
+    parser.add_argument(
         "filelist",
         type=str,
         nargs="+",
@@ -215,6 +254,7 @@ def _cli(args=None):
             target=parsed.target,
             data_release_id=parsed.data_release_id,
             psf_match_reference_filter=parsed.psf_match_reference_filter,
+            _tweakreg_catalogs=parsed._tweakreg_catalogs,
         )
         _, serialized = asn.dump()
         outfile.write(serialized)

--- a/romancal/associations/asn_from_list.py
+++ b/romancal/associations/asn_from_list.py
@@ -4,8 +4,10 @@ import argparse
 import sys
 import warnings
 from collections import OrderedDict
+from pathlib import Path
 
 from romancal.associations.lib._rules_elpp_base import DMS_ELPP_Base
+from romancal.lib.suffix import replace_suffix
 
 __all__ = ["asn_from_list"]
 
@@ -70,7 +72,7 @@ def _add_tweakreg_catalogs(asn):
     catalog name in their own metadata.
 
     Catalog names are derived from each member's ``expname`` by replacing
-    the final suffix with the ``cat`` suffix, so ``x_cal.asdf`` becomes
+    the known suffix with the ``cat`` suffix, so ``x_cal.asdf`` becomes
     ``x_cat.parquet``. Names are relative, matching how the catalog name
     was previously stored in image metadata.
 
@@ -83,8 +85,9 @@ def _add_tweakreg_catalogs(asn):
     """
     for product in asn["products"]:
         for member in product["members"]:
-            stem = member["expname"].rsplit("_", 1)[0]
-            member["tweakreg_catalog"] = f"{stem}_cat.parquet"
+            expname = Path(member["expname"])
+            catalog = replace_suffix(expname.stem, "cat") + ".parquet"
+            member["tweakreg_catalog"] = str(expname.with_name(catalog))
 
 
 def _create_ordered_meta(asn):

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -188,3 +188,39 @@ def test_api_with_type():
     members_dict = {member["expname"]: member["exptype"] for member in members}
     for name, type_ in inlist:
         assert members_dict[name] == type_
+
+
+def test_api_tweakreg_catalogs():
+    """Catalog names are derived from the member expnames"""
+    inlist = ["a_cal.asdf", "b_cal.asdf"]
+
+    asn = asn_from_list(inlist, product_name="test", _tweakreg_catalogs=True)
+    members = asn["products"][0]["members"]
+    catalogs = [member["tweakreg_catalog"] for member in members]
+    assert catalogs == ["a_cat.parquet", "b_cat.parquet"]
+
+
+def test_api_tweakreg_catalogs_off_by_default():
+    """Members carry no catalog unless one was requested"""
+    asn = asn_from_list(["a_cal.asdf"], product_name="test")
+    assert "tweakreg_catalog" not in asn["products"][0]["members"][0]
+
+
+def test_cmdline_tweakreg_catalogs(tmp_path):
+    """Catalog names survive a trip through the association file"""
+    path = tmp_path / "test_asn.json"
+    inlist = ["a_cal.asdf", "b_cal.asdf"]
+    args = [
+        "-o",
+        str(path),
+        "--product-name",
+        "test",
+        "--_tweakreg-catalogs",
+    ]
+    _cli(args + inlist)
+
+    with path.open() as fp:
+        asn = load_asn(fp)
+    members = asn["products"][0]["members"]
+    catalogs = [member["tweakreg_catalog"] for member in members]
+    assert catalogs == ["a_cat.parquet", "b_cat.parquet"]

--- a/romancal/associations/tests/test_asn_from_list.py
+++ b/romancal/associations/tests/test_asn_from_list.py
@@ -190,14 +190,26 @@ def test_api_with_type():
         assert members_dict[name] == type_
 
 
-def test_api_tweakreg_catalogs():
+@pytest.mark.parametrize(
+    "expname, catalog",
+    [
+        ("a_cal.asdf", "a_cat.parquet"),
+        (
+            "r0000101001001001001_0001_wfi01_f158_cal.asdf",
+            "r0000101001001001001_0001_wfi01_f158_cat.parquet",
+        ),
+        # a directory on the member is kept on the catalog
+        ("sub/dir/a_cal.asdf", "sub/dir/a_cat.parquet"),
+        # the separator of the replaced suffix is preserved
+        ("a-cal.asdf", "a-cat.parquet"),
+        # an unknown suffix is appended to, not replaced
+        ("a_unknown.asdf", "a_unknown_cat.parquet"),
+    ],
+)
+def test_api_tweakreg_catalogs(expname, catalog):
     """Catalog names are derived from the member expnames"""
-    inlist = ["a_cal.asdf", "b_cal.asdf"]
-
-    asn = asn_from_list(inlist, product_name="test", _tweakreg_catalogs=True)
-    members = asn["products"][0]["members"]
-    catalogs = [member["tweakreg_catalog"] for member in members]
-    assert catalogs == ["a_cat.parquet", "b_cat.parquet"]
+    asn = asn_from_list([expname], product_name="test", _tweakreg_catalogs=True)
+    assert asn["products"][0]["members"][0]["tweakreg_catalog"] == catalog
 
 
 def test_api_tweakreg_catalogs_off_by_default():


### PR DESCRIPTION
This PR adds a feature to asn_from_list that makes it easy for SDP to make associations including tweakreg source catalog metadata in the way that they're used to.  asn_from_list gains a new argument that populates tweakreg_catalog in an association with a name inferred from the image file names using our usual approach (roughly, _cal.asdf -> _cat.parquet), so that associations have both images and corresponding catalogs.

In B23 we reworked how the source catalog is returned (https://github.com/spacetelescope/romancal/pull/2352) and this impacts how SDP does tweakreg for the 18 detector case (see e.g. discussion around https://github.com/spacetelescope/romancal/issues/1386#issuecomment-4927778009).  We didn't fully resolve that discussion and I'm putting in this change as a PR to smooth things over for SDP in B23; we should still consider better longer-term solutions.

Regression test here: https://github.com/spacetelescope/RegressionTests/actions/runs/31015799188
All green.

## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
