### PR TITLE
avoid a ramp-sized temporary in the uniform-weighted slopes

### DIFF
--- a/changes/2430.ramp_fitting.rst
+++ b/changes/2430.ramp_fitting.rst
@@ -1,0 +1,2 @@
+Reduce peak memory usage of ramp fitting by not materializing a ramp-sized
+temporary while computing the uniform-weighted slopes.

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -530,11 +530,16 @@ def slopes_uniform_weights(input_model):
 
     # We want the weighted sum over reads.
     if len(input_model.data.shape) == 3:
-        return np.sum(weights[:, None, None] * input_model.data, axis=0)
+        data = input_model.data
     elif len(input_model.data.shape) == 4:
-        return np.sum(weights[:, None, None] * input_model.data[0], axis=0)
+        data = input_model.data[0]
     else:
         raise ValueError("Unexpected shape for input_model.data")
+
+    # einsum rather than sum-of-products so that a ramp sized (and float64)
+    # temporary is never materialized; this is the largest allocation in the
+    # step for ramps with few resultants.
+    return np.einsum("i,ijk->jk", weights, data)
 
 
 def get_pixeldq_flags(groupdq, pixeldq, slopes, err, gain):


### PR DESCRIPTION
One more memory-reduction PR: the new uniform weight computation computed a product of the double precision floats with the single precision ramp values, causing a copy of the full ramp to be made at double precision.  That can be avoided by replacing the sum(weights * data) with a np.einsum("i,ijk->jk", weights, data).  This only affects dumo which gets cast down to float16.  The einsum call still accumulates internally as double precision before having the difference wrt optimal weights cast as float16, but the order of operations is different than in the sum(weights * data) case, so some numerical precision differences are possible.

In concert with https://github.com/spacetelescope/stcal/pull/577, this removes the spike in memory usage at the end of the ramp fitting step (green line vs. blue line).
<img width="1206" height="575" alt="image" src="https://github.com/user-attachments/assets/a788df2a-c5c3-4775-9946-f35da26b8b77" />

Regression here, all green: https://github.com/spacetelescope/RegressionTests/actions/runs/33394254962

## Tasks
- [x] **request a review from someone specific**, to avoid making the maintainers review every PR
- [X] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [X] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [X] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/romancal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)
