### PR TITLE
update crds version, add upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "romanisim>=0.14,<0.15",
     # "romanisim@git+https://github.com/spacetelescope/romanisim@main",
     "asdf>=4.1.0,<6",
-    "crds>=13.0.2",
+    "crds>=13.2.7,<14",
     "drizzle>=2.2.0,<2.3.0",
     "gwcs>=1.0.1,<2",
     "stcal>=1.20.0,<2",


### PR DESCRIPTION
Update the required crds version to:
- minimum 13.2.7 (Closes #2396)
- maximum 14

From slack conversation with @alphasentaurii crds follows semantic versioning.

We may need to backport this and make releases depending on how https://github.com/spacetelescope/crds/pull/1228 proceeds.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
