### PR TITLE
Reduce refpix memory usage

### DIFF
--- a/changes/2427.refpix.rst
+++ b/changes/2427.refpix.rst
@@ -1,7 +1,3 @@
-Correct the reference pixels one resultant at a time rather than holding the
-whole ramp in the padded channel view, cutting peak memory usage of the step
-from roughly 6.5x the size of the ramp to well under 0.5x (29.7 GB to 5.4 GB
-for a 55-resultant TVAC ramp) while leaving the results bit-for-bit unchanged.
-Also fix the arguments passed from ``RefPixStep`` to ``run_steps``, which were
-each shifted by one position, so that (for example) ``fft_interpolate=False``
-no longer turns off the cosine interpolation instead.
+Reduce peak memory usage of the reference pixel correction step dramatically by
+processing resultants individually. Also fix the arguments passed from
+``RefPixStep`` to ``run_steps``, which were each shifted by one position.

--- a/changes/2427.refpix.rst
+++ b/changes/2427.refpix.rst
@@ -1,0 +1,7 @@
+Correct the reference pixels one resultant at a time rather than holding the
+whole ramp in the padded channel view, cutting peak memory usage of the step
+from roughly 6.5x the size of the ramp to well under 0.5x (29.7 GB to 5.4 GB
+for a 55-resultant TVAC ramp) while leaving the results bit-for-bit unchanged.
+Also fix the arguments passed from ``RefPixStep`` to ``run_steps``, which were
+each shifted by one position, so that (for example) ``fft_interpolate=False``
+no longer turns off the cosine interpolation instead.

--- a/changes/2427.refpix.rst
+++ b/changes/2427.refpix.rst
@@ -1,5 +1,5 @@
 Reduce peak memory usage of the reference pixel correction step dramatically by
-processing resultants individually. The step no longer overwrites
-``border_ref_pix_left`` and ``border_ref_pix_right``, which it had been updating
-inconsistently with the top and bottom borders. Also fix the arguments passed
+processing resultants individually. The step no longer writes its corrected
+reference pixels back to ``amp33`` or ``border_ref_pix_left`` / ``_right``,
+leaving all of them as ``dq_init`` extracted them. Also fix the arguments passed
 from ``RefPixStep`` to ``run_steps``, which were each shifted by one position.

--- a/changes/2427.refpix.rst
+++ b/changes/2427.refpix.rst
@@ -1,3 +1,5 @@
 Reduce peak memory usage of the reference pixel correction step dramatically by
-processing resultants individually. Also fix the arguments passed from
-``RefPixStep`` to ``run_steps``, which were each shifted by one position.
+processing resultants individually. The step no longer overwrites
+``border_ref_pix_left`` and ``border_ref_pix_right``, which it had been updating
+inconsistently with the top and bottom borders. Also fix the arguments passed
+from ``RefPixStep`` to ``run_steps``, which were each shifted by one position.

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -130,12 +130,10 @@ class StandardView(BaseView):
 
         # update in place
         datamodel.data[frames] = self.detector
-        # ABS to avoid casting negative numbers to uint16
-        datamodel.amp33[frames] = np.abs(self.amp33).astype(datamodel.amp33.dtype)
 
-        # the border_ref_pix_* arrays are deliberately left alone; they are
-        # extracted once in dq_init, and refpix previously re-extracted only
-        # the left and right of the four, which was never consistent
+        # The reference pixels the correction is derived from -- amp33 and the
+        # border_ref_pix_* arrays -- are deliberately left as dq_init extracted
+        # them, rather than being written back in their corrected form.
 
         return datamodel
 

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -82,33 +82,98 @@ class StandardView(BaseView):
     """
 
     @classmethod
-    def from_datamodel(cls, datamodel: RampModel) -> StandardView:
+    def from_arrays(cls, detector: np.ndarray, amp33: np.ndarray) -> StandardView:
         """
-        Read the datamodel into the standard view.
+        Combine the detector and amp33 pixels into the standard view.
         """
-        detector = datamodel.data
-
-        # Extract amp33
-        amp33 = datamodel.amp33
         # amp33 is normally a uint16, but this computation requires it to match
         # the data type of the detector pixels.
         amp33 = amp33.astype(detector.dtype)
 
         return cls(np.dstack([detector, amp33]))
 
-    def update(self, datamodel: RampModel) -> RampModel:
+    @classmethod
+    def from_datamodel(
+        cls, datamodel: RampModel, resultant: int | None = None
+    ) -> StandardView:
+        """
+        Read the datamodel into the standard view.
+
+        Parameters
+        ----------
+        datamodel : RampModel
+            The ramp to read.
+        resultant : int, optional
+            Read only this resultant rather than the whole ramp. It is selected
+            with a slice rather than an index so that the returned view keeps
+            the leading resultant axis, which lets the rest of the computation
+            be written without caring how many resultants it was handed.
+        """
+        frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
+
+        return cls.from_arrays(datamodel.data[frames], datamodel.amp33[frames])
+
+    def update(self, datamodel: RampModel, resultant: int | None = None) -> RampModel:
         """
         Update the datamodel in place with the data from the standard view.
             - Returns the updated datamodel for a functional approach.
-        """
 
-        datamodel.data = self.detector
+        The datamodel's arrays are written into rather than replaced. This is
+        what allows a single resultant to be updated at a time, and it also
+        avoids leaving the datamodel holding a (non-contiguous) view of this
+        view's padded array, which would keep that whole array alive.
+
+        Parameters
+        ----------
+        datamodel : RampModel
+            The ramp to update.
+        resultant : int, optional
+            Update only this resultant, which is expected when this view holds
+            a single resultant read by ``from_datamodel``.
+        """
+        frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
+
+        datamodel.data[frames] = self.detector
         # ABS to avoid casting negative numbers to uint16
-        datamodel.amp33 = np.abs(self.amp33).astype(datamodel.amp33.dtype)
-        datamodel.border_ref_pix_left = self.left
-        datamodel.border_ref_pix_right = self.right
+        datamodel.amp33[frames] = np.abs(self.amp33).astype(datamodel.amp33.dtype)
+        datamodel.border_ref_pix_left[frames] = self.left
+        datamodel.border_ref_pix_right[frames] = self.right
 
         return datamodel
+
+    @classmethod
+    def compute_offset(cls, detector: np.ndarray, amp33: np.ndarray) -> np.ndarray:
+        """
+        Use linear least squares regression to compute the best fit intercept
+        (offset) of all the data, combining one resultant at a time.
+
+        The offset is the only part of the correction which couples the
+        resultants to each other, so it is fit up front. That lets the
+        correction itself be applied one resultant at a time, without ever
+        building the standard view of the whole ramp.
+        """
+        frames = detector.shape[0]
+
+        # Create an independent variable indexed by frame and centered at zero
+        indep = np.arange(frames, dtype=detector.dtype)
+        indep = indep - np.mean(indep)
+
+        # Compute sums needed for linear least squares, accumulating over the
+        # resultants rather than reducing across a whole-ramp array
+        sx = np.sum(indep)
+        sxx = np.sum(indep**2)
+        sy = sxy = None
+        for resultant in range(frames):
+            frame = cls.from_arrays(
+                detector[resultant : resultant + 1], amp33[resultant : resultant + 1]
+            ).data[0]
+            if sy is None:
+                sy, sxy = np.zeros_like(frame), np.zeros_like(frame)
+            sy += frame
+            sxy += indep[resultant] * frame
+
+        # Compute the offset (y-intercept) for the fit
+        return (sy * sxx - sx * sxy) / (frames * sxx - sx**2)
 
     @property
     def detector(self) -> np.ndarray:
@@ -170,40 +235,23 @@ class StandardView(BaseView):
 
         return ChannelView(output, offset=self.offset)
 
-    def remove_offset(self) -> StandardView:
+    def remove_offset(self, offset: np.ndarray) -> StandardView:
         """
-        Use linear least squares regression to compute the best fit intercept
-        (offset) of all the data and then subtract that from the data.
+        Subtract the offset fit by ``compute_offset`` from the data.
             - This records the offset in the class so that it can be added back
               to the data later.
             - Returns the class back to the user even though it will be modified
               in place by the views. This is so that it can be treated functionally.
+
+        The fit is made over the whole ramp while the subtraction is made a
+        resultant at a time, so the offset is computed separately and handed in
+        here rather than being fit from this view's data.
         """
 
-        frames, rows, columns = self.data.shape
+        # Apply the offset to the data (in place), broadcasting over the frames
+        self.data -= offset
 
-        # Reshape data so that it is a view of the data of shape:
-        #    [frame, frame_data]
-        # where frame_data is the data for a single frame
-        data = self.data.reshape((frames, rows * columns))
-
-        # Craate an independent variable indexed by frame and centered at zero
-        indep = np.arange(frames, dtype=data.dtype)
-        indep = indep - np.mean(indep)
-
-        # Compute sums needed for linear least squares
-        sx = np.sum(indep)
-        sxx = np.sum(indep**2)
-        sy = np.sum(data, axis=0)
-        sxy = np.matmul(indep, data, dtype=data.dtype)
-
-        # Compute the offset (y-intercept) for the fit
-        offset = (sy * sxx - sx * sxy) / (frames * sxx - sx**2)
-
-        # Apply the offset to the data (in place)
-        data -= offset
-
-        self.offset = offset.reshape(rows, columns)
+        self.offset = offset
 
         return self
 
@@ -528,9 +576,17 @@ class ChannelView(BaseView):
         """
         Compute the the correction array for the the detector.
         """
-        correction = self.reference_fft.correction(coeffs)
+        channels, frames, rows, columns = self.data.shape
 
-        return correction.reshape(self.data.shape).astype(self.data.dtype)
+        # Fill in the correction one channel at a time (rather than stacking the
+        # channels once they have all been computed) so that only one copy of it
+        # is ever held in memory.
+        correction = np.empty(self.data.shape, dtype=self.data.dtype)
+        self.reference_fft.correction(
+            coeffs, out=correction.reshape(channels, frames, rows * columns)
+        )
+
+        return correction
 
     def apply_correction(self, coeffs: Coefficients) -> StandardView:
         """
@@ -582,9 +638,12 @@ class ReferenceFFT:
             yield correction
 
         # Add zeros in for the amp33 channel as it does not get changed
-        yield np.zeros(correction.shape)
+        # (matching the dtype so that stacking does not promote everything)
+        yield np.zeros(correction.shape, dtype=correction.dtype)
 
-    def correction(self, coeffs: Coefficients) -> np.ndarray:
+    def correction(
+        self, coeffs: Coefficients, out: np.ndarray | None = None
+    ) -> np.ndarray:
         """
         Get the correction array for all of the data.
             - Stacks all channels into a single array
@@ -592,9 +651,23 @@ class ReferenceFFT:
         Returns the correction array with the rows and columns in a single combined
         dimension, and the dtypes not adjusted to the original dtypes.
             - This will be handled by the ChannelView class
-        """
 
-        return np.array(list(self.channel_correction(coeffs)))
+        Parameters
+        ----------
+        out : np.ndarray, optional
+            Write each channel into this array (casting to its dtype) as it is
+            computed, instead of stacking the channels afterwards. This avoids
+            holding a second copy of the full correction.
+        """
+        channels = self.channel_correction(coeffs)
+
+        if out is None:
+            return np.array(list(channels))
+
+        for index, correction in enumerate(channels):
+            out[index] = correction
+
+        return out
 
 
 @dataclass

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -128,12 +128,8 @@ class StandardView(BaseView):
         """
         frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
 
-        # update in place
+        # update data in place; note separate border and amp33 arrays are left unchanged
         datamodel.data[frames] = self.detector
-
-        # The reference pixels the correction is derived from -- amp33 and the
-        # border_ref_pix_* arrays -- are deliberately left as dq_init extracted
-        # them, rather than being written back in their corrected form.
 
         return datamodel
 

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -132,8 +132,10 @@ class StandardView(BaseView):
         datamodel.data[frames] = self.detector
         # ABS to avoid casting negative numbers to uint16
         datamodel.amp33[frames] = np.abs(self.amp33).astype(datamodel.amp33.dtype)
-        datamodel.border_ref_pix_left[frames] = self.left
-        datamodel.border_ref_pix_right[frames] = self.right
+
+        # the border_ref_pix_* arrays are deliberately left alone; they are
+        # extracted once in dq_init, and refpix previously re-extracted only
+        # the left and right of the four, which was never consistent
 
         return datamodel
 

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -104,11 +104,11 @@ class StandardView(BaseView):
         datamodel : RampModel
             The ramp to read.
         resultant : int, optional
-            Read only this resultant rather than the whole ramp. It is selected
-            with a slice rather than an index so that the returned view keeps
-            the leading resultant axis, which lets the rest of the computation
-            be written without caring how many resultants it was handed.
+            Read only this resultant rather than the whole ramp.
         """
+        # select with slice rather than integer in order to preserve the leading axis,
+        # making the returned number of dimensions independent of whether an individual
+        # resultant was requested
         frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
 
         return cls.from_arrays(datamodel.data[frames], datamodel.amp33[frames])
@@ -117,11 +117,6 @@ class StandardView(BaseView):
         """
         Update the datamodel in place with the data from the standard view.
             - Returns the updated datamodel for a functional approach.
-
-        The datamodel's arrays are written into rather than replaced. This is
-        what allows a single resultant to be updated at a time, and it also
-        avoids leaving the datamodel holding a (non-contiguous) view of this
-        view's padded array, which would keep that whole array alive.
 
         Parameters
         ----------
@@ -133,6 +128,7 @@ class StandardView(BaseView):
         """
         frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
 
+        # update in place
         datamodel.data[frames] = self.detector
         # ABS to avoid casting negative numbers to uint16
         datamodel.amp33[frames] = np.abs(self.amp33).astype(datamodel.amp33.dtype)
@@ -655,9 +651,7 @@ class ReferenceFFT:
         Parameters
         ----------
         out : np.ndarray, optional
-            Write each channel into this array (casting to its dtype) as it is
-            computed, instead of stacking the channels afterwards. This avoids
-            holding a second copy of the full correction.
+            Write output to this array
         """
         channels = self.channel_correction(coeffs)
 

--- a/romancal/refpix/_data.py
+++ b/romancal/refpix/_data.py
@@ -128,7 +128,8 @@ class StandardView(BaseView):
         """
         frames = slice(None) if resultant is None else slice(resultant, resultant + 1)
 
-        # update data in place; note separate border and amp33 arrays are left unchanged
+        # update data in place; note separate border and amp33 arrays are left
+        # unchanged (see #2429 for what they ought to contain)
         datamodel.data[frames] = self.detector
 
         return datamodel

--- a/romancal/refpix/refpix.py
+++ b/romancal/refpix/refpix.py
@@ -25,50 +25,64 @@ def run_steps(
 ) -> RampModel:
     """
     Organize the steps to run the reference pixel correction.
-    """
 
-    # Read in the data from the datamodels
-    log.debug("Reading data from datamodel into single array")
+    Apart from the offset, the correction is independent between resultants, so
+    the ramp is corrected one resultant at a time. The intermediate channel view
+    and correction arrays are each larger than the ramp itself, so doing this
+    keeps the peak memory usage proportional to a single resultant rather than
+    to the whole ramp.
+    """
 
     if zero_bad_ref_pix:
         _mask_bad_ref_pixels(datamodel)
 
     coeffs = Coefficients.from_ref(refs)
-    standard = StandardView.from_datamodel(datamodel)
 
-    # Remove offset from the data
+    # The offset is fit over all of the resultants, so it has to be accumulated
+    # before any of them are corrected.
+    offset = None
     if remove_offset:
-        standard = standard.remove_offset()
-        log.debug("Removed the general offset from data, to be re-applied later.")
+        offset = StandardView.compute_offset(datamodel.data, datamodel.amp33)
+        log.debug("Computed the general offset of the data, to be re-applied later.")
 
-    # Convert to channel view
-    channel = standard.channels
+    log.debug(
+        "Correcting the data one resultant at a time "
+        f"(remove_trends={remove_trends}, cosine_interpolate={cosine_interpolate}, "
+        f"fft_interpolate={fft_interpolate})."
+    )
 
-    # Remove the boundary trends
-    if remove_trends:
-        channel = channel.remove_trends()
-        log.debug("Removed boundary trends (in time) from data.")
+    for resultant in range(datamodel.data.shape[0]):
+        # Read a single resultant from the datamodel into the standard view
+        standard = StandardView.from_datamodel(datamodel, resultant)
 
-    # Cosine interpolate the the data
-    if cosine_interpolate:
-        channel = channel.cosine_interpolate()
-        log.debug("Cosine interpolated the reference pixels.")
+        # Remove offset from the data
+        if offset is not None:
+            standard.remove_offset(offset)
 
-    # FFT interpolate the data
-    if fft_interpolate:
-        channel = channel.fft_interpolate()
-        log.debug("FFT interpolated the reference pixel pads.")
+        # Convert to channel view
+        channel = standard.channels
 
-    # Perform the reference pixel correction
-    standard = channel.apply_correction(coeffs)
-    log.debug("Applied reference pixel correction")
+        # Remove the boundary trends
+        if remove_trends:
+            channel = channel.remove_trends()
 
-    # Re-apply the offset (if necessary)
-    standard.apply_offset()
-    log.debug("Re-applied the general offset (if removed) to the data.")
+        # Cosine interpolate the the data
+        if cosine_interpolate:
+            channel = channel.cosine_interpolate()
 
-    # Write the data back to the datamodel
-    standard.update(datamodel)
+        # FFT interpolate the data
+        if fft_interpolate:
+            channel = channel.fft_interpolate()
+
+        # Perform the reference pixel correction
+        standard = channel.apply_correction(coeffs)
+
+        # Re-apply the offset (if necessary)
+        standard.apply_offset()
+
+        # Write the resultant back to the datamodel
+        standard.update(datamodel, resultant)
+
     log.debug("Updated the datamodel with the corrected data.")
 
     return datamodel

--- a/romancal/refpix/refpix_step.py
+++ b/romancal/refpix/refpix_step.py
@@ -65,10 +65,10 @@ class RefPixStep(RomanStep):
             refpix.run_steps(
                 datamodel,
                 refs,
-                self.remove_offset,
-                self.remove_trends,
-                self.cosine_interpolate,
-                self.fft_interpolate,
+                remove_offset=self.remove_offset,
+                remove_trends=self.remove_trends,
+                cosine_interpolate=self.cosine_interpolate,
+                fft_interpolate=self.fft_interpolate,
             )
             # Update the step status
             datamodel.meta.cal_step["refpix"] = "COMPLETE"

--- a/romancal/refpix/tests/conftest.py
+++ b/romancal/refpix/tests/conftest.py
@@ -54,8 +54,9 @@ def datamodel(data):
     datamodel.data = detector
     datamodel.amp33 = amp33.astype(datamodel.amp33.dtype)
 
-    datamodel.border_ref_pix_left = datamodel.data[:, :, : Const.REF]
-    datamodel.border_ref_pix_right = datamodel.data[:, :, -Const.REF :]
+    # copies, not views, matching what dq_init stores
+    datamodel.border_ref_pix_left = datamodel.data[:, :, : Const.REF].copy()
+    datamodel.border_ref_pix_right = datamodel.data[:, :, -Const.REF :].copy()
 
     return datamodel
 

--- a/romancal/refpix/tests/test_data.py
+++ b/romancal/refpix/tests/test_data.py
@@ -88,8 +88,10 @@ class TestStandardView:
         # Check that the datamodel's data has been updated
         assert (new.data != old_detector).any()
         assert (new.amp33 != old_amp33).any()
-        assert (new.border_ref_pix_left != old_left).any()
-        assert (new.border_ref_pix_right != old_right).any()
+
+        # The border reference pixels are extracted in dq_init and left alone
+        assert (new.border_ref_pix_left == old_left).all()
+        assert (new.border_ref_pix_right == old_right).all()
 
         # Check the dtype has been preserved
         assert new.data.dtype == old_detector.dtype
@@ -99,8 +101,6 @@ class TestStandardView:
 
         # Check the data has been updated correctly
         assert (new.data == standard.detector).all()
-        assert (new.border_ref_pix_left == standard.left).all()
-        assert (new.border_ref_pix_right == standard.right).all()
 
         # The amp33's dtype changes because it needs to be shifted to match the
         # original data's dtype

--- a/romancal/refpix/tests/test_data.py
+++ b/romancal/refpix/tests/test_data.py
@@ -106,6 +106,36 @@ class TestStandardView:
         # original data's dtype
         assert (new.amp33 == standard.amp33.astype(old_amp33.dtype)).all()
 
+    def test_from_datamodel_single_resultant(self, datamodel):
+        """
+        Reading a single resultant has to match that resultant of the whole ramp.
+        """
+        whole = StandardView.from_datamodel(datamodel)
+
+        for resultant in range(Dims.N_FRAMES):
+            single = StandardView.from_datamodel(datamodel, resultant)
+
+            # The resultant axis is kept so the rest of the computation is
+            # unchanged
+            assert single.data.shape == (1, Dims.N_ROWS, Dims.N_COLS)
+            assert (single.data[0] == whole.data[resultant]).all()
+
+    def test_update_single_resultant(self, datamodel):
+        """
+        Updating one resultant at a time writes each one into the right place,
+        and leaves the rest of the ramp alone.
+        """
+        model = datamodel.copy()
+        expected = model.data.copy()
+
+        for resultant in range(Dims.N_FRAMES):
+            view = StandardView.from_datamodel(model, resultant)
+            view.data *= 2
+            view.update(model, resultant)
+
+            expected[resultant] *= 2
+            assert (model.data == expected).all()
+
     def test_create_standard_view(self, data):
         """
         Sanity that the StandardView constructs correctly
@@ -254,12 +284,38 @@ class TestStandardView:
         # Check that the regression matches the channels property
         assert (standard.channels.data == regression).all()
 
+    def test_compute_offset(self, data):
+        offset = StandardView.compute_offset(
+            data[:, :, : Const.N_COLUMNS], data[:, :, Const.N_COLUMNS :]
+        )
+
+        assert offset.shape == (Dims.N_ROWS, Dims.N_COLS)
+        assert offset.dtype == data.dtype
+        assert (offset != 0).all()
+
+    def test_compute_offset_regression(self, data):
+        # Copy the data, because the regression utility modifies the data in-place
+        regression = data.copy()
+        _, b = reference_utils.remove_linear_trends(regression, True)
+
+        # Run the internal utility. Accumulating the fit a resultant at a time
+        # has to reproduce the fit made across the whole ramp at once.
+        offset = StandardView.compute_offset(
+            data[:, :, : Const.N_COLUMNS], data[:, :, Const.N_COLUMNS :]
+        )
+
+        # Check that the regression matches
+        assert (offset == b).all()
+
     def test_remove_offset(self, data):
         non_view_data = data.copy()
         standard = StandardView(data)
         assert standard.offset is None
 
-        new = standard.remove_offset()
+        offset = StandardView.compute_offset(
+            data[:, :, : Const.N_COLUMNS], data[:, :, Const.N_COLUMNS :]
+        )
+        new = standard.remove_offset(offset)
 
         # Check that new object returned is the same as the original
         assert new is standard
@@ -267,14 +323,12 @@ class TestStandardView:
         # Check that the data is still a view of the original
         assert new.data is data
 
-        # Check that the offset is now set
-        assert new.offset is not None
-        assert new.offset.shape == (Dims.N_ROWS, Dims.N_COLS)
-        assert (new.offset != 0).all()
+        # Check that the offset is now recorded
+        assert new.offset is offset
 
         # Check that the data has been updated and that the offset has been removed
         assert (new.data != non_view_data).any()
-        assert (new.data == (non_view_data - new.offset)).all()
+        assert (new.data == (non_view_data - offset)).all()
 
         # add offset back (error accumulates due to floating point arithmetic)
         reset = StandardView(new.data + new.offset)
@@ -288,10 +342,9 @@ class TestStandardView:
         _, b = reference_utils.remove_linear_trends(regression, True)
 
         # Run the internal utility
-        new = standard.remove_offset()
+        new = standard.remove_offset(b)
 
         # Check that the regression matches the new object
-        assert (new.offset == b).all()
         assert (new.data == regression).all()
 
     def test_apply_offset(self, data, offset):
@@ -333,7 +386,11 @@ class TestStandardView:
     def test_offset_roundtrip(self, data):
         standard = StandardView(data.copy())
 
-        no_offset = standard.remove_offset()
+        no_offset = standard.remove_offset(
+            StandardView.compute_offset(
+                data[:, :, : Const.N_COLUMNS], data[:, :, Const.N_COLUMNS :]
+            )
+        )
         assert no_offset.offset is not None
         assert (no_offset.data != data).any()
 

--- a/romancal/refpix/tests/test_data.py
+++ b/romancal/refpix/tests/test_data.py
@@ -87,9 +87,9 @@ class TestStandardView:
 
         # Check that the datamodel's data has been updated
         assert (new.data != old_detector).any()
-        assert (new.amp33 != old_amp33).any()
 
-        # The border reference pixels are extracted in dq_init and left alone
+        # The reference pixels are extracted in dq_init and left alone
+        assert (new.amp33 == old_amp33).all()
         assert (new.border_ref_pix_left == old_left).all()
         assert (new.border_ref_pix_right == old_right).all()
 
@@ -101,10 +101,6 @@ class TestStandardView:
 
         # Check the data has been updated correctly
         assert (new.data == standard.detector).all()
-
-        # The amp33's dtype changes because it needs to be shifted to match the
-        # original data's dtype
-        assert (new.amp33 == standard.amp33.astype(old_amp33.dtype)).all()
 
     def test_from_datamodel_single_resultant(self, datamodel):
         """

--- a/romancal/refpix/tests/test_refpix.py
+++ b/romancal/refpix/tests/test_refpix.py
@@ -22,10 +22,8 @@ def test_run_steps_regression(datamodel, ref_pix_ref):
         fft_interpolate=True,
     )
 
-    # The correction is applied one resultant at a time, while the reference
-    # code works on the whole ramp at once. scipy >= 1.18 batches transforms
-    # across resultants differently than it does a single resultant, so the two
-    # agree only to float32 round off (about one ULP of the largest values).
+    # tolerance corresponds to one quantum of float32 precision for the largest values
+    # and addresses different numerical approaches in different scipy versions
     assert_allclose(
         result.data,
         regression_out,

--- a/romancal/refpix/tests/test_refpix.py
+++ b/romancal/refpix/tests/test_refpix.py
@@ -1,3 +1,6 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
 from romancal.refpix._data import StandardView
 from romancal.refpix.refpix import run_steps
 
@@ -19,5 +22,14 @@ def test_run_steps_regression(datamodel, ref_pix_ref):
         fft_interpolate=True,
     )
 
-    assert (result.data == regression_out).all()
+    # The correction is applied one resultant at a time, while the reference
+    # code works on the whole ramp at once. scipy >= 1.18 batches transforms
+    # across resultants differently than it does a single resultant, so the two
+    # agree only to float32 round off (about one ULP of the largest values).
+    assert_allclose(
+        result.data,
+        regression_out,
+        rtol=1e-5,
+        atol=1e-6 * np.abs(regression_out).max(),
+    )
     # regression_out does not return amp33 data

--- a/romancal/refpix/tests/test_refpix.py
+++ b/romancal/refpix/tests/test_refpix.py
@@ -10,7 +10,14 @@ def test_run_steps_regression(datamodel, ref_pix_ref):
         regression, ref_pix_ref.alpha, ref_pix_ref.gamma, ref_pix_ref.zeta
     )
 
-    result = run_steps(datamodel, ref_pix_ref, True, True, True, True)
+    result = run_steps(
+        datamodel,
+        ref_pix_ref,
+        remove_offset=True,
+        remove_trends=True,
+        cosine_interpolate=True,
+        fft_interpolate=True,
+    )
 
     assert (result.data == regression_out).all()
     # regression_out does not return amp33 data

--- a/romancal/refpix/tests/test_step.py
+++ b/romancal/refpix/tests/test_step.py
@@ -23,10 +23,10 @@ def test_refpix_step(
     regression = run_steps(
         regression_datamodel,
         regression_ref_pix_ref,
-        remove_offset,
-        remove_trends,
-        cosine_interpolate,
-        fft_interpolate,
+        remove_offset=remove_offset,
+        remove_trends=remove_trends,
+        cosine_interpolate=cosine_interpolate,
+        fft_interpolate=fft_interpolate,
     )
 
     # Run the step


### PR DESCRIPTION
The refpix step is currently the high water mark for memory usage in exposure level pipeline runs; see e.g. this plot
<img width="1260" height="540" alt="image" src="https://github.com/user-attachments/assets/2533a73a-030c-4952-bb91-170bdf4bd111" />
from Dave's memory tests.  It doesn't need to be, however.  This PR changes the processing to go one resultant at a time instead of processing all of the resultants simultaneously.  The only step that couples the different resultants together is the offset computation, which can be performed early and saved without requiring holding multiple copies of all of the resultants in memory.

For an example 55 resultant TVAC file, this reduces memory usage from 30 GB to 5 GB.  For 5 resultants the difference is more like 5 GB -> 2 GB.

I stumbled onto an issue while doing this involving the reference pixels.  We save copies of the border pixels to separate arrays during the dq_init step.  The reference pixel correction was updating the values of the left and right border pixels but not the top and bottom ones.  It also updated the amp33 pixels, but left them as amp33.  I've changed this to leave all border pixels untouched.  This doesn't affect other things in the pipeline but is worth a separate discussion.  As a separate issue, the way the left and right border pixels were being assigned before this PR were as views into data, and so these arrays were getting mutated by later steps like dark subtraction and linearity.  It's honestly not clear to me what is desired and I've filed #2429 to try to resolve this; we don't use these saved border pixel arrays elsewhere.  

Resolves #2429.

One unrelated fix: a new argument was added to run_steps in #2294, but run_steps(...) callers were called with all positional arguments and wasn't updated, so some non-default parameter settings were getting jumbled arguments.  I updated some callers to use keyword arguments instead.

Regression test started here: https://github.com/spacetelescope/RegressionTests/actions/runs/33206169144
Tests show the expected changes in the left & right border pixels, as well as amp33 for TVAC data.  No changes to data.

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [X] update or add relevant tests
  - [X] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
