### PR TITLE
convert "all saturated" regtests to a unit test

### DIFF
--- a/romancal/pipeline/tests/test_exposure_pipeline.py
+++ b/romancal/pipeline/tests/test_exposure_pipeline.py
@@ -144,3 +144,31 @@ def test_on_disk(function_jail, fake_science_raw, on_disk):
     pipeline.dq_init.skip = False  # unskip dqinit
     output_value, _, _ = pipeline.run(asn_filename)
     assert output_value._on_disk == on_disk
+
+
+def test_all_saturated(fake_science_raw):
+    """
+    Test ELP behavior for an all saturated image.
+    """
+    # make an all-saturated uncal
+    fake_science_raw.data[...] = 65535
+    cal, cat, segm = ExposurePipeline.call(fake_science_raw)
+    assert isinstance(cal, rdm.ImageModel)
+    cal_step_status = {
+        "dq_init": "COMPLETE",
+        "saturation": "COMPLETE",
+        "linearity": "SKIPPED",
+        "dark": "SKIPPED",
+        "ramp_fit": "SKIPPED",
+        "assign_wcs": "SKIPPED",
+        "flat_field": "SKIPPED",
+        "photom": "SKIPPED",
+        "source_catalog": "SKIPPED",
+        "tweakreg": "SKIPPED",
+    }
+    for step_name, expected in cal_step_status.items():
+        assert cal.meta.cal_step[step_name] == expected
+    for array_name in ("data", "err", "var_poisson"):
+        np.testing.assert_array_equal(cal[array_name], 0)
+    assert cat is None
+    assert segm is None

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -5,7 +5,6 @@ import pytest
 import roman_datamodels as rdm
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose
-from roman_datamodels.datamodels import ImageModel
 from roman_datamodels.dqflags import pixel
 
 from romancal.assign_wcs.assign_wcs_step import AssignWcsStep
@@ -254,87 +253,6 @@ def test_elp_input_dm(rtdata, ignore_asdf_paths):
         assert model.meta.cal_step.assign_wcs == "COMPLETE"
         assert model.meta.cal_step.flat_field == "COMPLETE"
         assert model.meta.cal_step.photom == "COMPLETE"
-
-
-@pytest.fixture(scope="module")
-def run_all_saturated(rtdata_module):
-    """
-    Test ELP handling of an all saturated input model
-    """
-    rtdata = rtdata_module
-
-    input_data = "r0000101001001001001_0001_wfi01_f158_ALL_SATURATED_uncal.asdf"
-    rtdata.get_data(f"WFI/image/{input_data}")
-    rtdata.input = input_data
-
-    # Test Pipeline
-    output = "r0000101001001001001_0001_wfi01_f158_ALL_SATURATED_cal.asdf"
-    rtdata.output = output
-    args = [
-        "roman_elp",
-        rtdata.input,
-    ]
-    ExposurePipeline.from_cmdline(args)
-
-    # get truth file
-    rtdata.get_truth(f"truth/WFI/image/{output}")
-    return rtdata
-
-
-@pytest.fixture(scope="module")
-def all_saturated_model(run_all_saturated):
-    with rdm.open(run_all_saturated.output) as model:
-        yield model
-
-
-def test_all_staturated_outputs(run_all_saturated):
-    cal_filename = run_all_saturated.output
-    assert not Path(cal_filename.replace("_cal.asdf", "_cat.parquet")).exists()
-    assert not Path(cal_filename.replace("_cal.asdf", "_segm.asdf")).exists()
-
-
-def test_all_saturated_against_truth(run_all_saturated, ignore_asdf_paths):
-    diff = compare_asdf(
-        run_all_saturated.output, run_all_saturated.truth, **ignore_asdf_paths
-    )
-    assert diff.identical, diff.report()
-
-
-@pytest.mark.parametrize(
-    "step_name, status",
-    [
-        ("dq_init", "COMPLETE"),
-        ("saturation", "COMPLETE"),
-        ("linearity", "SKIPPED"),
-        ("dark", "SKIPPED"),
-        ("ramp_fit", "SKIPPED"),
-        ("assign_wcs", "SKIPPED"),
-        ("flat_field", "SKIPPED"),
-        ("photom", "SKIPPED"),
-        ("source_catalog", "SKIPPED"),
-        ("tweakreg", "SKIPPED"),
-    ],
-)
-def test_all_saturated_status(all_saturated_model, step_name, status):
-    """
-    For an all saturated input the pipeline should skip all steps after saturation.
-    """
-    assert getattr(all_saturated_model.meta.cal_step, step_name) == status
-
-
-def test_all_saturated_model_type(all_saturated_model):
-    """
-    For an all saturated input the output model should be an ImageModel.
-    """
-    assert isinstance(all_saturated_model, ImageModel)
-
-
-@pytest.mark.parametrize("array_name", ["data", "err", "var_poisson"])
-def test_all_saturated_zeroed(all_saturated_model, array_name):
-    """
-    For an all saturated input the output model should contain 0s for data and err arrays.
-    """
-    np.testing.assert_array_equal(getattr(all_saturated_model, array_name), 0)
 
 
 def test_pipeline_suffix(rtdata, ignore_asdf_paths):

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -75,22 +75,6 @@ cp r0000101001001001001_0002_wfi01_f158_cal.asdf $outdir/WFI/image/
 strun roman_elp r0000101001001001001_0002_wfi10_f158_uncal.asdf
 cp r0000101001001001001_0002_wfi10_f158_cal.asdf $outdir/WFI/image/
 
-# need to make a special ALL_SATURATED file for the all saturated test.
-echo "Creating regtest files for all saturated tests..."
-basename="r0000101001001001001_0001_wfi01_f158"
-python -c "
-import asdf
-basename = '$basename'
-f = asdf.open(f'{basename}_uncal.asdf')
-data = f['roman']['data'].copy()
-data[...] = 65535
-f['roman']['data'] = data
-f['roman']['meta']['filename'] = f'{basename}_ALL_SATURATED_uncal.asdf'
-f.write_to(f'{basename}_ALL_SATURATED_uncal.asdf')"
-strun roman_elp ${basename}_ALL_SATURATED_uncal.asdf
-cp ${basename}_ALL_SATURATED_uncal.asdf $outdir/WFI/image/
-cp ${basename}_ALL_SATURATED_cal.asdf $outdir/truth/WFI/image/
-
 
 # make a special file dark file with a different name
 strun romancal.step.DarkCurrentStep r0000101001001001001_0001_wfi01_f158_rampfit.asdf --output_file=Test_dark


### PR DESCRIPTION
Replace regression tests that check ELP behavior for all saturated input with a unit test that does the same.

This test runs in a few seconds and this replacement allows cleaning up:
- the regtest file generation script
- removal of a regtest input and truth file
- cleanup of the elp regtest submodule

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/32162305695

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
