### PR TITLE
Match flat field and photom regtest inputs to the pipeline step order

### DIFF
--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -13,8 +13,9 @@ from .regtestdata import compare_asdf
 # mark all tests in this module
 pytestmark = [pytest.mark.bigdata]
 
-IMAGE_FILENAME = "r0000101001001001001_0001_wfi01_f158_assignwcs.asdf"
-GRISM_FILENAME = "r0000201001001001001_0001_wfi01_grism_assignwcs.asdf"
+# photom stage is input to flat fielding
+IMAGE_FILENAME = "r0000101001001001001_0001_wfi01_f158_photom.asdf"
+GRISM_FILENAME = "r0000201001001001001_0001_wfi01_grism_photom.asdf"
 
 
 @pytest.fixture(

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -17,7 +17,8 @@ def test_absolute_photometric_calibration(
     """DMS140 Test: Testing application of photometric correction using
     CRDS selected photom file."""
 
-    input_data = "r0000101001001001001_0001_wfi01_f158_flat.asdf"
+    # assign_wcs stage is input to photom
+    input_data = "r0000101001001001001_0001_wfi01_f158_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -105,10 +105,10 @@ cp Test_linearity.asdf $outdir/truth/WFI/image/
 strun romancal.step.RampFitStep r0000101001001001001_0001_wfi01_f158_linearity.asdf --algorithm=likely --output_file=r0000101001001001001_0001_wfi01_f158_like_rampfit.asdf
 cp r0000101001001001001_0001_wfi01_f158_like_rampfit.asdf $outdir/truth/WFI/image/
 
-# We have a test that runs the flat field step directly on an _L1_ spectroscopic
-# file and verifies that it gets skipped.
+# We have a test that runs the flat field step directly on a spectroscopic
+# file and verifies that it gets skipped.  That would happen on a photom file.
 basename="r0000201001001001001_0001_wfi01_grism"
-strun romancal.step.FlatFieldStep ${basename}_assignwcs.asdf
+strun romancal.step.FlatFieldStep ${basename}_photom.asdf
 cp ${basename}_flat.asdf $outdir/truth/WFI/grism/
 
 # make a version of a file with a different pointing


### PR DESCRIPTION
In #2327 we changed the order of the photom and flat field step in order to make sure that spectroscopic images had photom information populated.  But I forgot to make corresponding updates to the regression tests and regression test generating script, so that when generating fresh regression test files we no longer automatically pass.  When doing that, we get failures in the photom and flat regtests, as expected.
https://github.com/spacetelescope/RegressionTests/actions/runs/31021131849

This PR makes the regression tests and generation script consistent with the pipeline step ordering to fix this.

I've run a new set of regtest files here:
https://github.com/spacetelescope/RegressionTests/actions/runs/31034280203
and a regtest run against those new files:
https://github.com/spacetelescope/RegressionTests/actions/runs/31178322502 .
which is clean except for a transient sonar scan failure.



## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [x] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
